### PR TITLE
HRT-29: Application overview

### DIFF
--- a/components/application/application-forms.tsx
+++ b/components/application/application-forms.tsx
@@ -1,3 +1,5 @@
+import { HeadingOne } from "../content/headings"
+import Paragraph from "../content/paragraph"
 import EligibilityOutcome from "../eligibility"
 import Form from "../form/form"
 import { Store } from "../../lib/store"
@@ -59,7 +61,15 @@ export default function ApplicationForms({ activeStep, baseHref, onCompletion, s
       <>
         {steps.map((step, index) => {
           if (step == activeStep) {
-            return <Form key={index} formData={getFormData(step)} onSave={onSave} onSubmit={next} />
+            const formData = getFormData(step)
+
+            return (
+              <>
+                {formData.heading && <HeadingOne content={formData.heading} />}
+                {formData.copy && <Paragraph>{formData.copy}</Paragraph>}
+                <Form buttonText="Save and continue" key={index} formData={formData} onSave={onSave} onSubmit={next} />
+              </>
+            )
           }
         })}
       </>

--- a/components/application/application-forms.tsx
+++ b/components/application/application-forms.tsx
@@ -1,11 +1,11 @@
 import { HeadingOne } from "../content/headings"
 import Paragraph from "../content/paragraph"
-import EligibilityOutcome from "../eligibility"
 import Form from "../form/form"
 import { Store } from "../../lib/store"
-import { updateFormData } from "../../lib/store/resident"
-import { getFormData } from "../../lib/utils/form-data"
 import { FormData } from "../../lib/types/form"
+import { Resident } from "../../lib/types/resident"
+import { getFormData } from "../../lib/utils/form-data"
+import { updateResidentsFormData } from "../../lib/utils/resident"
 import Link from "next/link"
 import { useRouter } from "next/router"
 import { useState } from "react"
@@ -15,6 +15,7 @@ interface ApplicationFormsProps {
   activeStep?: string
   baseHref: string
   onCompletion: (values: FormData) => void
+  resident: Resident
   steps: string[]
 }
 
@@ -25,15 +26,10 @@ interface ApplicationFormsProps {
  * @param {ApplicationFormsProps} param0 - Property object of the application
  * @returns {JSX.Element}
  */
-export default function ApplicationForms({ activeStep, baseHref, onCompletion, steps }: ApplicationFormsProps): JSX.Element {
+export default function ApplicationForms({ activeStep, baseHref, onCompletion, resident, steps }: ApplicationFormsProps): JSX.Element {
   const router = useRouter()
   const store = useStore<Store>()
   const [applicationData, setApplicationData] = useState({})
-  const isEligible = store.getState().resident.isEligible
-
-  if (isEligible === false) {
-    return <EligibilityOutcome />
-  }
 
   if (steps.includes(activeStep!)) {
     const next = () => {
@@ -49,7 +45,7 @@ export default function ApplicationForms({ activeStep, baseHref, onCompletion, s
       data[activeStep!] = values
 
       setApplicationData(data)
-      store.dispatch(updateFormData(data))
+      updateResidentsFormData(store, resident, data)
 
       const index = steps.indexOf(activeStep!) + 1;
       if (index == steps.length) {
@@ -64,11 +60,11 @@ export default function ApplicationForms({ activeStep, baseHref, onCompletion, s
             const formData = getFormData(step)
 
             return (
-              <>
+              <div key={index}>
                 {formData.heading && <HeadingOne content={formData.heading} />}
                 {formData.copy && <Paragraph>{formData.copy}</Paragraph>}
-                <Form buttonText="Save and continue" key={index} formData={formData} onSave={onSave} onSubmit={next} />
-              </>
+                <Form buttonText="Save and continue" formData={formData} onSave={onSave} onSubmit={next} />
+              </div>
             )
           }
         })}

--- a/components/breadcrumbs.tsx
+++ b/components/breadcrumbs.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link"
+
 interface BreadcrumbsProps {
   items: { href: string, name: string }[]
 }
@@ -8,9 +10,11 @@ export default function Breadcrumbs({ items }: BreadcrumbsProps): JSX.Element {
       <ol className="govuk-breadcrumbs__list">
         {items?.map((item, index) => (
           <li key={index} className="govuk-breadcrumbs__list-item">
-            <a className="govuk-breadcrumbs__link" href={item.href}>
-              {item.name}
-            </a>
+            <Link href={item.href}>
+              <a className="govuk-breadcrumbs__link">
+                {item.name}
+              </a>
+            </Link>
           </li>
         ))}
       </ol>

--- a/components/delete-link.tsx
+++ b/components/delete-link.tsx
@@ -1,0 +1,16 @@
+interface DeleteLinkProps {
+  content: string
+  onDelete: () => void
+}
+
+export default function DeleteLink({ content, onDelete }: DeleteLinkProps) {
+  return (
+    <div className="text-center">
+      <a onClick={onDelete}>
+        <span className="govuk-error-message lbh-error-message">
+          {content}
+        </span>
+      </a>
+    </div>
+  )
+}

--- a/components/form/form.tsx
+++ b/components/form/form.tsx
@@ -1,6 +1,6 @@
 import Button from "../button"
 import DynamicField from "./dynamic-field"
-import { HeadingOne } from "../content/headings"
+import { HeadingTwo } from "../content/headings"
 import { FormData, FormStep, MultiStepForm } from "../../lib/types/form"
 import { getDisplayStateOfField, getInitialValuesFromMultiStepForm } from "../../lib/utils/form"
 import { buildValidationSchema } from "../../lib/utils/validation"
@@ -9,12 +9,13 @@ import { useState } from "react"
 import Paragraph from "../content/paragraph"
 
 interface FormProps {
+  buttonText?: string
   formData: MultiStepForm
-  onSave?: (values: {}) => void
-  onSubmit: (values: {}, bag: any) => void
+  onSave?: (values: FormData) => void
+  onSubmit: (values: FormData, bag: any) => void
 }
 
-export default function Form({ formData, onSave, onSubmit }: FormProps): JSX.Element {
+export default function Form({ buttonText, formData, onSave, onSubmit }: FormProps): JSX.Element {
   const [formDataSnapshot] = useState(formData)
   const [stepNumber, setStepNumber] = useState(0)
   const [snapshot, setSnapshot] = useState(getInitialValuesFromMultiStepForm(formDataSnapshot))
@@ -58,7 +59,7 @@ export default function Form({ formData, onSave, onSubmit }: FormProps): JSX.Ele
       >
         {({ isSubmitting, values }) => (
           <FormikForm>
-            {step.heading && <HeadingOne content={step.heading} />}
+            {step.heading && <HeadingTwo content={step.heading} />}
             {step.copy && <Paragraph>{step.copy}</Paragraph>}
             
             {step.fields.map((field, index) => {
@@ -79,7 +80,7 @@ export default function Form({ formData, onSave, onSubmit }: FormProps): JSX.Ele
 
               <div className="c-flex__1 text-right">
                 <Button disabled={isSubmitting} type="submit">
-                  Save and continue
+                  {buttonText ? buttonText : "Save"}
                 </Button>
               </div>
             </div>

--- a/components/summary-list.tsx
+++ b/components/summary-list.tsx
@@ -1,0 +1,61 @@
+interface SummaryListProps {
+  children: JSX.Element | JSX.Element[]
+}
+
+export default function SummaryList({ children }: SummaryListProps): JSX.Element {
+  return (
+    <dl className="govuk-summary-list lbh-summary-list">
+      {children}
+    </dl>
+  )
+}
+
+export function SummaryListActions({ children }: SummaryListProps): JSX.Element {
+  return (
+    <dd className="govuk-summary-list__actions">
+      {children}
+    </dd>
+  )
+}
+
+interface SummaryListKeyProps {
+  children: string | JSX.Element
+}
+
+export function SummaryListKey({ children }: SummaryListKeyProps): JSX.Element {
+  return (
+    <dt className="govuk-summary-list__key">
+      {children}
+    </dt>
+  )
+}
+
+interface SummaryListRowProps extends SummaryListProps {
+  verticalAlign?: "bottom" | "middle"
+}
+
+export function SummaryListRow({ children, verticalAlign }: SummaryListRowProps): JSX.Element {
+  let className = "govuk-summary-list__row"
+
+  if (verticalAlign) {
+    className += ` ${className}__${verticalAlign}`
+  }
+
+  return (
+    <div className={className}>
+      {children}
+    </div>
+  )
+}
+
+interface SummaryListValueProps {
+  children: string | JSX.Element
+}
+
+export function SummaryListValue({ children }: SummaryListValueProps): JSX.Element {
+  return (
+    <dd className="govuk-summary-list__value">
+      {children}
+    </dd>
+  )
+}

--- a/data/forms/_test-form.json
+++ b/data/forms/_test-form.json
@@ -1,4 +1,5 @@
 {
+  "heading": "Test data",
   "steps": [
     {
       "heading": "Standard fields",

--- a/data/forms/immigration-status.json
+++ b/data/forms/immigration-status.json
@@ -1,4 +1,5 @@
 {
+  "heading": "Immigration status",
   "eligibility": [
     {
       "field": "uk-studying",
@@ -22,7 +23,6 @@
   ],
   "steps": [
     {
-      "heading": "Immigration status",
       "fields": [
         {
           "as": "radios",

--- a/data/forms/person-details.json
+++ b/data/forms/person-details.json
@@ -1,0 +1,16 @@
+{
+  "heading": "Personal details",
+  "steps": [
+    {
+      "fields": [
+        {
+          "label": "Name",
+          "name": "name",
+          "validation": {
+            "required": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/data/forms/your-situation.json
+++ b/data/forms/your-situation.json
@@ -1,8 +1,8 @@
 {
+  "heading": "Your situation",
+  "copy": "Help us determine if you need alternative support from the Council",
   "steps": [
     {
-      "heading": "Your situation",
-      "copy": "Help us determine if you need alternative support from the Council",
       "fields": [
         {
           "as": "checkboxes",

--- a/lib/store/additionalResidents.ts
+++ b/lib/store/additionalResidents.ts
@@ -1,0 +1,32 @@
+import { Resident } from "../types/resident"
+import { createSlice, PayloadAction } from "@reduxjs/toolkit"
+
+const initialState: Resident[] = [
+  {
+    "formData": {},
+    "name": "test user",
+    "slug": "test-user"
+  }
+]
+
+const slice = createSlice({
+  name: 'additionalResidents',
+  initialState,
+  reducers: {
+    /**
+     * Add additional resident to store
+     * @param {{[key: string]: Resident}} state The current residents state
+     * @param {PayloadAction<{[key: string]: Resident}>} action The new resident
+     * @returns {{[key: string]: Resident}} Updated residents state
+     */
+     addResident: (state: Resident[], action: PayloadAction<Resident>) => {
+      return [
+        ...state,
+        action.payload
+      ]
+    }
+  }
+})
+
+export default slice
+export const { addResident } = slice.actions

--- a/lib/store/additionalResidents.ts
+++ b/lib/store/additionalResidents.ts
@@ -34,7 +34,9 @@ const slice = createSlice({
         name: action.payload.name,
         slug: generateSlug(action.payload.name)
       }
-      resident.formData = action.payload
+      resident.formData = {
+        "personal-details": action.payload
+      }
 
       // Prevent duplicates
       const duplicates = state.filter(item => item.slug.match(new RegExp(`^${resident.slug}|(${resident.slug}_\d+)`)))
@@ -46,9 +48,24 @@ const slice = createSlice({
         ...state,
         resident
       ]
+    },
+
+    updateFormDataForResident: (state: Resident[], action: PayloadAction<Resident>): Resident[] => {
+      let index = 0
+      const newState = [...state]
+
+      newState.forEach((resident, i) => {
+        if (resident.slug == action.payload.slug) {
+          index = i
+        }
+      })
+
+      newState[index] = action.payload
+
+      return newState
     }
   }
 })
 
 export default slice
-export const { addResident, addResidentFromFormData } = slice.actions
+export const { addResident, addResidentFromFormData, updateFormDataForResident } = slice.actions

--- a/lib/store/additionalResidents.ts
+++ b/lib/store/additionalResidents.ts
@@ -29,18 +29,22 @@ const slice = createSlice({
      * @returns {Resident[]} Updated residents state
      */
      addResidentFromFormData: (state: Resident[], action: PayloadAction<FormData>): Resident[] => {
-      const newResident: Resident = {
+      const resident: Resident = {
         formData: action.payload,
         name: action.payload.name,
         slug: generateSlug(action.payload.name)
       }
-      newResident.formData = action.payload
+      resident.formData = action.payload
 
-      console.log(newResident)
+      // Prevent duplicates
+      const duplicates = state.filter(item => item.slug.match(new RegExp(`^${resident.slug}|(${resident.slug}_\d+)`)))
+      if (duplicates.length > 0) {
+        resident.slug += `_${duplicates.length}`
+      }
 
       return [
         ...state,
-        newResident
+        resident
       ]
     }
   }

--- a/lib/store/additionalResidents.ts
+++ b/lib/store/additionalResidents.ts
@@ -1,4 +1,6 @@
+import { FormData } from "../types/form"
 import { Resident } from "../types/resident"
+import { generateSlug } from "../utils/resident"
 import { createSlice, PayloadAction } from "@reduxjs/toolkit"
 
 const initialState: Resident[] = [
@@ -15,18 +17,40 @@ const slice = createSlice({
   reducers: {
     /**
      * Add additional resident to store
-     * @param {{[key: string]: Resident}} state The current residents state
-     * @param {PayloadAction<{[key: string]: Resident}>} action The new resident
-     * @returns {{[key: string]: Resident}} Updated residents state
+     * @param {Resident[]} state The current residents state
+     * @param {PayloadAction<{Resident}>} action The new resident
+     * @returns {Resident[]} Updated residents state
      */
-     addResident: (state: Resident[], action: PayloadAction<Resident>) => {
+     addResident: (state: Resident[], action: PayloadAction<Resident>): Resident[] => {
       return [
         ...state,
         action.payload
+      ]
+    },
+
+    /**
+     * Add additional resident to store (using form data)
+     * @param {Resident[]} state The current residents state
+     * @param {PayloadAction<FormData>} action The new resident
+     * @returns {Resident[]} Updated residents state
+     */
+     addResidentFromFormData: (state: Resident[], action: PayloadAction<FormData>): Resident[] => {
+      const newResident: Resident = {
+        formData: action.payload,
+        name: action.payload.name,
+        slug: generateSlug(action.payload.name)
+      }
+      newResident.formData = action.payload
+
+      console.log(newResident)
+
+      return [
+        ...state,
+        newResident
       ]
     }
   }
 })
 
 export default slice
-export const { addResident } = slice.actions
+export const { addResident, addResidentFromFormData } = slice.actions

--- a/lib/store/additionalResidents.ts
+++ b/lib/store/additionalResidents.ts
@@ -50,6 +50,23 @@ const slice = createSlice({
       ]
     },
 
+    /**
+     * Delete resident
+     * @param {Resident[]} state The current state 
+     * @param {PayloadAction<Resident>} action The resident we wish to delete
+     * @returns {Resident[]} New state with resident removed
+     */
+    deleteResident: (state: Resident[], action: PayloadAction<Resident>): Resident[] => {
+      const newState = state.filter(resident => resident.slug != action.payload.slug)
+      return [...newState]
+    },
+
+    /**
+     * Update residents record
+     * @param {Resident[]} state The current state 
+     * @param {PayloadAction<Resident>} action The resident we wish to update
+     * @returns {Resident[]} New state with updated resident
+     */
     updateFormDataForResident: (state: Resident[], action: PayloadAction<Resident>): Resident[] => {
       let index = 0
       const newState = [...state]
@@ -68,4 +85,4 @@ const slice = createSlice({
 })
 
 export default slice
-export const { addResident, addResidentFromFormData, updateFormDataForResident } = slice.actions
+export const { addResident, addResidentFromFormData, deleteResident, updateFormDataForResident } = slice.actions

--- a/lib/store/additionalResidents.ts
+++ b/lib/store/additionalResidents.ts
@@ -3,13 +3,7 @@ import { Resident } from "../types/resident"
 import { generateSlug } from "../utils/resident"
 import { createSlice, PayloadAction } from "@reduxjs/toolkit"
 
-const initialState: Resident[] = [
-  {
-    "formData": {},
-    "name": "test user",
-    "slug": "test-user"
-  }
-]
+const initialState: Resident[] = []
 
 const slice = createSlice({
   name: 'additionalResidents',

--- a/lib/store/index.ts
+++ b/lib/store/index.ts
@@ -1,13 +1,16 @@
+import additionalResidents from "./additionalResidents"
 import resident from "./resident"
-import { MainResident } from "../types/resident"
+import { MainResident, Resident } from "../types/resident"
 import { createStore, combineReducers } from "redux"
 import { createWrapper, Context } from "next-redux-wrapper"
 
 export interface Store {
+  additionalResidents: Resident[]
   resident: MainResident
 }
 
 const reducer = combineReducers({
+  additionalResidents: additionalResidents.reducer,
   resident: resident.reducer
 })
 

--- a/lib/store/resident.ts
+++ b/lib/store/resident.ts
@@ -2,12 +2,14 @@ import { checkEligible } from "../utils/form"
 import { MainResident } from "../types/resident"
 import { createSlice, PayloadAction } from "@reduxjs/toolkit"
 
+export const MAIN_RESIDENT_KEY = "you"
+
 const initialState: MainResident = {
   hasAgreed: false,
   formData: {},
   isLoggedIn: false,
   name: "You",
-  slug: "you"
+  slug: MAIN_RESIDENT_KEY
 }
 
 const slice = createSlice({
@@ -52,10 +54,10 @@ const slice = createSlice({
     /**
      * Update resident's form data
      * @param {MainResident} state The current state
-     * @param {PayloadAction<{}>} action The form data
+     * @param {PayloadAction<{[key: string]: FormData}>} action The form data
      * @returns {MainResident} Updated resident state
      */
-    updateFormData: (state: MainResident, action: PayloadAction<{}>): MainResident => {
+    updateFormData: (state: MainResident, action: PayloadAction<{[key: string]: FormData}>): MainResident => {
       state.formData = {
         ...state.formData,
         ...action.payload

--- a/lib/store/resident.ts
+++ b/lib/store/resident.ts
@@ -5,7 +5,9 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit"
 const initialState: MainResident = {
   hasAgreed: false,
   formData: {},
-  isLoggedIn: false
+  isLoggedIn: false,
+  name: "You",
+  slug: "you"
 }
 
 const slice = createSlice({

--- a/lib/types/form.ts
+++ b/lib/types/form.ts
@@ -47,6 +47,8 @@ export type FormStep = {
 }
 
 export type MultiStepForm = {
+  copy?: string
   eligibility?: EligibilityCriteria[]
+  heading?: string
   steps: FormStep[]
 }

--- a/lib/types/resident.ts
+++ b/lib/types/resident.ts
@@ -4,6 +4,8 @@ export interface Resident {
   formData: {[key: string]: FormData}
   ineligibilityReasons?: string[]
   isEligible?: boolean
+  name: string
+  slug: string
 }
 
 export interface MainResident extends Resident {

--- a/lib/utils/form-data.ts
+++ b/lib/utils/form-data.ts
@@ -1,11 +1,13 @@
 import agreementFormData from "../../data/forms/agreement.json"
 import immigrationStatusFormData from "../../data/forms/immigration-status.json"
+import personalDetailsFormData from "../../data/forms/person-details.json"
 import testFormData from "../../data/forms/_test-form.json"
 import yourSituationFormData from "../../data/forms/your-situation.json"
 import { EligibilityCriteria, MultiStepForm } from "../types/form"
 
 export const AGREEMENT = "agreement"
 export const IMMIGRATION_STATUS = "immigration-status"
+export const PERSONAL_DETAILS = "personal-details"
 export const YOUR_SITUATION = "your-situation"
 
 /**
@@ -30,6 +32,9 @@ export const YOUR_SITUATION = "your-situation"
 
     case "immigration-status":
       return getImmigrationStatusFormData()
+
+    case "personal-details":
+        return getPersonalDetailsFormData()
     
     case "your-situation":
       return getYourSituationFormData()
@@ -53,6 +58,14 @@ export const YOUR_SITUATION = "your-situation"
  */
  export function getImmigrationStatusFormData(): MultiStepForm {
   return immigrationStatusFormData
+}
+
+/**
+ * Get the form data that makes up the personal details form
+ * @returns {MultiStepForm}
+ */
+ export function getPersonalDetailsFormData(): MultiStepForm {
+  return personalDetailsFormData
 }
 
 /**

--- a/lib/utils/resident.ts
+++ b/lib/utils/resident.ts
@@ -1,0 +1,3 @@
+export const generateSlug = (input: string) => {
+  return encodeURI(input.toLowerCase().replaceAll(' ', '-'))
+}

--- a/lib/utils/resident.ts
+++ b/lib/utils/resident.ts
@@ -1,3 +1,53 @@
-export const generateSlug = (input: string) => {
+import { Store as ReduxStore } from "../store"
+import { updateFormDataForResident } from "../store/additionalResidents"
+import { MAIN_RESIDENT_KEY, updateFormData } from "../store/resident"
+import { FormData } from "../types/form"
+import { Resident } from "../types/resident"
+import { Store } from "redux"
+
+/**
+ * Generate a slug from an input
+ * @param {string} input The input value we wish to modify
+ * @returns {string} The modified value
+ */
+export const generateSlug = (input: string): string => {
   return encodeURI(input.toLowerCase().replaceAll(' ', '-'))
+}
+
+export const getResident = (slug: string, store: ReduxStore): Resident | undefined => {
+  if (slug == MAIN_RESIDENT_KEY) {
+    return store.resident
+  }
+  else {
+    const matches = store.additionalResidents.filter(resident => resident.slug == slug)
+    if (matches.length > 0) {
+      return matches[0]
+    }
+  }
+}
+
+/**
+ * Check to see if the resident is the main applicant
+ * @param {Resident} resident The resident we are interrogating
+ * @returns {boolean}
+ */
+export const isMainResident = (resident: Resident): boolean => {
+  return resident.slug == MAIN_RESIDENT_KEY
+}
+
+/**
+ * Update the form data for the given resident
+ * @param {Store} store The redux store
+ * @param {Resident} resident The resident we wish to update
+ * @param {FormData} data The data we are updating
+ */
+export const updateResidentsFormData = (store: Store, resident: Resident, data: FormData): void => {
+  if (isMainResident(resident)) {
+    store.dispatch(updateFormData(data))
+  }
+  else {
+    resident = { ...resident }
+    resident.formData = { ... resident.formData, data }
+    store.dispatch(updateFormDataForResident(resident))
+  }
 }

--- a/pages/apply/[resident]/[[...step]].tsx
+++ b/pages/apply/[resident]/[[...step]].tsx
@@ -1,16 +1,16 @@
 import ApplicationForms from "../../../components/application/application-forms"
 import Layout from "../../../components/layout/resident-layout"
 import whenEligible from "../../../lib/hoc/whenEligible"
-import { IMMIGRATION_STATUS, YOUR_SITUATION } from "../../../lib/utils/form-data"
+import { IMMIGRATION_STATUS, PERSONAL_DETAILS } from "../../../lib/utils/form-data"
 import { useRouter } from "next/router"
 
 const ApplicationStep = (): JSX.Element => {
   const router = useRouter()
-  let { person, step } = router.query
-  person = person as string
+  let { resident, step } = router.query
+  resident = resident as string
 
-  const baseHref = `/apply/${person}`
-  const steps = [YOUR_SITUATION, IMMIGRATION_STATUS]
+  const baseHref = `/apply/${resident}`
+  const steps = [IMMIGRATION_STATUS, PERSONAL_DETAILS]
   const activeStep = step ? step[0] : undefined
 
   const breadcrumbs = [
@@ -20,7 +20,7 @@ const ApplicationStep = (): JSX.Element => {
     },
     {
       href: baseHref,
-      name: person
+      name: resident
     }
   ]
 

--- a/pages/apply/[resident]/[[...step]].tsx
+++ b/pages/apply/[resident]/[[...step]].tsx
@@ -8,6 +8,7 @@ import { getResident, isMainResident } from "../../../lib/utils/resident"
 import { useRouter } from "next/router"
 import { useStore } from "react-redux"
 import Custom404 from "../../404"
+import DeleteLink from "../../../components/delete-link"
 
 const ApplicationStep = (): JSX.Element => {
   const router = useRouter()
@@ -38,7 +39,7 @@ const ApplicationStep = (): JSX.Element => {
     }
   ]
 
-  const deleteResidentFromStore = () => {
+  const onDelete = () => {
     store.dispatch(deleteResident(currentResident))
     router.push(returnHref)
   }
@@ -57,9 +58,7 @@ const ApplicationStep = (): JSX.Element => {
         steps={steps} />
       
       {!activeStep && !isMainResident(currentResident) && (
-        <a onClick={deleteResidentFromStore}>
-          Delete this information
-        </a>
+        <DeleteLink content="Delete this information" onDelete={onDelete} />
       )}
     </Layout>
   )

--- a/pages/apply/[resident]/[[...step]].tsx
+++ b/pages/apply/[resident]/[[...step]].tsx
@@ -2,8 +2,9 @@ import ApplicationForms from "../../../components/application/application-forms"
 import Layout from "../../../components/layout/resident-layout"
 import whenEligible from "../../../lib/hoc/whenEligible"
 import { Store } from "../../../lib/store"
+import { deleteResident } from "../../../lib/store/additionalResidents"
 import { IMMIGRATION_STATUS, PERSONAL_DETAILS } from "../../../lib/utils/form-data"
-import { getResident } from "../../../lib/utils/resident"
+import { getResident, isMainResident } from "../../../lib/utils/resident"
 import { useRouter } from "next/router"
 import { useStore } from "react-redux"
 import Custom404 from "../../404"
@@ -22,12 +23,13 @@ const ApplicationStep = (): JSX.Element => {
   }
 
   const baseHref = `/apply/${currentResident.slug}`
+  const returnHref = "/apply/overview"
   const steps = [IMMIGRATION_STATUS, PERSONAL_DETAILS]
   const activeStep = step ? step[0] : undefined
 
   const breadcrumbs = [
     {
-      href: "/apply/overview",
+      href: returnHref,
       name: "Application"
     },
     {
@@ -35,6 +37,11 @@ const ApplicationStep = (): JSX.Element => {
       name: currentResident.name
     }
   ]
+
+  const deleteResidentFromStore = () => {
+    store.dispatch(deleteResident(currentResident))
+    router.push(returnHref)
+  }
 
   const onCompletion = () => {
     router.push(baseHref)
@@ -48,6 +55,12 @@ const ApplicationStep = (): JSX.Element => {
         onCompletion={onCompletion}
         resident={currentResident!}
         steps={steps} />
+      
+      {!activeStep && !isMainResident(currentResident) && (
+        <a onClick={deleteResidentFromStore}>
+          Delete this information
+        </a>
+      )}
     </Layout>
   )
 }

--- a/pages/apply/[resident]/[[...step]].tsx
+++ b/pages/apply/[resident]/[[...step]].tsx
@@ -1,15 +1,27 @@
 import ApplicationForms from "../../../components/application/application-forms"
 import Layout from "../../../components/layout/resident-layout"
 import whenEligible from "../../../lib/hoc/whenEligible"
+import { Store } from "../../../lib/store"
 import { IMMIGRATION_STATUS, PERSONAL_DETAILS } from "../../../lib/utils/form-data"
+import { getResident } from "../../../lib/utils/resident"
 import { useRouter } from "next/router"
+import { useStore } from "react-redux"
+import Custom404 from "../../404"
 
 const ApplicationStep = (): JSX.Element => {
   const router = useRouter()
+  const store = useStore<Store>()
+
   let { resident, step } = router.query
   resident = resident as string
 
-  const baseHref = `/apply/${resident}`
+  const currentResident = getResident(resident, store.getState())
+
+  if (!currentResident) {
+    return <Custom404 />
+  }
+
+  const baseHref = `/apply/${currentResident.slug}`
   const steps = [IMMIGRATION_STATUS, PERSONAL_DETAILS]
   const activeStep = step ? step[0] : undefined
 
@@ -20,7 +32,7 @@ const ApplicationStep = (): JSX.Element => {
     },
     {
       href: baseHref,
-      name: resident
+      name: currentResident.name
     }
   ]
 
@@ -34,6 +46,7 @@ const ApplicationStep = (): JSX.Element => {
         activeStep={activeStep}
         baseHref={baseHref}
         onCompletion={onCompletion}
+        resident={currentResident!}
         steps={steps} />
     </Layout>
   )

--- a/pages/apply/add-resident.tsx
+++ b/pages/apply/add-resident.tsx
@@ -1,0 +1,41 @@
+import { HeadingOne } from "../../components/content/headings"
+import Form from "../../components/form/form"
+import Layout from "../../components/layout/resident-layout"
+import whenEligible from "../../lib/hoc/whenEligible"
+import { Store } from "../../lib/store"
+import { addResidentFromFormData } from "../../lib/store/additionalResidents"
+import { FormData } from "../../lib/types/form"
+import { getPersonalDetailsFormData } from "../../lib/utils/form-data"
+import { useStore } from "react-redux"
+import { useRouter } from "next/router"
+
+const AddPersonToApplication = (): JSX.Element => {
+  const returnHref = "/apply/overview"
+  const router = useRouter()
+  const store = useStore<Store>()
+
+  const breadcrumbs = [
+    {
+      href: returnHref,
+      name: "Application"
+    }
+  ]
+
+  const onSubmit = (values: FormData) => {
+    store.dispatch(addResidentFromFormData(values))
+    router.push(returnHref)
+  }
+
+  return (
+    <Layout breadcrumbs={breadcrumbs}>
+      <HeadingOne content="Add a person" />
+      <Form buttonText="Add person" formData={getPersonalDetailsFormData()} onSubmit={onSubmit} />
+    </Layout>
+  )
+}
+
+export default whenEligible(AddPersonToApplication)
+
+// TODO!
+// > onSubmit
+//   - what if there is a clash?

--- a/pages/apply/add-resident.tsx
+++ b/pages/apply/add-resident.tsx
@@ -35,7 +35,3 @@ const AddPersonToApplication = (): JSX.Element => {
 }
 
 export default whenEligible(AddPersonToApplication)
-
-// TODO!
-// > onSubmit
-//   - what if there is a clash?

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -45,7 +45,7 @@ const Apply = (): JSX.Element => {
         If I do not allow entry, my application may be declined.
       </Paragraph>
 
-      <Form formData={agreementFormData} onSave={onSave} onSubmit={onSubmit} />
+      <Form buttonText="Save and continue" formData={agreementFormData} onSave={onSave} onSubmit={onSubmit} />
     </Layout>
   )
 }

--- a/pages/apply/overview.tsx
+++ b/pages/apply/overview.tsx
@@ -1,12 +1,13 @@
+import { ButtonLink } from "../../components/button"
 import { HeadingOne } from "../../components/content/headings"
+import Hint from "../../components/form/hint"
 import Layout from "../../components/layout/resident-layout"
 import SummaryList, { SummaryListActions as Actions, SummaryListKey as Key, SummaryListRow as Row } from "../../components/summary-list"
+import Tag from "../../components/tag"
 import whenEligible from "../../lib/hoc/whenEligible"
 import { Store } from "../../lib/store"
 import Link from "next/link"
 import { useStore } from "react-redux"
-import Hint from "../../components/form/hint"
-import Tag from "../../components/tag"
 
 const ApplicationPersonsOverview = (): JSX.Element => {
   const store = useStore<Store>()
@@ -38,6 +39,10 @@ const ApplicationPersonsOverview = (): JSX.Element => {
           </Row>
         ))}
       </SummaryList>
+
+      <ButtonLink href="/apply/add-resident" secondary={true}>
+        Add a person
+      </ButtonLink>
     </Layout>
   )
 }

--- a/pages/apply/overview.tsx
+++ b/pages/apply/overview.tsx
@@ -1,20 +1,50 @@
 import { HeadingOne } from "../../components/content/headings"
 import Layout from "../../components/layout/resident-layout"
+import SummaryList, { SummaryListActions as Actions, SummaryListKey as Key, SummaryListRow as Row } from "../../components/summary-list"
 import whenEligible from "../../lib/hoc/whenEligible"
+import { Store } from "../../lib/store"
 import Link from "next/link"
+import { useStore } from "react-redux"
+import Hint from "../../components/form/hint"
+import Tag from "../../components/tag"
 
 const ApplicationPersonsOverview = (): JSX.Element => {
+  const store = useStore<Store>()
+  const users = [store.getState().resident, ...store.getState().additionalResidents]
+
+  const breadcrumbs = [
+    {
+      href: "/apply/overview",
+      name: "Application"
+    }
+  ]
+
   return (
-    <Layout>
+    <Layout breadcrumbs={breadcrumbs}>
       <HeadingOne content="People in this application" />
       
-      <Link href={`/apply/person-one`}>
-        You
-      </Link>
+      <SummaryList>
+        {users.map((user, index) => (
+          <Row key={index} verticalAlign="middle">
+            <Key>
+              <>
+                <Hint content={`Person ${index + 1}`} />
+                <Link href={`/apply/${user.slug}`}>{user.name}</Link>
+              </>
+            </Key>
+            <Actions>
+              <Tag content="X tasks to do" />
+            </Actions>
+          </Row>
+        ))}
+      </SummaryList>
     </Layout>
   )
 }
 
-// TODO: list of people
-
 export default whenEligible(ApplicationPersonsOverview)
+
+// TODO!
+// Work out how many steps are required
+
+// Add additional user

--- a/pages/apply/overview.tsx
+++ b/pages/apply/overview.tsx
@@ -6,6 +6,7 @@ import SummaryList, { SummaryListActions as Actions, SummaryListKey as Key, Summ
 import Tag from "../../components/tag"
 import whenEligible from "../../lib/hoc/whenEligible"
 import { Store } from "../../lib/store"
+import { MAIN_RESIDENT_KEY } from "../../lib/store/resident"
 import Link from "next/link"
 import { useStore } from "react-redux"
 
@@ -29,7 +30,7 @@ const ApplicationPersonsOverview = (): JSX.Element => {
           <Row key={index} verticalAlign="middle">
             <Key>
               <>
-                <Hint content={`Person ${index + 1}`} />
+                <Hint content={`Person ${index + 1}` + (users.length > 1 && user.slug == MAIN_RESIDENT_KEY ? " (you)" : "")} />
                 <Link href={`/apply/${user.slug}`}>{user.name}</Link>
               </>
             </Key>
@@ -48,9 +49,3 @@ const ApplicationPersonsOverview = (): JSX.Element => {
 }
 
 export default whenEligible(ApplicationPersonsOverview)
-
-// TODO!
-// (You) on Person X
-// Work out how many steps are required
-
-// Add additional user

--- a/pages/apply/overview.tsx
+++ b/pages/apply/overview.tsx
@@ -50,6 +50,7 @@ const ApplicationPersonsOverview = (): JSX.Element => {
 export default whenEligible(ApplicationPersonsOverview)
 
 // TODO!
+// (You) on Person X
 // Work out how many steps are required
 
 // Add additional user

--- a/pages/eligibility-checker/[[...step]].tsx
+++ b/pages/eligibility-checker/[[...step]].tsx
@@ -35,6 +35,7 @@ export default function EligibilityChecker(): JSX.Element {
         activeStep={activeStep}
         baseHref={baseHref}
         onCompletion={onCompletion}
+        resident={resident}
         steps={steps}
         />
     </Layout>

--- a/styles/components/_summary-list.scss
+++ b/styles/components/_summary-list.scss
@@ -1,0 +1,7 @@
+@import "node_modules/lbh-frontend/lbh/components/lbh-summary-list/summary-list";
+
+@each $position in bottom middle {
+  .govuk-summary-list__row__#{$position} > * {
+    vertical-align: $position;
+  }
+}

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -21,10 +21,10 @@
 @import "node_modules/lbh-frontend/lbh/components/lbh-simple-pagination/simple-pagination";
 @import "node_modules/lbh-frontend/lbh/components/lbh-skip-link/skip-link";
 @import "node_modules/lbh-frontend/lbh/components/lbh-stat/stat";
-@import "node_modules/lbh-frontend/lbh/components/lbh-summary-list/summary-list";
 @import "node_modules/lbh-frontend/lbh/components/lbh-table/table";
 @import "node_modules/lbh-frontend/lbh/components/lbh-tag/tag";
 @import "node_modules/lbh-frontend/lbh/components/lbh-textarea/textarea";
+@import "components/summary-list";
 
 // Objects
 @import "objects/flex";


### PR DESCRIPTION
Reworked the application overview section (`/application/overview`):

- List of people (including the main resident) as set by the resident store
- Ability to add/remove people to and from the application
- - Resolve clashes with duplicate slugs
- Storing resident / main residents form data