### PR TITLE
Changes linting rules for Next Build

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,7 @@
       "version": "detect"
     }
   },
-  "ignorePatterns": ["mocks/**", "coverage/**"],
+  "ignorePatterns": ["mocks/**", "coverage/**", "next.config.js"],
   "rules": {
     "linebreak-style": ["error", "unix"],
     "require-atomic-updates": "off",

--- a/next.config.js
+++ b/next.config.js
@@ -30,6 +30,13 @@ const moduleExports = {
       },
     ];
   },
+  eslint: {
+    // Warning: This allows production builds to successfully complete even if
+    // your project has ESLint errors. This is due to the current ESLint setup
+    // for staged files only as we clear the linting errors as we work.
+    // eslint-disable-next-line
+    ignoreDuringBuilds: true,
+  },
 
   webpack: (config, { webpack }) => {
     config.plugins.push(

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cypress:run": "cypress run --browser chrome"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "eslint --fix --max-warnings 0",
+    "*.{js,jsx,ts,tsx}": "eslint --fix --max-warnings 0 --no-ignore",
     "!package-lock.json": "prettier --ignore-unknown --write"
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cypress:run": "cypress run --browser chrome"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "eslint --fix --max-warnings 0 --no-ignore",
+    "*.{js,jsx,ts,tsx}": "eslint --fix --max-warnings 0",
     "!package-lock.json": "prettier --ignore-unknown --write"
   },
   "browserslist": {


### PR DESCRIPTION
Please see merged PR: https://github.com/LBHackney-IT/lbh-housing-register/pull/391

Currently, the next build step in the pipeline will Lint all files for a build. As we have only just implemented linting rules, we want to disable this until we've cleaned and tested. 

