### PR TITLE
HRT-48: Application start screen, adding example wait times

### DIFF
--- a/components/announcement.tsx
+++ b/components/announcement.tsx
@@ -1,0 +1,18 @@
+interface AnnouncementProps {
+  children: JSX.Element | JSX.Element[]
+  variant: "info" | "success" | "warning"
+}
+
+export default function Announcement({ children, variant }: AnnouncementProps): JSX.Element {
+  let className = "lbh-page-announcement"
+
+  if (variant) {
+    className += ` ${className}--${variant}`
+  }
+
+  return (
+    <section className={className}>
+      {children}
+    </section>
+  )
+}

--- a/components/content/table.tsx
+++ b/components/content/table.tsx
@@ -1,0 +1,76 @@
+interface TableProps {
+  children: JSX.Element | JSX.Element[]
+}
+
+export default function Table({ children }: TableProps): JSX.Element {
+  children = Array.isArray(children) ? children : [children]
+
+  const headings: JSX.Element[] = []
+  const rows: JSX.Element[] = []
+
+  children.map(child => {
+    switch (child.type) {
+      case TableHeading:
+        headings.push(child)
+        break;
+
+      default:
+        rows.push(child)
+        break;
+    }
+  })
+
+  return (
+    <table className="govuk-table lbh-table">
+      {headings.length > 0 && (
+        <thead className="govuk-table__head">
+          <TableRow>
+            {headings.map(heading => heading)}
+          </TableRow>
+        </thead>
+      )}
+
+      <tbody className="govuk-table__body">
+        {rows.map(row => row)}
+      </tbody>
+    </table>
+  )
+}
+
+interface TableCellProps {
+  children: number | string
+}
+
+export function TableCell({ children }: TableCellProps): JSX.Element {
+  let className = "govuk-table__cell"
+
+  if (typeof(children) == "number") {
+    className += ` ${className}--numeric`
+  }
+
+  return (
+    <td className={className}>
+      {children}
+    </td>
+  )
+}
+
+interface TableHeadingProps {
+  children: string
+}
+
+export function TableHeading({ children }: TableHeadingProps): JSX.Element {
+  return (
+    <th scope="col" className="govuk-table__header">
+      {children}
+    </th>
+  )
+}
+
+export function TableRow({ children }: TableProps): JSX.Element {
+  return (
+    <tr className="govuk-table__row">
+      {children}
+    </tr>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,10 @@
+import Announcement from "../components/announcement"
 import { ButtonLink } from "../components/button"
 import { HeadingOne, HeadingTwo } from "../components/content/headings"
 import Layout from '../components/layout/resident-layout'
 import Paragraph from "../components/content/paragraph"
+import Table, { TableCell, TableHeading, TableRow } from "../components/content/table"
+import Link from "next/link"
 
 export default function Home(): JSX.Element {
   return (
@@ -11,12 +14,14 @@ export default function Home(): JSX.Element {
       <HeadingTwo content="What to expect" />
       <Paragraph>
         It may take up to one hour to complete your application.
-        You will need to supply personal details for each person in your application, and information about your current accommodation, income and any benefits received.
+        You will need to supply personal details for each person in your application.
+        You can save your progress and return to your application within 30 days before submitting. 
       </Paragraph>
 
-      <HeadingTwo content="What you'll need to provide" />
+      <HeadingTwo content="What documents you'll need to provide" />
       <Paragraph>
-        You will need to upload proof of identity, address, income, savings, benefits for each person in your application.
+        You will need to upload proof of identity, address, income, any savings, and benefits for each person in your application.
+        You may need to supply additional documentation based on your circumstances.
       </Paragraph>
 
       <HeadingTwo content="What happens afterwards?" />
@@ -26,6 +31,47 @@ export default function Home(): JSX.Element {
         If you application is successful, you may still wait many years until a housing offer is made.
       </Paragraph>
 
+      <Announcement variant="info">
+        <Table>
+          <TableHeading>Bedrooms required</TableHeading>
+          <TableHeading>Housing Register</TableHeading>
+          <TableHeading>Private rental</TableHeading>
+
+          <TableRow>
+            <TableCell>1 bedroom</TableCell>
+            <TableCell>? years</TableCell>
+            <TableCell>1 month</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>2 bedrooms</TableCell>
+            <TableCell>? years</TableCell>
+            <TableCell>1 month</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>3 bedrooms</TableCell>
+            <TableCell>? years</TableCell>
+            <TableCell>1 month</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>4 bedrooms</TableCell>
+            <TableCell>? years</TableCell>
+            <TableCell>1 month</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>5 bedrooms</TableCell>
+            <TableCell>? years</TableCell>
+            <TableCell>2 months</TableCell>
+          </TableRow>
+        </Table>
+
+        <Paragraph>
+          <Link href="#">
+            Why we recommend renting privately
+          </Link>
+        </Paragraph>
+      </Announcement>
+
+      <HeadingTwo content="I still want to apply" />
       <ButtonLink href="/apply">Start now</ButtonLink>
     </Layout>
   )

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -14,6 +14,7 @@
 @import "node_modules/lbh-frontend/lbh/components/lbh-input/input";
 @import "node_modules/lbh-frontend/lbh/components/lbh-inset-text/inset-text";
 @import "node_modules/lbh-frontend/lbh/components/lbh-label/label";
+@import "node_modules/lbh-frontend/lbh/components/lbh-page-announcement/page-announcement";
 @import "node_modules/lbh-frontend/lbh/components/lbh-phase-banner/phase-banner";
 @import "node_modules/lbh-frontend/lbh/components/lbh-radios/radios";
 @import "node_modules/lbh-frontend/lbh/components/lbh-select/select";


### PR DESCRIPTION
Superficial changes to the start page:

1. Amending copy to match latest figma designs
2. Adding additional copy
3. Adding example of wait times (not currently driven by any data)
4. Wrapping wait times in the standard `<Accountment />` component (`info` variant is being used) - this does not currently match Figma, but we should probably stick to the design system here