### PR TITLE
Disable sentry on dev environments

### DIFF
--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/nextjs';
 import { CaptureConsole as CaptureConsoleIntegration } from '@sentry/integrations';
 
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+const ENVIRONMENT = process.env.NEXT_PUBLIC_ENV;
 
 Sentry.init({
   dsn:
@@ -20,4 +21,5 @@ Sentry.init({
 
   environment: process.env.NEXT_PUBLIC_ENV,
   integrations: [new CaptureConsoleIntegration({ levels: ['error'] })],
+  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging'
 });

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -21,5 +21,5 @@ Sentry.init({
 
   environment: process.env.NEXT_PUBLIC_ENV,
   integrations: [new CaptureConsoleIntegration({ levels: ['error'] })],
-  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging'
+  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging',
 });

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/nextjs';
 import { CaptureConsole as CaptureConsoleIntegration } from '@sentry/integrations';
 
 const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
+const ENVIRONMENT = process.env.NEXT_PUBLIC_ENV;
 
 Sentry.init({
   dsn:
@@ -20,4 +21,5 @@ Sentry.init({
 
   environment: process.env.NEXT_PUBLIC_ENV,
   integrations: [new CaptureConsoleIntegration({ levels: ['error'] })],
+  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging'
 });

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -21,5 +21,5 @@ Sentry.init({
 
   environment: process.env.NEXT_PUBLIC_ENV,
   integrations: [new CaptureConsoleIntegration({ levels: ['error'] })],
-  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging'
+  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging',
 });


### PR DESCRIPTION
## WHAT
Disable sentry on other than staging and production environments

## WHY
This will reduce the noise in the console on development environments and also makes working with Cypress easier until we've had a proper chance to resolve all the existing errors.

## HOW
Check if we are running on staging or production environment and if so, enable Sentry.