### PR TITLE
Residential status removed from eligibility checker

### DIFF
--- a/lib/utils/application-forms.ts
+++ b/lib/utils/application-forms.ts
@@ -30,11 +30,7 @@ export const getEligibilitySteps = (): ApplicationSteps[] => {
         {
           heading: 'Immigration status',
           id: IMMIGRATION_STATUS,
-        },
-        {
-          heading: 'Residential status',
-          id: RESIDENTIAL_STATUS,
-        },
+        }
       ],
     },
   ];


### PR DESCRIPTION
Removed the residential status from the eligibility checker at the pre-application screen.