### PR TITLE
Resident store

### DIFF
--- a/components/application/application-forms.tsx
+++ b/components/application/application-forms.tsx
@@ -1,7 +1,7 @@
 import EligibilityOutcome from "../eligibility"
 import Form from "../form/form"
 import { Store } from "../../lib/store"
-import { updateFormData } from "../../lib/store/user"
+import { updateFormData } from "../../lib/store/resident"
 import { getFormData } from "../../lib/utils/form-data"
 import { FormData } from "../../lib/types/form"
 import Link from "next/link"
@@ -27,7 +27,7 @@ export default function ApplicationForms({ activeStep, baseHref, onCompletion, s
   const router = useRouter()
   const store = useStore<Store>()
   const [applicationData, setApplicationData] = useState({})
-  const isEligible = store.getState().user.isEligible
+  const isEligible = store.getState().resident.isEligible
 
   if (isEligible === false) {
     return <EligibilityOutcome />

--- a/components/eligibility/index.tsx
+++ b/components/eligibility/index.tsx
@@ -5,7 +5,7 @@ import { useStore } from "react-redux"
 
 export default function EligibilityOutcome(): JSX.Element {
   const store = useStore<Store>()
-  const isEligible = store.getState().user.isEligible
+  const isEligible = store.getState().resident.isEligible
 
   return isEligible ? <Eligible /> : <NotEligible />
 }

--- a/components/eligibility/not-eligible.tsx
+++ b/components/eligibility/not-eligible.tsx
@@ -9,7 +9,7 @@ import { useStore } from "react-redux"
 
 export default function NotEligible(): JSX.Element {
   const store = useStore<Store>()
-  const reasons = store.getState().user.ineligibilityReasons
+  const reasons = store.getState().resident.ineligibilityReasons
 
   return (
     <>

--- a/lib/store/index.ts
+++ b/lib/store/index.ts
@@ -1,10 +1,10 @@
 import resident from "./resident"
-import { Resident } from "../types/resident"
+import { MainResident } from "../types/resident"
 import { createStore, combineReducers } from "redux"
 import { createWrapper, Context } from "next-redux-wrapper"
 
 export interface Store {
-  resident: Resident
+  resident: MainResident
 }
 
 const reducer = combineReducers({

--- a/lib/store/index.ts
+++ b/lib/store/index.ts
@@ -1,17 +1,17 @@
-import user from "./user"
-import { User } from "../types/user"
+import resident from "./resident"
+import { Resident } from "../types/resident"
 import { createStore, combineReducers } from "redux"
 import { createWrapper, Context } from "next-redux-wrapper"
 
 export interface Store {
-  user: User
+  resident: Resident
 }
 
 const reducer = combineReducers({
-  user: user.reducer
+  resident: resident.reducer
 })
 
 // Store function
 const store = (context: Context) => createStore(reducer)
-export const wrapper = createWrapper(store);
+export const wrapper = createWrapper(store)
 export default store

--- a/lib/store/resident.ts
+++ b/lib/store/resident.ts
@@ -1,8 +1,9 @@
 import { checkEligible } from "../utils/form"
-import { Resident } from "../types/resident"
+import { MainResident } from "../types/resident"
 import { createSlice, PayloadAction } from "@reduxjs/toolkit"
 
-const initialState: Resident = {
+const initialState: MainResident = {
+  hasAgreed: false,
   formData: {},
   isLoggedIn: false
 }
@@ -12,11 +13,24 @@ const slice = createSlice({
   initialState,
   reducers: {
     /**
-     * Log the resident in
-     * @param {Resident} state The current state
-     * @returns {Resident} Updated resident state
+     * Agree to terms and conditions
+     * @param {MainResident} state The current state
+     * @param {PayloadAction<boolean>} action The agreement state
+     * @returns {MainResident} Updated resident state
      */
-    logIn: (state: Resident): Resident => {
+    agree: (state: MainResident, action: PayloadAction<boolean>) => {
+      return {
+        ...state,
+        hasAgreed: action.payload
+      }
+    },
+
+    /**
+     * Log the resident in
+     * @param {MainResident} state The current state
+     * @returns {MainResident} Updated resident state
+     */
+    logIn: (state: MainResident): MainResident => {
       return {
         ...state,
         isLoggedIn: true
@@ -27,33 +41,19 @@ const slice = createSlice({
 
     /**
      * Log the resident out
-     * @returns {Resident} Initial resident state
+     * @returns {MainResident} Initial resident state
      */
-    logOut: (): Resident => {
+    logOut: (): MainResident => {
       return initialState
     },
 
     /**
-     * Update resident's eligibility status
-     * @param {Resident} state The current state
-     * @param {PayloadAction<[boolean, string[]]>} action Is the resident eligible?
-     * @returns {Resident} Updated resident state
-     */
-    updateEligibility: (state: Resident, action: PayloadAction<[boolean, string[]]>): Resident => {
-      return {
-        ...state,
-        isEligible: action.payload[0],
-        ineligibilityReasons: action.payload[1]
-      }
-    },
-
-    /**
      * Update resident's form data
-     * @param {Resident} state The current state
+     * @param {MainResident} state The current state
      * @param {PayloadAction<{}>} action The form data
-     * @returns {Resident} Updated resident state
+     * @returns {MainResident} Updated resident state
      */
-    updateFormData: (state: Resident, action: PayloadAction<{}>): Resident => {
+    updateFormData: (state: MainResident, action: PayloadAction<{}>): MainResident => {
       state.formData = {
         ...state.formData,
         ...action.payload
@@ -69,4 +69,4 @@ const slice = createSlice({
 })
 
 export default slice
-export const { logIn, logOut, updateEligibility, updateFormData } = slice.actions
+export const { agree, logIn, logOut, updateFormData } = slice.actions

--- a/lib/store/resident.ts
+++ b/lib/store/resident.ts
@@ -1,22 +1,22 @@
 import { checkEligible } from "../utils/form"
-import { User } from "../types/user"
+import { Resident } from "../types/resident"
 import { createSlice, PayloadAction } from "@reduxjs/toolkit"
 
-const initialState: User = {
+const initialState: Resident = {
   formData: {},
   isLoggedIn: false
 }
 
 const slice = createSlice({
-  name: 'user',
+  name: 'resident',
   initialState,
   reducers: {
     /**
-     * Log the user in
-     * @param {User} state The current state
-     * @returns {User} Updated user state
+     * Log the resident in
+     * @param {Resident} state The current state
+     * @returns {Resident} Updated resident state
      */
-    logIn: (state: User): User => {
+    logIn: (state: Resident): Resident => {
       return {
         ...state,
         isLoggedIn: true
@@ -26,20 +26,20 @@ const slice = createSlice({
     },
 
     /**
-     * Log the user out
-     * @returns {User} Initial user state
+     * Log the resident out
+     * @returns {Resident} Initial resident state
      */
-    logOut: (): User => {
+    logOut: (): Resident => {
       return initialState
     },
 
     /**
-     * Update user's eligibility status
-     * @param {User} state The current state
-     * @param {PayloadAction<[boolean, string[]]>} action Is the user eligible?
-     * @returns {User} Updated user state
+     * Update resident's eligibility status
+     * @param {Resident} state The current state
+     * @param {PayloadAction<[boolean, string[]]>} action Is the resident eligible?
+     * @returns {Resident} Updated resident state
      */
-    updateEligibility: (state: User, action: PayloadAction<[boolean, string[]]>): User => {
+    updateEligibility: (state: Resident, action: PayloadAction<[boolean, string[]]>): Resident => {
       return {
         ...state,
         isEligible: action.payload[0],
@@ -48,12 +48,12 @@ const slice = createSlice({
     },
 
     /**
-     * Update user's form data
-     * @param {User} state The current state
+     * Update resident's form data
+     * @param {Resident} state The current state
      * @param {PayloadAction<{}>} action The form data
-     * @returns {User} Updated user state
+     * @returns {Resident} Updated resident state
      */
-    updateFormData: (state: User, action: PayloadAction<{}>): User => {
+    updateFormData: (state: Resident, action: PayloadAction<{}>): Resident => {
       state.formData = {
         ...state.formData,
         ...action.payload

--- a/lib/types/resident.ts
+++ b/lib/types/resident.ts
@@ -1,8 +1,12 @@
 import { FormData } from "./form"
 
-export type Resident = {
+export interface Resident {
   formData: {[key: string]: FormData}
   ineligibilityReasons?: string[]
   isEligible?: boolean
+}
+
+export interface MainResident extends Resident {
+  hasAgreed: boolean
   isLoggedIn: boolean
 }

--- a/lib/types/resident.ts
+++ b/lib/types/resident.ts
@@ -1,6 +1,6 @@
 import { FormData } from "./form"
 
-export type User = {
+export type Resident = {
   formData: {[key: string]: FormData}
   ineligibilityReasons?: string[]
   isEligible?: boolean

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -2,23 +2,29 @@ import Form from "../../components/form/form"
 import { HeadingOne } from "../../components/content/headings"
 import Paragraph from "../../components/content/paragraph"
 import Layout from "../../components/layout/resident-layout"
+import { Store } from "../../lib/store"
+import { agree } from "../../lib/store/resident"
 import { FormData } from "../../lib/types/form"
-import { getAgreementFormData } from '../../lib/utils/form-data'
-import { useRouter } from 'next/router'
+import { getAgreementFormData } from "../../lib/utils/form-data"
+import { useRouter } from "next/router"
+import { useStore } from "react-redux"
 
 export default function Apply(): JSX.Element {
-  // TODO! Check if eligible, before continuing
-
   const router = useRouter()
-  const agreementFormData = getAgreementFormData()
-
-  const onSave = (values: FormData) => {
-    // TODO: Bypass step if user has already agreed
-    console.info('agreement form', values)
-  }
+  const store = useStore<Store>()
+  const resident = store.getState().resident
 
   const onSubmit = () => {
     router.push("/apply/overview")
+  }
+  
+  if (resident.hasAgreed) {
+    onSubmit()
+  }
+  
+  const agreementFormData = getAgreementFormData()
+  const onSave = (values: FormData) => {
+    store.dispatch(agree(values.agreement))
   }
   
   return (

--- a/pages/eligibility-checker/[[...step]].tsx
+++ b/pages/eligibility-checker/[[...step]].tsx
@@ -7,8 +7,8 @@ import { useSelector } from "react-redux"
 import EligibilityOutcome from "../../components/eligibility"
 
 export default function EligibilityChecker(): JSX.Element {
-  let { user } = useSelector<Store, Store>(state => state)
-  const [isComplete, complete] = useState(user.isEligible)
+  let { resident } = useSelector<Store, Store>(state => state)
+  const [isComplete, complete] = useState(resident.isEligible)
 
   if (isComplete) {
     return (


### PR DESCRIPTION
- Renaming the `user` store to `resident` for clarity (between who is a resident user and what is an admin user)
- Storing the `agreement` state within the resident store, so we don't keep asking them to agree whenever they re-load their application