### PR TITLE
Forms: set focus to the first field

### DIFF
--- a/components/form/checkboxes.tsx
+++ b/components/form/checkboxes.tsx
@@ -10,7 +10,7 @@ interface CheckboxProps extends FormField {
   value: string
 }
 
-export function Checkbox({ hint, index, label, name, value }: CheckboxProps): JSX.Element {
+export function Checkbox({ focus, hint, index, label, name, value }: CheckboxProps): JSX.Element {
   let id = name
 
   if (index) {
@@ -20,6 +20,7 @@ export function Checkbox({ hint, index, label, name, value }: CheckboxProps): JS
   return (
     <div className="govuk-checkboxes__item">
       <Field
+        autoFocus={focus}
         className="govuk-checkboxes__input"
         type="checkbox"
         id={id}
@@ -38,7 +39,7 @@ export interface CheckboxesProps extends FormField {
   value: string
 }
 
-export default function Checkboxes({ hint, label, options, name, value }: CheckboxesProps): JSX.Element {
+export default function Checkboxes({ focus, hint, label, options, name, value }: CheckboxesProps): JSX.Element {
   const checkboxes: FormFieldOption[] = options || [{ hint, label, value }]
   const hasMultipleOptions: boolean = checkboxes.length > 1
 
@@ -56,7 +57,7 @@ export default function Checkboxes({ hint, label, options, name, value }: Checkb
               render={() => (
                 <>
                   {checkboxes.map((checkbox, index) => (
-                    <Checkbox key={index} index={index} hint={checkbox.hint} label={checkbox.label!} name={field.name} value={checkbox.value} />
+                    <Checkbox key={index} index={index} focus={focus} hint={checkbox.hint} label={checkbox.label!} name={field.name} value={checkbox.value} />
                   ))}
                 </>
               )}

--- a/components/form/form.tsx
+++ b/components/form/form.tsx
@@ -24,13 +24,11 @@ export default function Form({ formData, onSave, onSubmit }: FormProps): JSX.Ele
   const isLastStep: boolean = stepNumber === totalSteps - 1
 
   const next = (values: FormData): void => {
-    // TODO: Scroll to top + set focus to first field
     setSnapshot(values);
     setStepNumber(Math.min(stepNumber + 1, totalSteps - 1));
   };
 
   const previous = (values: FormData): void => {
-    // TODO: Scroll to top + set focus to first field
     setSnapshot(values);
     setStepNumber(Math.max(stepNumber - 1, 0));
   };
@@ -64,6 +62,7 @@ export default function Form({ formData, onSave, onSubmit }: FormProps): JSX.Ele
             {step.fields.map((field, index) => {
                 const display: boolean = getDisplayStateOfField(field, values)
                 if (display) {
+                  field.focus = index == 0
                   return <DynamicField key={index} field={field} />
                 }
             })}

--- a/components/form/input.tsx
+++ b/components/form/input.tsx
@@ -9,7 +9,7 @@ interface InputProps extends FormField {
   className?: string
 }
 
-export default function Input({ className, hint, label, name, placeholder, type }: InputProps): JSX.Element {
+export default function Input({ className, focus, hint, label, name, placeholder, type }: InputProps): JSX.Element {
   return (
     <Field name={name}>
       {({ field, meta }: { field: FieldInputProps<string>, meta: FieldMetaProps<string> }) => (
@@ -19,6 +19,7 @@ export default function Input({ className, hint, label, name, placeholder, type 
           {meta.touched && meta.error && <ErrorMessage message={meta.error} />}
 
           <input
+            autoFocus={focus}
             className={`${className} ${meta.touched && meta.error && "govuk-input--error"} govuk-input lbh-input`}
             id={name}
             placeholder={placeholder}

--- a/components/form/radios.tsx
+++ b/components/form/radios.tsx
@@ -10,7 +10,7 @@ interface RadioProps extends FormField {
   value: string
 }
 
-export function Radio({ index, hint, label, name, value }: RadioProps): JSX.Element {
+export function Radio({ focus, hint, index, label, name, value }: RadioProps): JSX.Element {
   let id = name
 
   if (index !== undefined) {
@@ -20,6 +20,7 @@ export function Radio({ index, hint, label, name, value }: RadioProps): JSX.Elem
   return (
     <div className="govuk-radios__item">
       <Field
+        autoFocus={focus}
         className="govuk-radios__input"
         type="radio"
         id={id}
@@ -37,7 +38,7 @@ export interface RadiosProps extends FormField {
   value: string
 }
 
-export default function Radios({ hint, label, name, options }: RadiosProps): JSX.Element {
+export default function Radios({ focus, hint, label, name, options }: RadiosProps): JSX.Element {
   return (
     <Field name={name}>
       {({ field, meta }: { field: FieldInputProps<string>, meta: FieldMetaProps<string> }) => (
@@ -48,7 +49,7 @@ export default function Radios({ hint, label, name, options }: RadiosProps): JSX
 
           <div className="govuk-radios lbh-radios">
             {options?.map((radio, index) => 
-              <Radio key={index} index={index} hint={radio.hint} label={radio.label!} name={field.name} value={radio.value} />
+              <Radio key={index} index={index} focus={focus} hint={radio.hint} label={radio.label!} name={field.name} value={radio.value} />
             )}
           </div>
         </FormGroup>

--- a/components/form/select.tsx
+++ b/components/form/select.tsx
@@ -8,7 +8,7 @@ import { Field, FieldInputProps, FieldMetaProps } from "formik"
 interface SelectProps extends FormField {
 }
 
-export default function Select({ hint, label, name, options }: SelectProps): JSX.Element {
+export default function Select({ focus, hint, label, name, options }: SelectProps): JSX.Element {
   return (
     <Field name={name}>
       {({ field, meta }: { field: FieldInputProps<string>, meta: FieldMetaProps<string> }) => (
@@ -17,7 +17,7 @@ export default function Select({ hint, label, name, options }: SelectProps): JSX
           {hint && <Hint content={hint} />}
           {meta.touched && meta.error && <ErrorMessage message={meta.error} />}
 
-          <select className={`${!!meta.touched && !!meta.error ? "govuk-select--error" : ""} govuk-select lbh-select`} id={field.name} {...field}>
+          <select autoFocus={focus} className={`${!!meta.touched && !!meta.error ? "govuk-select--error" : ""} govuk-select lbh-select`} id={field.name} {...field}>
             {options?.map((option, index) => (
               <option key={index} value={option.value}>
                 {option.label || option.value}

--- a/components/form/textarea.tsx
+++ b/components/form/textarea.tsx
@@ -8,7 +8,7 @@ import { Field, FieldInputProps, FieldMetaProps } from "formik"
 interface TextareaProps extends FormField {
 }
 
-export default function Textarea({ hint, label, name, placeholder }: TextareaProps): JSX.Element {
+export default function Textarea({ focus, hint, label, name, placeholder }: TextareaProps): JSX.Element {
   return (
     <Field name={name}>
       {({ field, meta }: { field: FieldInputProps<string>, meta: FieldMetaProps<string> }) => (
@@ -18,6 +18,7 @@ export default function Textarea({ hint, label, name, placeholder }: TextareaPro
           {meta.touched && meta.error && <ErrorMessage message={meta.error} />}
 
           <textarea
+            autoFocus={focus}
             className={`${!!meta.touched && !!meta.error ? "govuk-textarea--error" : ""} govuk-textarea lbh-textarea`}
             id={field.name}
             placeholder={placeholder}

--- a/lib/types/form.ts
+++ b/lib/types/form.ts
@@ -12,6 +12,7 @@ export type FormData = {
 export type FormField = {
   as?: string
   conditionalDisplay?: FormFieldDisplayCriteria[]
+  focus?: boolean
   hint?: string
   initialValue?: boolean | number | string | string[]
   label: string


### PR DESCRIPTION
A simple fix which jumps the user to the top of the form when they progress onto the next/previous step of a multi-step form.

Previously this was keeping the users' focus at the bottom of the new step, which is not idea.