### PR TITLE
Date mismatch and editing/displaying applicant and household member fixes

### DIFF
--- a/components/admin/other-members.tsx
+++ b/components/admin/other-members.tsx
@@ -4,6 +4,7 @@ import { formatDob, getAgeInYears } from '../../lib/utils/dateOfBirth';
 import React from 'react';
 import { HeadingThree } from '../content/headings';
 import { getGenderName } from '../../lib/utils/gender';
+import capitalize from '../../lib/utils/capitalize';
 
 interface SummaryProps {
   heading: string;
@@ -31,14 +32,16 @@ export default function OtherMembers({
                     <strong>
                       {applicant.person?.title} {applicant.person?.firstName}{' '}
                       {applicant.person?.surname}
-                    </strong>
+                    </strong>{' '}
+                    {getGenderName(applicant) !== ''
+                      ? `(${getGenderName(applicant)})`
+                      : ''}
                   </li>
                   <li>
                     {applicant.person?.relationshipType &&
-                      applicant.person?.relationshipType}
+                      capitalize(applicant.person?.relationshipType)}
                   </li>
                   <li>
-                    {getGenderName(applicant)},{' '}
                     {applicant.person?.dateOfBirth &&
                       formatDob(new Date(applicant.person?.dateOfBirth))}{' '}
                     {applicant.person?.dateOfBirth &&

--- a/components/admin/personal-details.tsx
+++ b/components/admin/personal-details.tsx
@@ -34,11 +34,12 @@ export default function PersonalDetails({
                   <strong>
                     {applicant.person?.title} {applicant.person?.firstName}{' '}
                     {applicant.person?.surname}
-                  </strong>
+                  </strong>{' '}
+                  {getGenderName(applicant) !== ''
+                    ? `(${getGenderName(applicant)})`
+                    : ''}
                 </li>
-                <li>Applicant</li>
                 <li>
-                  {getGenderName(applicant)},{' '}
                   {applicant.person?.dateOfBirth &&
                     formatDob(new Date(applicant.person?.dateOfBirth))}{' '}
                   {applicant.person?.dateOfBirth &&

--- a/lib/utils/adminHelpers.ts
+++ b/lib/utils/adminHelpers.ts
@@ -130,6 +130,7 @@ export const generateEditInitialValues = (
     personalDetails_surname: personData?.person?.surname,
     personalDetails_dateOfBirth: personData?.person?.dateOfBirth,
     personalDetails_gender: personData?.person?.gender,
+    personalDetails_genderDescription: personData?.person?.genderDescription,
     personalDetails_nationalInsuranceNumber:
       personData?.person?.nationalInsuranceNumber,
     personalDetails_relationshipType: personData?.person?.relationshipType,
@@ -157,6 +158,8 @@ export const generateInitialValues = (sections: SectionData[]) => {
     (acc: { [key: string]: string }, current) => ((acc[current] = ''), acc),
     {}
   );
+
+  console.log(initialValuesObject);
 
   return initialValuesObject;
 };

--- a/lib/utils/dateOfBirth.ts
+++ b/lib/utils/dateOfBirth.ts
@@ -3,6 +3,7 @@ import { Applicant } from '../../domain/HousingApi';
 export function formatDate(date: string | undefined) {
   if (!date) return '';
   return `${new Date(date).toLocaleString('default', {
+    timeZone: 'UTC',
     day: 'numeric',
     month: 'short',
     year: 'numeric',
@@ -11,6 +12,7 @@ export function formatDate(date: string | undefined) {
 
 export function formatDob(date: Date) {
   return `${date.toLocaleString('default', {
+    timeZone: 'UTC',
     day: 'numeric',
     month: 'short',
     year: 'numeric',

--- a/pages/applications/edit/[id]/[person]/edit-household-member.tsx
+++ b/pages/applications/edit/[id]/[person]/edit-household-member.tsx
@@ -53,7 +53,7 @@ export default function EditApplicant({
         surname: values.personalDetails_surname,
         dateOfBirth: values.personalDetails_dateOfBirth,
         gender: values.personalDetails_gender,
-        genderDescription: '',
+        genderDescription: values.personalDetails_genderDescription,
         nationalInsuranceNumber: values.personalDetails_nationalInsuranceNumber,
         relationshipType: values.personalDetails_relationshipType,
       },

--- a/pages/applications/edit/[id]/[person]/index.tsx
+++ b/pages/applications/edit/[id]/[person]/index.tsx
@@ -64,7 +64,7 @@ export default function EditApplicant({
           surname: values.personalDetails_surname,
           dateOfBirth: values.personalDetails_dateOfBirth,
           gender: values.personalDetails_gender,
-          genderDescription: '',
+          genderDescription: values.personalDetails_genderDescription,
           nationalInsuranceNumber:
             values.personalDetails_nationalInsuranceNumber,
         },

--- a/pages/applications/edit/[id]/add-household-member.tsx
+++ b/pages/applications/edit/[id]/add-household-member.tsx
@@ -41,7 +41,7 @@ export default function AddHouseholdMember({
         surname: values.personalDetails_surname,
         dateOfBirth: values.personalDetails_dateOfBirth,
         gender: values.personalDetails_gender,
-        genderDescription: '',
+        genderDescription: values.personalDetails_genderDescription,
         nationalInsuranceNumber: values.personalDetails_nationalInsuranceNumber,
         relationshipType: values.personalDetails_relationshipType,
       },


### PR DESCRIPTION
Stops date of birth from adding and hour for daylight saving.
Correctly displays and allows editing of gender description