### PR TITLE
Dialog confirmation when trying to delete a resident from the application

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -2,14 +2,15 @@ import Link from "next/link"
 
 interface ButtonProps {
   children: string
+  className?: string
   disabled?: boolean
   onClick?: () => void
   secondary?: boolean
   type?: "button" | "reset" | "submit"
 }
 
-export default function Button({ children, disabled, onClick, secondary, type }: ButtonProps): JSX.Element {
-  let className = "govuk-button lbh-button"
+export default function Button({ children, className, disabled, onClick, secondary, type }: ButtonProps): JSX.Element {
+  className += " govuk-button lbh-button"
 
   if (disabled) {
     className += " govuk-button--disabled lbh-button--disabled"

--- a/components/delete-link.tsx
+++ b/components/delete-link.tsx
@@ -1,12 +1,27 @@
+import Dialog from "./dialog"
+import { useState } from "react"
+
 interface DeleteLinkProps {
   content: string
   onDelete: () => void
 }
 
 export default function DeleteLink({ content, onDelete }: DeleteLinkProps) {
+  const [confirmation, setConfirmation] = useState(false)
+
+  if (confirmation) {
+    const onConfirmation = () => onDelete()
+
+    return <Dialog
+              title="Are you sure?"
+              copy="This record will be permanently deleted"
+              onConfirmation={onConfirmation}
+              onCancel={() => setConfirmation(false)} />
+  }
+
   return (
     <div className="text-center">
-      <a onClick={onDelete}>
+      <a onClick={() => setConfirmation(true)}>
         <span className="govuk-error-message lbh-error-message">
           {content}
         </span>

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -1,0 +1,31 @@
+import Button from "./button"
+import { HeadingTwo } from "./content/headings"
+import Paragraph from "./content/paragraph"
+
+interface DialogProps {
+  copy?: string
+  title?: string
+  onCancel?: () => void
+  onConfirmation: () => void
+}
+
+export default function Dialog({ copy, title, onCancel, onConfirmation }: DialogProps) {
+  return (
+    <div className="lbh-dialog" aria-modal="true" aria-label="Are you sure?" role="dialog">
+      {title && <HeadingTwo content={title} />}
+      {copy && <Paragraph>{copy}</Paragraph>}
+
+      <div className="lbh-dialog__actions">
+        <a onClick={onConfirmation} className="govuk-button lbh-button">
+          Yes
+        </a>
+        
+        {onCancel && 
+          <Button className="lbh-link lbh-link--no-visited-state" onClick={onCancel}>
+            No, cancel
+          </Button>
+        }
+      </div>
+    </div>
+  )
+}

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -11,20 +11,22 @@ interface DialogProps {
 
 export default function Dialog({ copy, title, onCancel, onConfirmation }: DialogProps) {
   return (
-    <div className="lbh-dialog" aria-modal="true" aria-label="Are you sure?" role="dialog">
-      {title && <HeadingTwo content={title} />}
-      {copy && <Paragraph>{copy}</Paragraph>}
+    <div data-reach-dialog-overlay>
+      <div className="lbh-dialog" aria-modal="true" aria-label="Are you sure?" role="dialog">
+        {title && <HeadingTwo content={title} />}
+        {copy && <Paragraph>{copy}</Paragraph>}
 
-      <div className="lbh-dialog__actions">
-        <a onClick={onConfirmation} className="govuk-button lbh-button">
-          Yes
-        </a>
-        
-        {onCancel && 
-          <Button className="lbh-link lbh-link--no-visited-state" onClick={onCancel}>
-            No, cancel
-          </Button>
-        }
+        <div className="lbh-dialog__actions">
+          <a onClick={onConfirmation} className="govuk-button lbh-button">
+            Yes
+          </a>
+          
+          {onCancel && 
+            <Button className="lbh-link lbh-link--no-visited-state" onClick={onCancel}>
+              No, cancel
+            </Button>
+          }
+        </div>
       </div>
     </div>
   )

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -8,6 +8,7 @@
 @import "node_modules/lbh-frontend/lbh/components/lbh-checkboxes/checkboxes";
 @import "node_modules/lbh-frontend/lbh/components/lbh-collapsible/collapsible";
 @import "node_modules/lbh-frontend/lbh/components/lbh-date-input/date-input";
+@import "node_modules/lbh-frontend/lbh/components/lbh-dialog/dialog";
 @import "node_modules/lbh-frontend/lbh/components/lbh-fieldset/fieldset";
 @import "node_modules/lbh-frontend/lbh/components/lbh-header/header";
 @import "node_modules/lbh-frontend/lbh/components/lbh-hint/hint";


### PR DESCRIPTION
Not the tidiest of implementations, but quickly integrating as proof-of-concept.

To test:

1. Go to /application/overview
2. Add a new person
3. Click on the person's link to view their progress
4. At the bottom the 'delete link' should be visible, click on this
5. You should be shown the dialog in place of the link
6. On cancel, the link should be reinstated and the dialog removed
7. Alternatively: On confirmation you should be taken back to the overview and that person should be removed from the application