### PR TITLE
Prevent residents from accessing the application if they are ineligible

### DIFF
--- a/lib/hoc/whenEligible.tsx
+++ b/lib/hoc/whenEligible.tsx
@@ -1,0 +1,26 @@
+import EligibilityOutcome from "../../components/eligibility"
+import Layout from "../../components/layout/resident-layout"
+import { Store } from "../store"
+import { MainResident } from "../types/resident"
+import React from "react"
+import { connect } from "react-redux"
+import { compose } from "redux"
+
+const whenEligible = (WrappedComponent: React.ComponentType<any>) => {
+  return (props: MainResident) => {
+    if (props.isEligible === false) {
+      return (
+        <Layout>
+          <EligibilityOutcome />
+        </Layout>
+      )
+    }
+
+    return <WrappedComponent {...props} />
+  }
+}
+
+export default compose(
+  connect((state: Store) => state.resident),
+  whenEligible
+)

--- a/pages/apply/[person]/[[...step]].tsx
+++ b/pages/apply/[person]/[[...step]].tsx
@@ -1,8 +1,9 @@
 import ApplicationForms from "../../../components/application/application-forms"
 import Layout from "../../../components/layout/resident-layout"
-import { useRouter } from 'next/router'
+import whenEligible from "../../../lib/hoc/whenEligible"
+import { useRouter } from "next/router"
 
-export default function ApplicationStep(): JSX.Element {
+const ApplicationStep = (): JSX.Element => {
   const router = useRouter()
   let { person, step } = router.query
   person = person as string
@@ -36,3 +37,5 @@ export default function ApplicationStep(): JSX.Element {
     </Layout>
   )
 }
+
+export default whenEligible(ApplicationStep)

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -2,6 +2,7 @@ import Form from "../../components/form/form"
 import { HeadingOne } from "../../components/content/headings"
 import Paragraph from "../../components/content/paragraph"
 import Layout from "../../components/layout/resident-layout"
+import whenEligible from "../../lib/hoc/whenEligible"
 import { Store } from "../../lib/store"
 import { agree } from "../../lib/store/resident"
 import { FormData } from "../../lib/types/form"
@@ -9,7 +10,7 @@ import { getAgreementFormData } from "../../lib/utils/form-data"
 import { useRouter } from "next/router"
 import { useStore } from "react-redux"
 
-export default function Apply(): JSX.Element {
+const Apply = (): JSX.Element => {
   const router = useRouter()
   const store = useStore<Store>()
   const resident = store.getState().resident
@@ -48,3 +49,5 @@ export default function Apply(): JSX.Element {
     </Layout>
   )
 }
+
+export default whenEligible(Apply)

--- a/pages/apply/overview.tsx
+++ b/pages/apply/overview.tsx
@@ -1,8 +1,9 @@
 import { HeadingOne } from "../../components/content/headings"
 import Layout from "../../components/layout/resident-layout"
+import whenEligible from "../../lib/hoc/whenEligible"
 import Link from "next/link"
 
-export default function ApplicationPersonsOverview(): JSX.Element {
+const ApplicationPersonsOverview = (): JSX.Element => {
   return (
     <Layout>
       <HeadingOne content="People in this application" />
@@ -15,3 +16,5 @@ export default function ApplicationPersonsOverview(): JSX.Element {
 }
 
 // TODO: list of people
+
+export default whenEligible(ApplicationPersonsOverview)


### PR DESCRIPTION
A new high-order component that restricts access to the application (`/apply`) if the use is ineligible for housing.

Any ineligible requests will be shown the `<EligibilityOutcome />` component which details further information and reasonings behind this decision (as stored against the resident state).

Undefined eligibility state means that the user has not taken the eligibility checker tool or we have no record of it, so we cannot currently determine if they are eligible or not - we should continue to allow them to apply, and the decision will be made as they progress through the application.