### PR TITLE
Disable ga on other than prod

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,12 +6,13 @@ export default class AppDocument extends Document {
     return (
       <Html id="root" lang="en">
         <Head>
-          {process.env.NEXT_PUBLIC_ENV === "production" ? (
+          {process.env.NEXT_PUBLIC_ENV === 'production' ? (
             <script
               dangerouslySetInnerHTML={{
                 __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src="https://www.googletagmanager.com/gtm.js?id="+i+dl;f.parentNode.insertBefore(j,f);})(window,document,"script","dataLayer","GTM-P3HRQWH");`,
               }}
-            />) : null}
+            />
+          ) : null}
         </Head>
         <body className="govuk-template__body lbh-template__body js-enabled">
           <noscript>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,11 +6,12 @@ export default class AppDocument extends Document {
     return (
       <Html id="root" lang="en">
         <Head>
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src="https://www.googletagmanager.com/gtm.js?id="+i+dl;f.parentNode.insertBefore(j,f);})(window,document,"script","dataLayer","GTM-P3HRQWH");`,
-            }}
-          />
+          {process.env.NEXT_PUBLIC_ENV === "production" ? (
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({"gtm.start":new Date().getTime(),event:"gtm.js"});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!="dataLayer"?"&l="+l:"";j.async=true;j.src="https://www.googletagmanager.com/gtm.js?id="+i+dl;f.parentNode.insertBefore(j,f);})(window,document,"script","dataLayer","GTM-P3HRQWH");`,
+              }}
+            />) : null}
         </Head>
         <body className="govuk-template__body lbh-template__body js-enabled">
           <noscript>


### PR DESCRIPTION
## WHAT
Disable Google Tag Manager on other than production environment

## WHY
This makes is easier to work with Cypress in development environment and also reduces unnecesary calls.

## HOW
Render the tag manager script on production environment only