### PR TITLE
bugfix/section-as-complete

### DIFF
--- a/components/application/application-forms.tsx
+++ b/components/application/application-forms.tsx
@@ -4,7 +4,6 @@ import { Applicant } from '../../domain/HousingApi';
 import {
   applicantHasId,
   getQuestionsForFormAsValues,
-  markSectionAsComplete,
   updateWithFormValues,
 } from '../../lib/store/applicant';
 import { useAppDispatch } from '../../lib/store/hooks';
@@ -54,12 +53,7 @@ export default function ApplicationForms({
           formID: activeStepId,
           personID: applicant.person.id,
           values,
-        })
-      );
-      dispatch(
-        markSectionAsComplete({
-          formID: activeStepId,
-          personID: applicant.person.id,
+          markAsComplete: true
         })
       );
     }

--- a/lib/store/applicant.ts
+++ b/lib/store/applicant.ts
@@ -22,20 +22,8 @@ export const updateWithFormValues = createAction<{
   personID: string;
   formID: FormID;
   values: FormikValues;
+  markAsComplete: boolean;
 }>('applicant/updateWithFormValues');
-
-export const markSectionAsComplete = ({
-  personID,
-  formID,
-}: {
-  personID: string;
-  formID: FormID;
-}) =>
-  updateWithFormValues({
-    personID,
-    formID,
-    values: { sectionCompleted: true },
-  });
 
 export function applyQuestions(
   state: Applicant | undefined = {},
@@ -79,18 +67,18 @@ export function updateApplicantReducer(
 
 export const selectApplicant =
   (applicantPersonId: string) =>
-  (store: Store): ApplicantWithPersonID | undefined => {
-    if (
-      applicantHasId(store.application.mainApplicant) &&
-      store.application.mainApplicant?.person?.id === applicantPersonId
-    ) {
-      return store.application.mainApplicant;
-    }
-    return store.application.otherMembers?.find(
-      (a): a is ApplicantWithPersonID =>
-        applicantHasId(a) && a.person?.id === applicantPersonId
-    );
-  };
+    (store: Store): ApplicantWithPersonID | undefined => {
+      if (
+        applicantHasId(store.application.mainApplicant) &&
+        store.application.mainApplicant?.person?.id === applicantPersonId
+      ) {
+        return store.application.mainApplicant;
+      }
+      return store.application.otherMembers?.find(
+        (a): a is ApplicantWithPersonID =>
+          applicantHasId(a) && a.person?.id === applicantPersonId
+      );
+    };
 
 export const findQuesiton =
   (formID: FormID, questionName: string) => (question: Question) =>

--- a/lib/store/mainApplicant.ts
+++ b/lib/store/mainApplicant.ts
@@ -39,6 +39,10 @@ const slice = createSlice({
           state?.person?.id &&
           state?.person?.id === action.payload.personID
         ) {
+          if (action.payload.markAsComplete) {
+            action.payload.values["sectionCompleted"] = true;
+          }
+
           return applyQuestions(
             state,
             action.payload.formID,

--- a/lib/store/otherMembers.ts
+++ b/lib/store/otherMembers.ts
@@ -79,6 +79,10 @@ const slice = createSlice({
           (p) => p.person?.id && p.person.id === action.payload.personID
         );
         if (applicant > -1) {
+          if (action.payload.markAsComplete) {
+            action.payload.values["sectionCompleted"] = true;
+          }
+
           // Immer
           state[applicant] = applyQuestions(
             state[applicant],

--- a/pages/apply/[resident]/address-history.tsx
+++ b/pages/apply/[resident]/address-history.tsx
@@ -15,7 +15,6 @@ import { AddressLookupAddress } from '../../../domain/addressLookup';
 import { AddressType } from '../../../domain/HousingApi';
 import { lookUpAddress } from '../../../lib/gateways/internal-api';
 import {
-  markSectionAsComplete,
   selectApplicant,
   updateApplicant,
   updateWithFormValues,
@@ -289,12 +288,7 @@ const ApplicationStep = (): JSX.Element => {
             personID: applicant.person.id,
             formID: FormID.ADDRESS_HISTORY,
             values: { addressHistory },
-          })
-        );
-        dispatch(
-          markSectionAsComplete({
-            personID: applicant.person.id,
-            formID: FormID.ADDRESS_HISTORY,
+            markAsComplete: true
           })
         );
         router.push(`/apply/${resident}`);

--- a/pages/apply/[resident]/personal-details.tsx
+++ b/pages/apply/[resident]/personal-details.tsx
@@ -5,7 +5,6 @@ import ApplicantStep from '../../../components/application/ApplicantStep';
 import Form from '../../../components/form/form';
 import {
   getQuestionsForFormAsValues,
-  markSectionAsComplete,
   selectApplicant,
   updateApplicant,
   updateWithFormValues,
@@ -69,12 +68,7 @@ const ApplicationStep = (): JSX.Element => {
         formID: FormID.PERSONAL_DETAILS,
         personID: applicant.person.id,
         values,
-      })
-    );
-    dispatch(
-      markSectionAsComplete({
-        formID: FormID.PERSONAL_DETAILS,
-        personID: applicant.person.id,
+        markAsComplete: true
       })
     );
   };

--- a/pages/apply/[resident]/your-situation.tsx
+++ b/pages/apply/[resident]/your-situation.tsx
@@ -8,7 +8,6 @@ import Hint from '../../../components/form/hint';
 import Layout from '../../../components/layout/resident-layout';
 import {
   getQuestionValue,
-  markSectionAsComplete,
   selectApplicant,
   updateWithFormValues,
 } from '../../../lib/store/applicant';
@@ -76,9 +75,11 @@ export default function YourSituation() {
 
     if (nextFormId === 'exit') {
       dispatch(
-        markSectionAsComplete({
+        updateWithFormValues({
           formID: FormID.YOUR_SITUATION,
           personID: applicant.person.id,
+          values,
+          markAsComplete: true
         })
       );
       router.push(baseHref);
@@ -94,6 +95,7 @@ export default function YourSituation() {
         formID: activeStepID,
         personID: applicant.person.id,
         values,
+        markAsComplete: true
       })
     );
   };


### PR DESCRIPTION
Fix issue with double dispatch of actions causing the form values to be cleared, when setting `sectionCompleted`.

Mark section as complete when updating the form values.