### PR TITLE
bugfix/dateinput

### DIFF
--- a/components/application/add-person-form.tsx
+++ b/components/application/add-person-form.tsx
@@ -268,6 +268,7 @@ const AddPersonForm = ({
           <DateInput
             name={'dateOfBirth'}
             label={'Date of birth'}
+            hint={'For example, 31 3 1980'}
             showDay={true}
           />
           <RadioConditional

--- a/components/form/dateinput.tsx
+++ b/components/form/dateinput.tsx
@@ -80,13 +80,10 @@ export default function DateInput({
   return (
     <FormGroup error={!!meta.touched && !!meta.error}>
       {label && <Label content={label} strong={true} hideLabel={hideLabel} />}
-      {hint && <Hint content={hint} />}
       {meta.touched && meta.error && <ErrorMessage message={meta.error} />}
 
-      <fieldset className="govuk-fieldset" role="group" aria-describedby="hint">
-        <span id="address-hint" className="govuk-hint lbh-hint">
-          For example, {showDay && '31'} 3 1980
-        </span>
+      <fieldset className="govuk-fieldset" role="group">
+        {hint && <Hint content={hint} />}
         <div className="govuk-date-input lbh-date-input" id="current-address">
           <div className="govuk-date-input__item">
             <div className="govuk-form-group">

--- a/data/forms/employment.json
+++ b/data/forms/employment.json
@@ -52,6 +52,7 @@
           "as": "dateinput",
           "label": "When will you complete your course?",
           "name": "course-completion-date",
+          "hint": "For example, 3 2023",
           "showDay": false,
           "options": [
             {

--- a/data/forms/person-details.json
+++ b/data/forms/person-details.json
@@ -56,6 +56,7 @@
           "as": "dateinput",
           "label": "Date of birth",
           "name": "dateOfBirth",
+          "hint": "For example, 31 3 1980",
           "validation": {
             "required": true
           }

--- a/data/forms/sign-up-details.json
+++ b/data/forms/sign-up-details.json
@@ -55,6 +55,7 @@
           "as": "dateinput",
           "label": "Date of birth",
           "name": "dateOfBirth",
+          "hint": "For example, 31 3 1980",
           "validation": {
             "required": true
           }


### PR DESCRIPTION
Remove default hint from date input.
This isn't always likely to be in the past and is possibly not helpful.

Specify the hint explicitly where the input type is declared.