### PR TITLE
Standard error messages are shown when a number or string field is of…

### DIFF
--- a/lib/utils/validation.ts
+++ b/lib/utils/validation.ts
@@ -76,8 +76,8 @@ export function buildValidationSchema(fields: FormField[]) {
 
             case 'number':
               baseType = Yup.number()
-                .integer(`${field.label} must be a valid number`)
-                .typeError(`${field.label} must be a valid number`);
+                .integer(`${field.label} must be a number`)
+                .typeError(`${field.label} must be a number`);
 
               fieldValidation = baseType;
               fieldValidation = checkRequired(fieldValidation, field, baseType);


### PR DESCRIPTION
… the wrong type. This PR shows a human readable error message