### PR TITLE
Require agreement before showing the application form

### DIFF
--- a/components/application/agreement.tsx
+++ b/components/application/agreement.tsx
@@ -1,0 +1,49 @@
+import { HeadingOne } from "../content/headings"
+import Paragraph from "../content/paragraph"
+import Form from "../form/form"
+import { Store } from "../../lib/store"
+import { agree } from "../../lib/store/resident"
+import { FormData } from "../../lib/types/form"
+import { getAgreementFormData } from "../../lib/utils/form-data"
+import { useRouter } from "next/router"
+import { useStore } from "react-redux"
+
+export default function ApplicationAgreement() {
+  const router = useRouter()
+  const store = useStore<Store>()
+  const resident = store.getState().resident
+
+  const onSubmit = () => {
+    router.push("/apply/overview")
+  }
+  
+  if (resident.hasAgreed) {
+    onSubmit()
+  }
+  
+  const agreementFormData = getAgreementFormData()
+  const onSave = (values: FormData) => {
+    store.dispatch(agree(values.agreement))
+  }
+
+  return (
+    <>
+      <HeadingOne content="Before you continue" />
+
+      <Paragraph>
+        I understand that the information I provide will be verified by Hackney Council to assess my level of housing need.
+      </Paragraph>
+
+      <Paragraph>
+        The answers and evidence I provide may be referred to credit agencies, other local authorities, medical professionals and HMRC.
+      </Paragraph>
+
+      <Paragraph>
+        I agree to allow a Housing Officer to conduct a home visit to assess my current living situation without advance notice.
+        If I do not allow entry, my application may be declined.
+      </Paragraph>
+
+      <Form buttonText="Save and continue" formData={agreementFormData} onSave={onSave} onSubmit={onSubmit} />
+    </>
+  )
+}

--- a/lib/hoc/whenAgreed.tsx
+++ b/lib/hoc/whenAgreed.tsx
@@ -1,0 +1,26 @@
+import ApplicationAgreement from "../../components/application/agreement"
+import Layout from "../../components/layout/resident-layout"
+import { Store } from "../store"
+import { MainResident } from "../types/resident"
+import React from "react"
+import { connect } from "react-redux"
+import { compose } from "redux"
+
+const whenAgreed = (WrappedComponent: React.ComponentType<any>) => {
+  return (props: MainResident) => {
+    if (!props.hasAgreed) {
+      return (
+        <Layout>
+          <ApplicationAgreement />
+        </Layout>
+      )
+    }
+
+    return <WrappedComponent {...props} />
+  }
+}
+
+export default compose(
+  connect((state: Store) => state.resident),
+  whenAgreed
+)

--- a/pages/apply/[resident]/[[...step]].tsx
+++ b/pages/apply/[resident]/[[...step]].tsx
@@ -2,6 +2,7 @@ import ApplicationForms from "../../../components/application/application-forms"
 import { HeadingOne } from "../../../components/content/headings"
 import Hint from "../../../components/form/hint"
 import Layout from "../../../components/layout/resident-layout"
+import whenAgreed from "../../../lib/hoc/whenAgreed"
 import whenEligible from "../../../lib/hoc/whenEligible"
 import { Store } from "../../../lib/store"
 import { deleteResident } from "../../../lib/store/additionalResidents"
@@ -91,4 +92,4 @@ const ApplicationStep = (): JSX.Element => {
   )
 }
 
-export default whenEligible(ApplicationStep)
+export default whenAgreed(whenEligible(ApplicationStep))

--- a/pages/apply/add-resident.tsx
+++ b/pages/apply/add-resident.tsx
@@ -1,6 +1,7 @@
 import { HeadingOne } from "../../components/content/headings"
 import Form from "../../components/form/form"
 import Layout from "../../components/layout/resident-layout"
+import whenAgreed from "../../lib/hoc/whenAgreed"
 import whenEligible from "../../lib/hoc/whenEligible"
 import { Store } from "../../lib/store"
 import { addResidentFromFormData } from "../../lib/store/additionalResidents"
@@ -34,4 +35,4 @@ const AddPersonToApplication = (): JSX.Element => {
   )
 }
 
-export default whenEligible(AddPersonToApplication)
+export default whenAgreed(whenEligible(AddPersonToApplication))

--- a/pages/apply/index.tsx
+++ b/pages/apply/index.tsx
@@ -1,51 +1,11 @@
-import Form from "../../components/form/form"
-import { HeadingOne } from "../../components/content/headings"
-import Paragraph from "../../components/content/paragraph"
 import Layout from "../../components/layout/resident-layout"
 import whenEligible from "../../lib/hoc/whenEligible"
-import { Store } from "../../lib/store"
-import { agree } from "../../lib/store/resident"
-import { FormData } from "../../lib/types/form"
-import { getAgreementFormData } from "../../lib/utils/form-data"
-import { useRouter } from "next/router"
-import { useStore } from "react-redux"
+import ApplicationAgreement from "../../components/application/agreement"
 
 const Apply = (): JSX.Element => {
-  const router = useRouter()
-  const store = useStore<Store>()
-  const resident = store.getState().resident
-
-  const onSubmit = () => {
-    router.push("/apply/overview")
-  }
-  
-  if (resident.hasAgreed) {
-    onSubmit()
-  }
-  
-  const agreementFormData = getAgreementFormData()
-  const onSave = (values: FormData) => {
-    store.dispatch(agree(values.agreement))
-  }
-  
   return (
     <Layout>
-      <HeadingOne content="Before you continue" />
-
-      <Paragraph>
-        I understand that the information I provide will be verified by Hackney Council to assess my level of housing need.
-      </Paragraph>
-
-      <Paragraph>
-        The answers and evidence I provide may be referred to credit agencies, other local authorities, medical professionals and HMRC.
-      </Paragraph>
-
-      <Paragraph>
-        I agree to allow a Housing Officer to conduct a home visit to assess my current living situation without advance notice.
-        If I do not allow entry, my application may be declined.
-      </Paragraph>
-
-      <Form buttonText="Save and continue" formData={agreementFormData} onSave={onSave} onSubmit={onSubmit} />
+      <ApplicationAgreement />
     </Layout>
   )
 }

--- a/pages/apply/overview.tsx
+++ b/pages/apply/overview.tsx
@@ -4,6 +4,7 @@ import Hint from "../../components/form/hint"
 import Layout from "../../components/layout/resident-layout"
 import SummaryList, { SummaryListActions as Actions, SummaryListKey as Key, SummaryListRow as Row } from "../../components/summary-list"
 import Tag from "../../components/tag"
+import whenAgreed from "../../lib/hoc/whenAgreed"
 import whenEligible from "../../lib/hoc/whenEligible"
 import { Store } from "../../lib/store"
 import { MAIN_RESIDENT_KEY } from "../../lib/store/resident"
@@ -57,4 +58,4 @@ const ApplicationPersonsOverview = (): JSX.Element => {
   )
 }
 
-export default whenEligible(ApplicationPersonsOverview)
+export default whenAgreed(whenEligible(ApplicationPersonsOverview))


### PR DESCRIPTION
Previously: going directly to parts of the application form (like `/application/overview`) would show the contents even if the user was not shown the agreement page.

This change ensures they have agreed before being able to see anything under the `/application` directory.