### PR TITLE
TS-1277 Update to node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ workflows:
             branches:
               only: development
       - build-deploy-development:
-          context: housing-register-build-context
+          context: housing-register-fe-build-context
           requires:
             - assume-role-development
           filters:
@@ -151,7 +151,7 @@ workflows:
             branches:
               only: main
       - build-deploy-staging:
-          context: housing-register-build-context
+          context: housing-register-fe-build-context
           requires:
             - assume-role-staging
           filters:
@@ -172,7 +172,7 @@ workflows:
             branches:
               only: main
       - build-deploy-production:
-          context: housing-register-build-context
+          context: housing-register-fe-build-context
           requires:
             - assume-role-production
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: circleci/node:16.20.2-browsers
+      - image: cimg/node:16.20.2-browsers
   docker-python:
     docker:
       - image: circleci/python:3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,7 @@ workflows:
           requires:
             - install-dependencies
       - build-test:
+          context: housing-register-build-context
           requires:
             - tests
       - assume-role-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: circleci/node:14.15.5-browsers
+      - image: circleci/node:16.20.2-browsers
   docker-python:
     docker:
       - image: circleci/python:3.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,8 @@ jobs:
     steps:
       - *attach_workspace
       - run:
-        name: Build
-        command: npm run build
+          name: Build
+          command: npm run build
 
   build-deploy-development:
     executor: aws-cli/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ workflows:
           requires:
             - install-dependencies
       - build-test:
-          context: housing-register-build-context
+          context: housing-register-fe-build-context
           requires:
             - tests
       - assume-role-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,11 @@ jobs:
 
   build-test:
     executor: node-executor
-      steps:
-       - *attach_workspace
-       - run:
-          name: Build
-          command: npm run build
+    steps:
+      - *attach_workspace
+      - run:
+        name: Build
+        command: npm run build
 
   build-deploy-development:
     executor: aws-cli/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,14 @@ jobs:
           name: Run Tests
           command: npm run test:ci
 
+  build-test:
+    executor: node-executor
+      steps:
+       - *attach_workspace
+       - run:
+          name: Build
+          command: npm run build
+
   build-deploy-development:
     executor: aws-cli/default
     steps:
@@ -117,6 +125,9 @@ workflows:
       - tests:
           requires:
             - install-dependencies
+      - build-test:
+          requires:
+            - tests
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,14 +46,6 @@ jobs:
           name: Run Tests
           command: npm run test:ci
 
-  build-test:
-    executor: node-executor
-    steps:
-      - *attach_workspace
-      - run:
-          name: Build
-          command: npm run build
-
   build-deploy-development:
     executor: aws-cli/default
     steps:
@@ -125,10 +117,6 @@ workflows:
       - tests:
           requires:
             - install-dependencies
-      - build-test:
-          context: housing-register-fe-build-context
-          requires:
-            - tests
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: housing-register-frontend
 
 provider:
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs16.x
   versionFunctions: false
   region: eu-west-2
   stage: ${opt:stage}


### PR DESCRIPTION
We currently have the following warning in the pipeline:

`npm WARN read-shrinkwrap This version of npm is compatible with lockfileVersion@1, but package-lock.json was generated for lockfileVersion@2. I'll try to do my best with it!`

This indicates the npm version used to generate the lock file was at least 7 which was introduced in Node v15. However the pipeline is setup to run Node v14 and also the Lambda runtime is using v14, so there's a conflict.

This updates both the pipeline and the Lambda runtime to use v16, so it matches the version currently used locally.

Also the docker image for Node executor has been updated to new version and also the build context has been updated to reference newly created CircleCi context.