### PR TITLE
Form step identifiers as constants - to prevent potential for error in the future

### DIFF
--- a/lib/utils/form-data.ts
+++ b/lib/utils/form-data.ts
@@ -4,6 +4,10 @@ import testFormData from "../../data/forms/_test-form.json"
 import yourSituationFormData from "../../data/forms/your-situation.json"
 import { EligibilityCriteria, MultiStepForm } from "../types/form"
 
+export const AGREEMENT = "agreement"
+export const IMMIGRATION_STATUS = "immigration-status"
+export const YOUR_SITUATION = "your-situation"
+
 /**
  * Get the eligibility criteria from the requested form
  * @param {string} formId - The requested eligibility criteria
@@ -21,6 +25,9 @@ import { EligibilityCriteria, MultiStepForm } from "../types/form"
  */
  export function getFormData(form: string): MultiStepForm {
   switch(form.toLowerCase()) {
+    case "agreement":
+      return getAgreementFormData()
+
     case "immigration-status":
       return getImmigrationStatusFormData()
     

--- a/pages/apply/[person]/[[...step]].tsx
+++ b/pages/apply/[person]/[[...step]].tsx
@@ -1,6 +1,7 @@
 import ApplicationForms from "../../../components/application/application-forms"
 import Layout from "../../../components/layout/resident-layout"
 import whenEligible from "../../../lib/hoc/whenEligible"
+import { IMMIGRATION_STATUS, YOUR_SITUATION } from "../../../lib/utils/form-data"
 import { useRouter } from "next/router"
 
 const ApplicationStep = (): JSX.Element => {
@@ -9,7 +10,7 @@ const ApplicationStep = (): JSX.Element => {
   person = person as string
 
   const baseHref = `/apply/${person}`
-  const steps: string[] = ["test-data", "immigration-status"]
+  const steps = [YOUR_SITUATION, IMMIGRATION_STATUS]
   const activeStep = step ? step[0] : undefined
 
   const breadcrumbs = [

--- a/pages/eligibility-checker/[[...step]].tsx
+++ b/pages/eligibility-checker/[[...step]].tsx
@@ -1,10 +1,11 @@
 import ApplicationForms from "../../components/application/application-forms"
+import EligibilityOutcome from "../../components/eligibility"
 import Layout from "../../components/layout/resident-layout"
 import { Store } from "../../lib/store"
+import { IMMIGRATION_STATUS, YOUR_SITUATION } from "../../lib/utils/form-data"
 import { useRouter } from "next/router"
 import { useState } from "react"
 import { useSelector } from "react-redux"
-import EligibilityOutcome from "../../components/eligibility"
 
 export default function EligibilityChecker(): JSX.Element {
   let { resident } = useSelector<Store, Store>(state => state)
@@ -20,7 +21,7 @@ export default function EligibilityChecker(): JSX.Element {
 
   const baseHref = "/eligibility-checker"
   const router = useRouter()
-  const steps: string[] = ["your-situation", "immigration-status"]
+  const steps = [YOUR_SITUATION, IMMIGRATION_STATUS]
   const activeStep = router.query.step ? router.query.step[0] : steps[0]
 
   const onCompletion = () => {


### PR DESCRIPTION
Simple change, swapping out the form identifiers for constants just to ensure consistency