### PR TITLE
Bugfix/assessment values

### DIFF
--- a/components/admin/actions.tsx
+++ b/components/admin/actions.tsx
@@ -226,7 +226,6 @@ export default function Actions({ data }: PageProps): JSX.Element {
       id: data.id,
       status: values.status,
       assessment: {
-        ...data.assessment,
         reason: values.reason,
       },
     };


### PR DESCRIPTION
If there was already some values set for an assessment, and a new assessment is provided. Then the previous values shouldn't be retained as it's a new decision being made.