### PR TITLE
Ts 1585 housing reg view only implement new view only group in the app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ jobs:
   run-cypress-e2e:
     executor:
       name: cypress/default
-      node-version: '16.20.2'
+      node-version: '16.18.1'
     steps:
       - cypress/install:
           package-manager: npm
@@ -195,7 +195,8 @@ jobs:
           post-install: npm run build
       - cypress/run-tests:
           start-command: npm run start
-          cypress-command: npx cypress run --reporter cypress-circleci-reporter
+          install-browsers: true
+          cypress-command: npx cypress run --reporter --browser chrome cypress-circleci-reporter
       - store_test_results:
           path: test_results
 
@@ -240,27 +241,27 @@ workflows:
             branches:
               only: development
       #--------------------------------------------- this is a working config -----------------------------------------------------------------
-      - cypress/run:
-          name: cypress-e2e-chrome
-          requires:
-            - install-dependencies
-          install-command: npm install
-          post-install: npm run build
-          install-browsers: true
-          start-command: npm run start
-          cypress-command: npx cypress run --e2e --reporter cypress-circleci-reporter
-          post-steps:
-            - store_test_results:
-                path: test_results
-            - store_artifacts:
-                path: cypress/videos
-            - store_artifacts:
-                path: cypress/screenshots
-            - store_artifacts:
-                path: cypress/reports
-          filters:
-            branches:
-              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
+      # - cypress/run:
+      #     name: cypress-e2e-chrome
+      #     requires:
+      #       - install-dependencies
+      #     install-command: npm install
+      #     post-install: npm run build
+      #     install-browsers: true
+      #     start-command: npm run start
+      #     cypress-command: npx cypress run --e2e --reporter cypress-circleci-reporter
+      #     post-steps:
+      #       - store_test_results:
+      #           path: test_results
+      #       - store_artifacts:
+      #           path: cypress/videos
+      #       - store_artifacts:
+      #           path: cypress/screenshots
+      #       - store_artifacts:
+      #           path: cypress/reports
+      #     filters:
+      #       branches:
+      #         only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
       # ------------------------------------------- this is a working config -----------------------------------------------------------------
       - run-cypress-e2e:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,8 +124,8 @@ jobs:
       node-version: '16.18.1'
     steps:
       - cypress/install:
-          install-command: npm install
-          post-install: npm run build
+          # install-command: npm install
+          # post-install: npm run build
           # working-directory: examples/angular-app
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "package.json" }}
           include-branch-in-node-cache-key: true
@@ -134,9 +134,21 @@ jobs:
           paths:
             - .cache/Cypress
             # - project
+
+  # install-and-persist:
+  #     executor: cypress/default
+  #     steps:
+  #       - cypress/install:
+  #       - persist_to_workspace:
+  #           root: ~/
+  #           paths:
+  #             - .cache/Cypress # this caches the Cypress binary for use across multiple jobs
+  #             - project # this caches your source code (from the `-checkout` command) for use across multiple jobs
+
   run-e2e-tests-in-chrome:
     docker:
       - image: 'cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1'
+    # executor: cypress/default
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
       - attach_workspace:
@@ -150,13 +162,13 @@ jobs:
 
   run-e2e-tests:
     docker:
-      - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+      - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
     steps:
       - attach_workspace:
           at: *workspace_root
-      # - restore_cache:
-      #     keys:
-      #       - cypress-cache-{{ checksum "package-lock.json" }}
+      - restore_cache:
+          keys:
+            - cypress-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install Dependencies
           command: npm install
@@ -173,10 +185,10 @@ jobs:
       - cypress/run-tests:
           # name: Run Cypress Tests
           cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
-      # - save_cache:
-      #     paths:
-      #       - /root/.cache/Cypress
-      #     key: cypress-cache-{{ checksum "package-lock.json" }}
+      - save_cache:
+          paths:
+            - /root/.cache/Cypress
+          key: cypress-cache-{{ checksum "package-lock.json" }}
       # - post-steps:
       #     store_test_results:
       #         path: test_results
@@ -193,6 +205,7 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies
+      - install-and-persist
       # Run E2E tests in Chrome
       # - install-and-persist
       # - run-e2e-tests-in-chrome:
@@ -251,7 +264,7 @@ workflows:
       - run-e2e-tests:
           name: cypress-e2e-chrome
           requires:
-            - tests
+            - install-and-persist
           # # attach-workspace: true
           # # package-manager: npm
           # install-command: npm install && echo "Cypress installed"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,9 +163,10 @@ jobs:
       - run:
           name: Start Application
           command: npm run start
-      - run:
-          name: Wait for Application to be Ready
-          command: npx wait-on@latest http-get://localhost:3000/api/ping
+          wait-on: 'http-get://localhost:3000/api/ping'
+      # - run:
+      #     name: Wait for Application to be Ready
+      #     command: npx wait-on@latest http-get://localhost:3000/api/ping
       - cypress/run-tests:
           # name: Run Cypress Tests
           cypress-command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           post-install: npm run build
       - cypress/run-tests:
           start-command: npm run start
-          cypress-command: npx cypress run --browser << parameters.browser >> --reporter cypress-circleci-reporter
+          cypress-command: npx cypress run --browser=<< parameters.browser >> --reporter cypress-circleci-reporter
       - store_test_results:
           path: test_results
 
@@ -164,7 +164,7 @@ workflows:
           requires:
             - run-tests
       - run-cypress-e2e:
-          name: Run Cypress E2E Tests in Chrome
+          name: E2E Tests:Chrome
           requires:
             - install-dependencies
           browser: chrome
@@ -172,7 +172,7 @@ workflows:
             branches:
               only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
       - run-cypress-e2e:
-          name: Run Cypress E2E Tests in Firefox
+          name: E2E Tests:Firefox
           browser: firefox
           requires:
             - install-dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
           at: *workspace_root
       - restore_cache:
           keys:
-            - cypress-cache-{{ checksum "package-lock.json" }}
+            - cypress-cache-{{ checksum "package.json" }}
       - run:
           name: Install Dependencies
           command: npm install
@@ -188,7 +188,7 @@ jobs:
       - save_cache:
           paths:
             - /root/.cache/Cypress
-          key: cypress-cache-{{ checksum "package-lock.json" }}
+          key: cypress-cache-{{ checksum "package.json" }}
       # - post-steps:
       #     store_test_results:
       #         path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
       - cypress/run-tests:
           # name: Run Cypress Tests
           cypress-command: |
-            npx run wait-on && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+            npm run wait-on && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
       # - post-steps:
       #     store_test_results:
       #         path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,7 +195,6 @@ jobs:
           post-install: npm run build
       - cypress/run-tests:
           start-command: npm run start
-          install-browsers: true
           cypress-command: npx cypress run --reporter --browser chrome cypress-circleci-reporter
       - store_test_results:
           path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,8 +180,8 @@ workflows:
             branches:
               only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
       - run-cypress-e2e:
-          name: E2E Tests - Edge
-          browser: edge
+          name: E2E Tests - Webkit
+          browser: webkit
           requires:
             - install-dependencies
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,8 +169,7 @@ jobs:
       #     command: npx wait-on http-get://localhost:3000/api/ping
       - cypress/run-tests:
           # name: Run Cypress Tests
-          cypress-command: |
-            npx wait-on@latest http-get://localhost:3000 && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+          cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
       # - post-steps:
       #     store_test_results:
       #         path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,8 @@ jobs:
       node-version: '16.18.1'
     steps:
       - cypress/install:
-          install-command: npm run build
+          install-command: npm run install
+          post-install: npm run build
           # working-directory: examples/angular-app
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "package.json" }}
           include-branch-in-node-cache-key: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,13 +117,18 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies
+      - cypress/install: # Use Cypress step to install and cache dependencies
+          build: npm run build
+          executor: cypress/base-16-14-2-slim
+          # post-checkout:
+          #   - run: cp .env.sample .env
       # Because we're using jest and cypress component, we'll use the cypress orb to run both tests.
       - cypress/run:
           name: tests
           package-manager: npm
           cypress-command: npx cypress run --component --reporter cypress-circleci-reporter
           requires:
-            - install-dependencies
+            - cypress/install
           post-steps:
             - run:
                 command: npm run test:ci
@@ -155,8 +160,12 @@ workflows:
       - cypress/run:
           name: cypress-e2e-chrome
           requires:
-            - build-deploy-development
-          package-manager: npm
+            - tests
+          executor: cypress/base-16-14-2-slim
+          attach-workspace: true
+          # package-manager: npm
+          start: npm run start
+          wait-on: 'http-get://127.0.0.1:3000/api/ping'
           install-browsers: true
           cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
           post-steps:
@@ -170,26 +179,26 @@ workflows:
                 path: cypress/reports
           filters:
             branches:
-              only: development
-      - cypress/run:
-          name: cypress-e2e-firefox
-          requires:
-            - build-deploy-development
-          package-manager: npm
-          install-browsers: true
-          cypress-command: npx cypress run --e2e --browser firefox --reporter cypress-circleci-reporter
-          post-steps:
-            - store_test_results:
-                path: test_results
-            - store_artifacts:
-                path: cypress/videos
-            - store_artifacts:
-                path: cypress/screenshots
-            - store_artifacts:
-                path: cypress/reports
-          filters:
-            branches:
-              only: development
+              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
+      # - cypress/run:
+      #     name: cypress-e2e-firefox
+      #     requires:
+      #       - build-deploy-development
+      #     package-manager: npm
+      #     install-browsers: true
+      #     cypress-command: npx cypress run --e2e --browser firefox --reporter cypress-circleci-reporter
+      #     post-steps:
+      #       - store_test_results:
+      #           path: test_results
+      #       - store_artifacts:
+      #           path: cypress/videos
+      #       - store_artifacts:
+      #           path: cypress/screenshots
+      #       - store_artifacts:
+      #           path: cypress/reports
+      #     filters:
+      #       branches:
+      #         only: development
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
           root: *workspace_root
           paths:
             - .cache/Cypress
-            - project
+            # - project
   run-e2e-tests-in-chrome:
     docker:
       - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
@@ -142,7 +142,7 @@ jobs:
           at: *workspace_root
       - cypress/run-tests:
           start-command: npm run start
-          working-directory: &workspace_root /project
+          working-directory: *workspace_root
           # working-directory: examples/angular-app
           # wait-on: 'http://localhost:3000'
           cypress-command: 'npx cypress run --e2e --browser chrome'
@@ -158,7 +158,7 @@ workflows:
           filters:
             branches:
               only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
-          name: Run CT Tests in Chrome
+          name: Run E2E Tests in Chrome
           requires:
             - install-and-persist
       # - cypress/install: # Use Cypress step to install and cache dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
           paths:
             - ./node_modules
             - ./.next/cache
+            - ./.cache/Cypress
       - persist_to_workspace:
           root: *workspace_root
           paths: .
@@ -118,22 +119,22 @@ jobs:
           paths:
             - .aws
 
-  install-and-persist:
-    executor:
-      name: cypress/default
-      node-version: '16.18.1'
-    steps:
-      - cypress/install:
-          # install-command: npm install
-          # post-install: npm run build
-          # working-directory: examples/angular-app
-          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "package.json" }}
-          include-branch-in-node-cache-key: true
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - .cache/Cypress
-            # - project
+  # install-cypress:
+  #   executor:
+  #     name: cypress/default
+  #     node-version: '16.18.1'
+  #   steps:
+  #     - cypress/install:
+  #         # install-command: npm install
+  #         # post-install: npm run build
+  #         # working-directory: examples/angular-app
+  #         cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "package.json" }}
+  #         include-branch-in-node-cache-key: true
+  #     - persist_to_workspace:
+  #         root: *workspace_root
+  #         paths:
+  #           - .cache/Cypress
+  #           # - project
 
   # install-and-persist:
   #     executor: cypress/default
@@ -145,33 +146,17 @@ jobs:
   #             - .cache/Cypress # this caches the Cypress binary for use across multiple jobs
   #             - project # this caches your source code (from the `-checkout` command) for use across multiple jobs
 
-  run-e2e-tests-in-chrome:
-    docker:
-      - image: 'cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1'
-    # executor: cypress/default
-    steps:
-      - run: echo "This step assumes dependencies were installed using the cypress/install job"
-      - attach_workspace:
-          at: *workspace_root
-      - cypress/run-tests:
-          start-command: npm run start
-          # working-directory: *workspace_root
-          # working-directory: examples/angular-app
-          # wait-on: 'http://localhost:3000'
-          cypress-command: 'npx cypress run --e2e --browser chrome'
-
   run-e2e-tests:
     docker:
       - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
     steps:
-      - attach_workspace:
-          at: *workspace_root
+      - *attach_workspace
+      - checkout
       - restore_cache:
-          keys:
-            - cypress-cache-{{ checksum "package.json" }}
-      - run:
-          name: Install Dependencies
-          command: npm install
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+      # - run:
+      #     name: Install Dependencies
+      #     command: npm install
       - run:
           name: Build Application
           command: npm run build
@@ -187,8 +172,9 @@ jobs:
           cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
       - save_cache:
           paths:
-            - /root/.cache/Cypress
-          key: cypress-cache-{{ checksum "package.json" }}
+            - ./.cache/Cypress
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+
       # - post-steps:
       #     store_test_results:
       #         path: test_results
@@ -205,7 +191,6 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies
-      - install-and-persist
       # Run E2E tests in Chrome
       # - install-and-persist
       # - run-e2e-tests-in-chrome:
@@ -264,7 +249,7 @@ workflows:
       - run-e2e-tests:
           name: cypress-e2e-chrome
           requires:
-            - install-and-persist
+            - install-dependencies
           # # attach-workspace: true
           # # package-manager: npm
           # install-command: npm install && echo "Cypress installed"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,16 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:16.20-browsers
   docker-python:
     docker:
       - image: circleci/python:3.7
-  orb-executor:
-    docker:
-      - image: cimg/node:21.6.1-browsers
-  cypress-node-16:
-    docker:
-      - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+  # sonar-executor:
+  #   docker:
+  #     - image: cimg/node:21.6.1-browsers
+  # cypress-node-16:
+  #   docker:
+  #     - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
 
 references:
   workspace_root: &workspace_root '~'
@@ -70,16 +70,17 @@ jobs:
           path: coverage
 
   sonar-scan:
-    executor: orb-executor
+    executor: node-executor
     steps:
       - *attach_workspace
       - sonarcloud/scan
 
   run-cypress-e2e:
-    executor: cypress-node-16
+    executor: node-executor
     steps:
       - cypress/install:
           package-manager: npm
+          install-browsers: true
           install-command: npm install
           post-install: npm run build
       - cypress/run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,14 +163,14 @@ jobs:
       - run:
           name: Start Application
           command: npm run start &
-      - run:
-          name: Wait for Application to be Ready
-          # wait-on: 'http-get://localhost:3000/api/ping'
-          command: npx wait-on http-get://localhost:3000/api/ping
+      # - run:
+      #     name: Wait for Application to be Ready
+      #     # wait-on: 'http-get://localhost:3000/api/ping'
+      #     command: npx wait-on http-get://localhost:3000/api/ping
       - cypress/run-tests:
           # name: Run Cypress Tests
           cypress-command: |
-            npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+            npx run wait-on && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
       # - post-steps:
       #     store_test_results:
       #         path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,9 +167,9 @@ workflows:
           install-command: npm install && echo "Cypress installed"
           post-install: npm run build
           # wait-on: 'http-get://127.0.0.1:3000/api/ping'
-          start-command: npm run start 3000
+          start-command: npm run start
           install-browsers: true
-          cypress-command: npx wait-on http://127.0.0.1:3000/api/ping && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+          cypress-command: npx wait-on@latest http://localhost:3000 && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
           post-steps:
             - store_test_results:
                 path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,9 +154,9 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
-      # - run:
-      #     name: Install Dependencies
-      #     command: npm install
+      - run:
+          name: Install Dependencies
+          command: npm install
       - run:
           name: Build Application
           command: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ executors:
   orb-executor:
     docker:
       - image: cimg/node:21.6.1-browsers
-  # with-chrome-and-firefox:
-  #   docker:
-  #     - image: "cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1"
+  with-chrome-and-firefox:
+    docker:
+      - image: 'cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1'
 
 references:
   workspace_root: &workspace_root '~'
@@ -190,27 +190,6 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies
-      # Run E2E tests in Chrome
-      # - install-and-persist
-      # - run-e2e-tests-in-chrome:
-      #     filters:
-      #       branches:
-      #         only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
-      #     name: Run E2E Tests in Chrome
-      #     requires:
-      #       - install-and-persist
-      # - cypress/install: # Use Cypress step to install and cache dependencies
-      #     build: npm run build
-      #     executor: cypress/base-16-14-2-slim
-      # post-checkout:
-      #   - run: cp .env.sample .env
-      # Because we're using jest and cypress component, we'll use the cypress orb to run both tests.
-      # - cypress/run:
-      #     filters: *filters
-      #     name: Standard Npm Example
-      #     # working-directory: examples/npm-install
-      #     cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "package.json" }}
-      #     post-install: "npm run say-hello && npm run say-goodbye"
       - cypress/run:
           name: tests
           package-manager: npm
@@ -249,12 +228,11 @@ workflows:
           name: cypress-e2e-chrome
           requires:
             - install-dependencies
-          install-command: npm install && echo "Cypress installed"
-          post-install: npm run build && npx cypress cache list
-          # wait-on: 'http-get://127.0.0.1:3000/api/ping'
+          install-command: npm install
+          post-install: npm run build
           install-browsers: true
           start-command: npm run start
-          cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+          cypress-command: npx cypress run --e2e --reporter cypress-circleci-reporter
           post-steps:
             - store_test_results:
                 path: test_results
@@ -267,27 +245,6 @@ workflows:
           filters:
             branches:
               only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
-      # - cypress/run:
-      #     post-install: npx cypress cache list
-      #     name: cypress-e2e-firefox
-      #     post-install: npx cypress cache list
-      #     requires:
-      #       - build-deploy-development
-      #     package-manager: npm
-      #     install-browsers: true
-      #     cypress-command: npx cypress run --e2e --browser firefox --reporter cypress-circleci-reporter
-      #     post-steps:
-      #       - store_test_results:
-      #           path: test_results
-      #       - store_artifacts:
-      #           path: cypress/videos
-      #       - store_artifacts:
-      #           path: cypress/screenshots
-      #       - store_artifacts:
-      #           path: cypress/reports
-      #     filters:
-      #       branches:
-      #         only: development
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
           root: *workspace_root
           paths:
             - .cache/Cypress
-            # - project
+            - project
   run-e2e-tests-in-chrome:
     docker:
       - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
@@ -142,6 +142,7 @@ jobs:
           at: *workspace_root
       - cypress/run-tests:
           start-command: npm run start
+          working-directory: &workspace_root /project
           # working-directory: examples/angular-app
           # wait-on: 'http://localhost:3000'
           cypress-command: 'npx cypress run --e2e --browser chrome'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,12 +153,20 @@ jobs:
       - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
     steps:
       - run:
+          name: Install Dependencies
+          command: npm install
+      - run:
+          name: Build Application
+          command: npm run build
+      - run:
           name: Start Application
           command: npm run start
+      - run:
+          name: Wait for Application to be Ready
+          command: npx wait-on@latest http-get://localhost:3000/api/ping
       - cypress/run-tests:
           # name: Run Cypress Tests
           cypress-command: |
-            npx wait-on@latest http-get://localhost:3000/api/ping
             npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
       # - post-steps:
       #     store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,10 @@ jobs:
 
   run-cypress-e2e:
     executor: node-executor
+    parameters:
+      browser:
+        type: string
+        default: chrome
     steps:
       - cypress/install:
           package-manager: npm
@@ -79,7 +83,7 @@ jobs:
           post-install: npm run build
       - cypress/run-tests:
           start-command: npm run start
-          cypress-command: npx cypress run --browser chrome --reporter cypress-circleci-reporter
+          cypress-command: npx cypress run --browser << parameters.browser >> --reporter cypress-circleci-reporter
       - store_test_results:
           path: test_results
 
@@ -160,6 +164,16 @@ workflows:
           requires:
             - run-tests
       - run-cypress-e2e:
+          name: Run Cypress E2E Tests in Chrome
+          requires:
+            - install-dependencies
+          browser: chrome
+          filters:
+            branches:
+              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
+      - run-cypress-e2e:
+          name: Run Cypress E2E Tests in Firefox
+          browser: firefox
           requires:
             - install-dependencies
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,16 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: cimg/node:16.20.2-browsers
+      - image: cimg/node:16.20.2
   docker-python:
     docker:
       - image: circleci/python:3.7
   orb-executor:
     docker:
       - image: cimg/node:21.6.1-browsers
-  # cypress-node-16:
-  #   docker:
-  #     - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+  cypress-node-16:
+    docker:
+      - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
 
 references:
   workspace_root: &workspace_root '~'
@@ -76,7 +76,7 @@ jobs:
       - sonarcloud/scan
 
   run-cypress-e2e:
-    executor: node-executor
+    executor: cypress-node-16
     steps:
       - cypress/install:
           package-manager: npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,11 +252,9 @@ workflows:
           install-command: npm install && echo "Cypress installed"
           post-install: npm run build && npx cypress cache list
           # wait-on: 'http-get://127.0.0.1:3000/api/ping'
-          start-command: npm run start
           install-browsers: true
-          cypress-command: |
-            npx wait-on@latest http-get://localhost:3000/api/ping
-            npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+          start-command: npm run start &
+          cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
           post-steps:
             - store_test_results:
                 path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ jobs:
           paths:
             - ./node_modules
             - ./.next/cache
-            - ./.cache/Cypress
       - persist_to_workspace:
           root: *workspace_root
           paths: .
@@ -146,44 +145,44 @@ jobs:
   #             - .cache/Cypress # this caches the Cypress binary for use across multiple jobs
   #             - project # this caches your source code (from the `-checkout` command) for use across multiple jobs
 
-  run-e2e-tests:
-    docker:
-      - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
-    steps:
-      - *attach_workspace
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: Install Dependencies
-          command: npm install
-      - run:
-          name: Build Application
-          command: npm run build
-      - run:
-          name: Start Application
-          command: npm run start &
-      # - run:
-      #     name: Wait for Application to be Ready
-      #     # wait-on: 'http-get://localhost:3000/api/ping'
-      #     command: npx wait-on http-get://localhost:3000/api/ping
-      - cypress/run-tests:
-          # name: Run Cypress Tests
-          cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
-      - save_cache:
-          paths:
-            - ./.cache/Cypress
-          key: dependency-cache-{{ checksum "package-lock.json" }}
+  # run-e2e-tests:
+  #   # docker:
+  #   #   - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+  #   steps:
+  #     - *attach_workspace
+  #     - checkout
+  #     - restore_cache:
+  #         key: dependency-cache-{{ checksum "package-lock.json" }}
+  #     - run:
+  #         name: Install Dependencies
+  #         command: npm install
+  #     - run:
+  #         name: Build Application
+  #         command: npm run build
+  #     - run:
+  #         name: Start Application
+  #         command: npm run start &
+  #     # - run:
+  #     #     name: Wait for Application to be Ready
+  #     #     # wait-on: 'http-get://localhost:3000/api/ping'
+  #     #     command: npx wait-on http-get://localhost:3000/api/ping
+  #     - cypress/run-tests:
+  #         # name: Run Cypress Tests
+  #         cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+  #     - save_cache:
+  #         paths:
+  #           - ./.cache/Cypress
+  #         key: dependency-cache-{{ checksum "package-lock.json" }}
 
-      # - post-steps:
-      #     store_test_results:
-      #         path: test_results
-      #     - store_artifacts:
-      #         path: cypress/videos
-      #     - store_artifacts:
-      #         path: cypress/screenshots
-      #     - store_artifacts:
-      #         path: cypress/reports
+  # - post-steps:
+  #     store_test_results:
+  #         path: test_results
+  #     - store_artifacts:
+  #         path: cypress/videos
+  #     - store_artifacts:
+  #         path: cypress/screenshots
+  #     - store_artifacts:
+  #         path: cypress/reports
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
@@ -246,34 +245,34 @@ workflows:
           filters:
             branches:
               only: development
-      - run-e2e-tests:
+      - cypress/run:
           name: cypress-e2e-chrome
           requires:
             - install-dependencies
-          # # attach-workspace: true
-          # # package-manager: npm
-          # install-command: npm install && echo "Cypress installed"
-          # post-install: npm run build
-          # # wait-on: 'http-get://127.0.0.1:3000/api/ping'
-          # start-command: npm run start
-          # install-browsers: true
-          # cypress-command: |
-          #   npx wait-on@latest http-get://localhost:3000/api/ping
-          #   npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
-          # post-steps:
-          #   - store_test_results:
-          #       path: test_results
-          #   - store_artifacts:
-          #       path: cypress/videos
-          #   - store_artifacts:
-          #       path: cypress/screenshots
-          #   - store_artifacts:
-          #       path: cypress/reports
+          install-command: npm install && echo "Cypress installed"
+          post-install: npm run build && npx cypress cache list
+          # wait-on: 'http-get://127.0.0.1:3000/api/ping'
+          start-command: npm run start
+          install-browsers: true
+          cypress-command: |
+            npx wait-on@latest http-get://localhost:3000/api/ping
+            npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+          post-steps:
+            - store_test_results:
+                path: test_results
+            - store_artifacts:
+                path: cypress/videos
+            - store_artifacts:
+                path: cypress/screenshots
+            - store_artifacts:
+                path: cypress/reports
           filters:
             branches:
               only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
       # - cypress/run:
+      #     post-install: npx cypress cache list
       #     name: cypress-e2e-firefox
+      #     post-install: npx cypress cache list
       #     requires:
       #       - build-deploy-development
       #     package-manager: npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,11 +117,11 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies
-      - cypress/install: # Use Cypress step to install and cache dependencies
-          build: npm run build
-          executor: cypress/base-16-14-2-slim
-          # post-checkout:
-          #   - run: cp .env.sample .env
+      # - cypress/install: # Use Cypress step to install and cache dependencies
+      #     build: npm run build
+      #     executor: cypress/base-16-14-2-slim
+      # post-checkout:
+      #   - run: cp .env.sample .env
       # Because we're using jest and cypress component, we'll use the cypress orb to run both tests.
       - cypress/run:
           name: tests
@@ -161,9 +161,10 @@ workflows:
           name: cypress-e2e-chrome
           requires:
             - tests
-          executor: cypress/base-16-14-2-slim
+          # executor: cypress/base-16-14-2-slim
           attach-workspace: true
           # package-manager: npm
+          build: npm run build
           start: npm run start
           wait-on: 'http-get://127.0.0.1:3000/api/ping'
           install-browsers: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,15 +16,16 @@ executors:
   orb-executor:
     docker:
       - image: cimg/node:21.6.1-browsers
-  cypress/base-16-18-1:
-    docker:
-      - image: cypress/base:16.18.1
+  # with-chrome-and-firefox:
+  #   docker:
+  #     - image: "cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1"
 
 references:
   workspace_root: &workspace_root '~'
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Commands ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Jobs ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
@@ -135,14 +136,14 @@ jobs:
             # - project
   run-e2e-tests-in-chrome:
     docker:
-      - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+      - image: 'cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1'
     steps:
       - run: echo "This step assumes dependencies were installed using the cypress/install job"
       - attach_workspace:
           at: *workspace_root
       - cypress/run-tests:
           start-command: npm run start
-          working-directory: *workspace_root
+          # working-directory: *workspace_root
           # working-directory: examples/angular-app
           # wait-on: 'http://localhost:3000'
           cypress-command: 'npx cypress run --e2e --browser chrome'
@@ -153,14 +154,15 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies
-      - install-and-persist
-      - run-e2e-tests-in-chrome:
-          filters:
-            branches:
-              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
-          name: Run E2E Tests in Chrome
-          requires:
-            - install-and-persist
+      # Run E2E tests in Chrome
+      # - install-and-persist
+      # - run-e2e-tests-in-chrome:
+      #     filters:
+      #       branches:
+      #         only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
+      #     name: Run E2E Tests in Chrome
+      #     requires:
+      #       - install-and-persist
       # - cypress/install: # Use Cypress step to install and cache dependencies
       #     build: npm run build
       #     executor: cypress/base-16-14-2-slim
@@ -216,7 +218,7 @@ workflows:
           install-command: npm install && echo "Cypress installed"
           post-install: npm run build
           # wait-on: 'http-get://127.0.0.1:3000/api/ping'
-          start-command: npm run start
+          start-command: npx run start
           install-browsers: true
           cypress-command: |
             npx wait-on@latest http-get://localhost:3000/api/ping

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       node-version: '16.18.1'
     steps:
       - cypress/install:
-          install-command: npm run install
+          install-command: npm install
           post-install: npm run build
           # working-directory: examples/angular-app
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,11 +162,10 @@ jobs:
           command: npm run build
       - run:
           name: Start Application
-          command: npm run start
-          wait-on: 'http-get://localhost:3000/api/ping'
-      # - run:
-      #     name: Wait for Application to be Ready
-      #     command: npx wait-on@latest http-get://localhost:3000/api/ping
+          command: npm run start &
+      - run:
+          name: Wait for Application to be Ready
+          command: npx wait-on@latest http-get://localhost:3000/api/ping
       - cypress/run-tests:
           # name: Run Cypress Tests
           cypress-command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ workflows:
           package-manager: npm
           cypress-command: npx cypress run --component --reporter cypress-circleci-reporter
           requires:
-            - cypress/install
+            - install-dependencies
           post-steps:
             - run:
                 command: npm run test:ci
@@ -162,13 +162,14 @@ workflows:
           requires:
             - tests
           # executor: cypress/base-16-14-2-slim
-          attach-workspace: true
+          # attach-workspace: true
           # package-manager: npm
-          build: npm run build
-          start: npm run start
-          wait-on: 'http-get://127.0.0.1:3000/api/ping'
+          install-command: npm install && echo "Cypress installed"
+          post-install: npm run build
+          # wait-on: 'http-get://127.0.0.1:3000/api/ping'
+          start-command: npm run start
           install-browsers: true
-          cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+          cypress-command: npx wait-on http://127.0.0.1:3000/api/ping && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
           post-steps:
             - store_test_results:
                 path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,13 +150,13 @@ jobs:
 
   run-e2e-tests:
     docker:
-      - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+      - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
     steps:
       - attach_workspace:
           at: *workspace_root
-      - restore_cache:
-          keys:
-            - cypress-cache-{{ checksum "package-lock.json" }}
+      # - restore_cache:
+      #     keys:
+      #       - cypress-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install Dependencies
           command: npm install
@@ -173,10 +173,10 @@ jobs:
       - cypress/run-tests:
           # name: Run Cypress Tests
           cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
-      - save_cache:
-          paths:
-            - /root/.cache/Cypress
-          key: cypress-cache-{{ checksum "package-lock.json" }}
+      # - save_cache:
+      #     paths:
+      #       - /root/.cache/Cypress
+      #     key: cypress-cache-{{ checksum "package-lock.json" }}
       # - post-steps:
       #     store_test_results:
       #         path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       node-version: '16.18.1'
     steps:
       - cypress/install:
-          # build-command: npm run build
+          install-command: npm run build
           # working-directory: examples/angular-app
           cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "package.json" }}
           include-branch-in-node-cache-key: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ workflows:
           post-install: npm run build && npx cypress cache list
           # wait-on: 'http-get://127.0.0.1:3000/api/ping'
           install-browsers: true
-          start-command: npm run start &
+          start-command: npm run start
           cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
           post-steps:
             - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ executors:
   orb-executor:
     docker:
       - image: cimg/node:21.6.1-browsers
-  with-chrome-and-firefox:
+  cypress-node-16:
     docker:
-      - image: 'cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1'
+      - image: cypress/included:12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
 
 references:
   workspace_root: &workspace_root '~'
@@ -185,9 +185,7 @@ jobs:
   #         path: cypress/reports
 
   run-cypress-e2e:
-    executor:
-      name: cypress/default
-      node-version: '16.18.1'
+    executor: cypress-node-16
     steps:
       - cypress/install:
           package-manager: npm
@@ -195,7 +193,7 @@ jobs:
           post-install: npm run build
       - cypress/run-tests:
           start-command: npm run start
-          cypress-command: npx cypress run --reporter --browser chrome cypress-circleci-reporter
+          cypress-command: npx cypress run --browser chrome --reporter cypress-circleci-reporter
       - store_test_results:
           path: test_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,12 +16,9 @@ executors:
   orb-executor:
     docker:
       - image: cimg/node:21.6.1-browsers
-  cypress-node-16:
-    docker:
-      - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
-    # working_directory: ~/project
-    # environment:
-    #   CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
+  # cypress-node-16:
+  #   docker:
+  #     - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
 
 references:
   workspace_root: &workspace_root '~'
@@ -53,11 +50,43 @@ jobs:
           root: *workspace_root
           paths: .
 
+  run-tests:
+    executor: node-executor
+    steps:
+      - cypress/install:
+          package-manager: npm
+          install-command: npm install
+      - cypress/run-tests:
+          cypress-command: npx cypress run --component --reporter cypress-circleci-reporter
+      - run:
+          name: Run Jest Tests
+          command: npm run test:ci
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: test_results
+            JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
+      - store_test_results:
+          path: test_results
+      - store_artifacts:
+          path: coverage
+
   sonar-scan:
     executor: orb-executor
     steps:
       - *attach_workspace
       - sonarcloud/scan
+
+  run-cypress-e2e:
+    executor: node-executor
+    steps:
+      - cypress/install:
+          package-manager: npm
+          install-command: npm install
+          post-install: npm run build
+      - cypress/run-tests:
+          start-command: npm run start
+          cypress-command: npx cypress run --browser chrome --reporter cypress-circleci-reporter
+      - store_test_results:
+          path: test_results
 
   build-deploy-development:
     executor: aws-cli/default
@@ -122,42 +151,6 @@ jobs:
           paths:
             - .aws
 
-  run-cypress-e2e:
-    executor: cypress-node-16
-    steps:
-      - cypress/install:
-          package-manager: npm
-          install-command: npm install
-          post-install: npm run build
-      - cypress/run-tests:
-          start-command: npm run start
-          cypress-command: npx cypress run --browser chrome --reporter cypress-circleci-reporter
-      - store_test_results:
-          path: test_results
-
-  run-tests:
-    executor: cypress-node-16
-    # name: Lint & Test
-    steps:
-      - cypress/install:
-          package-manager: npm
-          install-command: npm install
-      - cypress/run-tests:
-          cypress-command: npx cypress run --component --reporter cypress-circleci-reporter
-      # - store_test_results:
-      #     path: test_results
-      # - post-steps:
-      - run:
-          name: Run Jest Tests
-          command: npm run test:ci
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: test_results
-            JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
-      - store_test_results:
-          path: test_results
-      - store_artifacts:
-          path: coverage
-
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
   version: 2
@@ -167,22 +160,6 @@ workflows:
       - run-tests:
           requires:
             - install-dependencies
-      # - cypress/run:
-      #     name: e2e Tests
-      #     package-manager: npm
-      #     cypress-command: npx cypress run --component --reporter cypress-circleci-reporter
-      #     requires:
-      #       - install-dependencies
-      #     post-steps:
-      #       - run:
-      #           command: npm run test:ci
-      #           environment:
-      #             JEST_JUNIT_OUTPUT_DIR: test_results
-      #             JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
-      # - store_test_results:
-      #     path: test_results
-      # - store_artifacts:
-      #     path: coverage
       - sonar-scan:
           context: SonarCloud
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
       - cypress/run-tests:
           # name: Run Cypress Tests
           cypress-command: |
-            npm run wait-on && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+            npx wait-on@latest http-get://localhost:3000 && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
       # - post-steps:
       #     store_test_results:
       #         path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,13 +16,18 @@ executors:
   orb-executor:
     docker:
       - image: cimg/node:21.6.1-browsers
+  cypress/base-16-18-1:
+    docker:
+      - image: cypress/base:16.18.1
 
 references:
   workspace_root: &workspace_root '~'
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Commands ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Jobs ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 jobs:
   install-dependencies:
     executor: node-executor
@@ -111,7 +116,7 @@ jobs:
           root: *workspace_root
           paths:
             - .aws
-
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
   version: 2
   continuous-delivery:
@@ -161,7 +166,6 @@ workflows:
           name: cypress-e2e-chrome
           requires:
             - tests
-          # executor: cypress/base-16-14-2-slim
           # attach-workspace: true
           # package-manager: npm
           install-command: npm install && echo "Cypress installed"
@@ -169,7 +173,9 @@ workflows:
           # wait-on: 'http-get://127.0.0.1:3000/api/ping'
           start-command: npm run start
           install-browsers: true
-          cypress-command: npx wait-on@latest http://localhost:3000 && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+          cypress-command: |
+            npx wait-on@latest http-get://localhost:3000/api/ping
+            npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
           post-steps:
             - store_test_results:
                 path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ workflows:
           browser: chrome
           filters:
             branches:
-              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
+              only: development
       - run-cypress-e2e:
           name: E2E Tests - Firefox
           browser: firefox
@@ -178,19 +178,12 @@ workflows:
             - install-dependencies
           filters:
             branches:
-              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
-      - run-cypress-e2e:
-          name: E2E Tests - Webkit
-          browser: webkit
-          requires:
-            - install-dependencies
-          filters:
-            branches:
-              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
+              only: development
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
-            - sonar-scan
+            - E2E Tests - Chrome
+            - E2E Tests - Firefox
           filters:
             branches:
               only: development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,6 @@ executors:
   docker-python:
     docker:
       - image: circleci/python:3.7
-  # sonar-executor:
-  #   docker:
-  #     - image: cimg/node:21.6.1-browsers
-  # cypress-node-16:
-  #   docker:
-  #     - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
 
 references:
   workspace_root: &workspace_root '~'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,28 @@ jobs:
           # wait-on: 'http://localhost:3000'
           cypress-command: 'npx cypress run --e2e --browser chrome'
 
+  run-e2e-tests:
+    docker:
+      - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+    steps:
+      - run:
+          name: Start Application
+          command: npm run start
+      - cypress/run-tests:
+          # name: Run Cypress Tests
+          cypress-command: |
+            npx wait-on@latest http-get://localhost:3000/api/ping
+            npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+      # - post-steps:
+      #     store_test_results:
+      #         path: test_results
+      #     - store_artifacts:
+      #         path: cypress/videos
+      #     - store_artifacts:
+      #         path: cypress/screenshots
+      #     - store_artifacts:
+      #         path: cypress/reports
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
   version: 2
@@ -209,29 +231,29 @@ workflows:
           filters:
             branches:
               only: development
-      - cypress/run:
+      - run-e2e-tests:
           name: cypress-e2e-chrome
           requires:
             - tests
-          # attach-workspace: true
-          # package-manager: npm
-          install-command: npm install && echo "Cypress installed"
-          post-install: npm run build
-          # wait-on: 'http-get://127.0.0.1:3000/api/ping'
-          start-command: npx run start
-          install-browsers: true
-          cypress-command: |
-            npx wait-on@latest http-get://localhost:3000/api/ping
-            npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
-          post-steps:
-            - store_test_results:
-                path: test_results
-            - store_artifacts:
-                path: cypress/videos
-            - store_artifacts:
-                path: cypress/screenshots
-            - store_artifacts:
-                path: cypress/reports
+          # # attach-workspace: true
+          # # package-manager: npm
+          # install-command: npm install && echo "Cypress installed"
+          # post-install: npm run build
+          # # wait-on: 'http-get://127.0.0.1:3000/api/ping'
+          # start-command: npm run start
+          # install-browsers: true
+          # cypress-command: |
+          #   npx wait-on@latest http-get://localhost:3000/api/ping
+          #   npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+          # post-steps:
+          #   - store_test_results:
+          #       path: test_results
+          #   - store_artifacts:
+          #       path: cypress/videos
+          #   - store_artifacts:
+          #       path: cypress/screenshots
+          #   - store_artifacts:
+          #       path: cypress/reports
           filters:
             branches:
               only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ workflows:
           requires:
             - run-tests
       - run-cypress-e2e:
-          name: E2E Tests:Chrome
+          name: E2E Tests - Chrome
           requires:
             - install-dependencies
           browser: chrome
@@ -172,8 +172,16 @@ workflows:
             branches:
               only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
       - run-cypress-e2e:
-          name: E2E Tests:Firefox
+          name: E2E Tests - Firefox
           browser: firefox
+          requires:
+            - install-dependencies
+          filters:
+            branches:
+              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
+      - run-cypress-e2e:
+          name: E2E Tests - Edge
+          browser: edge
           requires:
             - install-dependencies
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
   #     - store_artifacts:
   #         path: cypress/reports
 
-  run-cypress-in-specified-node-version:
+  run-cypress-e2e:
     executor:
       name: cypress/default
       node-version: '16.20.2'
@@ -195,7 +195,9 @@ jobs:
           post-install: npm run build
       - cypress/run-tests:
           start-command: npm run start
-          cypress-command: npx cypress run
+          cypress-command: npx cypress run --reporter cypress-circleci-reporter
+      - store_test_results:
+          path: test_results
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
@@ -260,7 +262,7 @@ workflows:
             branches:
               only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
       # ------------------------------------------- this is a working config -----------------------------------------------------------------
-      - run-cypress-in-specified-node-version:
+      - run-cypress-e2e:
           requires:
             - install-dependencies
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,10 @@ executors:
       - image: cimg/node:21.6.1-browsers
   cypress-node-16:
     docker:
-      - image: cypress/included:12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+      - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+    working_directory: ~/project
+    environment:
+      CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
 
 references:
   workspace_root: &workspace_root '~'
@@ -45,6 +48,7 @@ jobs:
           paths:
             - ./node_modules
             - ./.next/cache
+            - ./.cache/Cypress
       - persist_to_workspace:
           root: *workspace_root
           paths: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,9 @@ jobs:
     steps:
       - attach_workspace:
           at: *workspace_root
+      - restore_cache:
+          keys:
+            - cypress-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Install Dependencies
           command: npm install
@@ -170,6 +173,10 @@ jobs:
       - cypress/run-tests:
           # name: Run Cypress Tests
           cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
+      - save_cache:
+          paths:
+            - /root/.cache/Cypress
+          key: cypress-cache-{{ checksum "package-lock.json" }}
       # - post-steps:
       #     store_test_results:
       #         path: test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,18 +116,61 @@ jobs:
           root: *workspace_root
           paths:
             - .aws
+
+  install-and-persist:
+    executor:
+      name: cypress/default
+      node-version: '16.18.1'
+    steps:
+      - cypress/install:
+          # build-command: npm run build
+          # working-directory: examples/angular-app
+          cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "package.json" }}
+          include-branch-in-node-cache-key: true
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .cache/Cypress
+            # - project
+  run-e2e-tests-in-chrome:
+    docker:
+      - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
+    steps:
+      - run: echo "This step assumes dependencies were installed using the cypress/install job"
+      - attach_workspace:
+          at: *workspace_root
+      - cypress/run-tests:
+          start-command: npm run start
+          # working-directory: examples/angular-app
+          # wait-on: 'http://localhost:3000'
+          cypress-command: 'npx cypress run --e2e --browser chrome'
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
   version: 2
   continuous-delivery:
     jobs:
       - install-dependencies
+      - install-and-persist
+      - run-e2e-tests-in-chrome:
+          filters:
+            branches:
+              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
+          name: Run CT Tests in Chrome
+          requires:
+            - install-and-persist
       # - cypress/install: # Use Cypress step to install and cache dependencies
       #     build: npm run build
       #     executor: cypress/base-16-14-2-slim
       # post-checkout:
       #   - run: cp .env.sample .env
       # Because we're using jest and cypress component, we'll use the cypress orb to run both tests.
+      # - cypress/run:
+      #     filters: *filters
+      #     name: Standard Npm Example
+      #     # working-directory: examples/npm-install
+      #     cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "package.json" }}
+      #     post-install: "npm run say-hello && npm run say-goodbye"
       - cypress/run:
           name: tests
           package-manager: npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,8 @@ jobs:
           command: npm run start &
       - run:
           name: Wait for Application to be Ready
-          command: npx wait-on@latest http-get://localhost:3000/api/ping
+          # wait-on: 'http-get://localhost:3000/api/ping'
+          command: npx wait-on http-get://localhost:3000/api/ping
       - cypress/run-tests:
           # name: Run Cypress Tests
           cypress-command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,8 @@ jobs:
     docker:
       - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
     steps:
+      - attach_workspace:
+          at: *workspace_root
       - run:
           name: Install Dependencies
           command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,7 +167,7 @@ workflows:
           install-command: npm install && echo "Cypress installed"
           post-install: npm run build
           # wait-on: 'http-get://127.0.0.1:3000/api/ping'
-          start-command: npm run start
+          start-command: npm run start 3000
           install-browsers: true
           cypress-command: npx wait-on http://127.0.0.1:3000/api/ping && npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
           post-steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ executors:
   cypress-node-16:
     docker:
       - image: cypress/included:cypress-12.6.0-node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
-    working_directory: ~/project
-    environment:
-      CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
+    # working_directory: ~/project
+    # environment:
+    #   CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
 
 references:
   workspace_root: &workspace_root '~'
@@ -122,72 +122,6 @@ jobs:
           paths:
             - .aws
 
-  # install-cypress:
-  #   executor:
-  #     name: cypress/default
-  #     node-version: '16.18.1'
-  #   steps:
-  #     - cypress/install:
-  #         # install-command: npm install
-  #         # post-install: npm run build
-  #         # working-directory: examples/angular-app
-  #         cypress-cache-key: cypress-cache-{{ arch }}-{{ checksum "package.json" }}
-  #         include-branch-in-node-cache-key: true
-  #     - persist_to_workspace:
-  #         root: *workspace_root
-  #         paths:
-  #           - .cache/Cypress
-  #           # - project
-
-  # install-and-persist:
-  #     executor: cypress/default
-  #     steps:
-  #       - cypress/install:
-  #       - persist_to_workspace:
-  #           root: ~/
-  #           paths:
-  #             - .cache/Cypress # this caches the Cypress binary for use across multiple jobs
-  #             - project # this caches your source code (from the `-checkout` command) for use across multiple jobs
-
-  # run-e2e-tests:
-  #   # docker:
-  #   #   - image: cypress/browsers:node-16.18.1-chrome-110.0.5481.96-1-ff-109.0-edge-110.0.1587.41-1
-  #   steps:
-  #     - *attach_workspace
-  #     - checkout
-  #     - restore_cache:
-  #         key: dependency-cache-{{ checksum "package-lock.json" }}
-  #     - run:
-  #         name: Install Dependencies
-  #         command: npm install
-  #     - run:
-  #         name: Build Application
-  #         command: npm run build
-  #     - run:
-  #         name: Start Application
-  #         command: npm run start &
-  #     # - run:
-  #     #     name: Wait for Application to be Ready
-  #     #     # wait-on: 'http-get://localhost:3000/api/ping'
-  #     #     command: npx wait-on http-get://localhost:3000/api/ping
-  #     - cypress/run-tests:
-  #         # name: Run Cypress Tests
-  #         cypress-command: npx cypress run --e2e --browser chrome --reporter cypress-circleci-reporter
-  #     - save_cache:
-  #         paths:
-  #           - ./.cache/Cypress
-  #         key: dependency-cache-{{ checksum "package-lock.json" }}
-
-  # - post-steps:
-  #     store_test_results:
-  #         path: test_results
-  #     - store_artifacts:
-  #         path: cypress/videos
-  #     - store_artifacts:
-  #         path: cypress/screenshots
-  #     - store_artifacts:
-  #         path: cypress/reports
-
   run-cypress-e2e:
     executor: cypress-node-16
     steps:
@@ -201,32 +135,64 @@ jobs:
       - store_test_results:
           path: test_results
 
+  run-tests:
+    executor: cypress-node-16
+    # name: Lint & Test
+    steps:
+      - cypress/install:
+          package-manager: npm
+          install-command: npm install
+      - cypress/run-tests:
+          cypress-command: npx cypress run --component --reporter cypress-circleci-reporter
+      # - store_test_results:
+      #     path: test_results
+      # - post-steps:
+      - run:
+          name: Run Jest Tests
+          command: npm run test:ci
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: test_results
+            JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
+      - store_test_results:
+          path: test_results
+      - store_artifacts:
+          path: coverage
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
   version: 2
   continuous-delivery:
     jobs:
       - install-dependencies
-      - cypress/run:
-          name: tests
-          package-manager: npm
-          cypress-command: npx cypress run --component --reporter cypress-circleci-reporter
+      - run-tests:
           requires:
             - install-dependencies
-          post-steps:
-            - run:
-                command: npm run test:ci
-                environment:
-                  JEST_JUNIT_OUTPUT_DIR: test_results
-                  JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
-            - store_test_results:
-                path: test_results
-            - store_artifacts:
-                path: coverage
+      # - cypress/run:
+      #     name: e2e Tests
+      #     package-manager: npm
+      #     cypress-command: npx cypress run --component --reporter cypress-circleci-reporter
+      #     requires:
+      #       - install-dependencies
+      #     post-steps:
+      #       - run:
+      #           command: npm run test:ci
+      #           environment:
+      #             JEST_JUNIT_OUTPUT_DIR: test_results
+      #             JEST_JUNIT_ADD_FILE_ATTRIBUTE: 'true'
+      # - store_test_results:
+      #     path: test_results
+      # - store_artifacts:
+      #     path: coverage
       - sonar-scan:
           context: SonarCloud
           requires:
-            - tests
+            - run-tests
+      - run-cypress-e2e:
+          requires:
+            - install-dependencies
+          filters:
+            branches:
+              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
@@ -241,39 +207,10 @@ workflows:
           filters:
             branches:
               only: development
-      #--------------------------------------------- this is a working config -----------------------------------------------------------------
-      # - cypress/run:
-      #     name: cypress-e2e-chrome
-      #     requires:
-      #       - install-dependencies
-      #     install-command: npm install
-      #     post-install: npm run build
-      #     install-browsers: true
-      #     start-command: npm run start
-      #     cypress-command: npx cypress run --e2e --reporter cypress-circleci-reporter
-      #     post-steps:
-      #       - store_test_results:
-      #           path: test_results
-      #       - store_artifacts:
-      #           path: cypress/videos
-      #       - store_artifacts:
-      #           path: cypress/screenshots
-      #       - store_artifacts:
-      #           path: cypress/reports
-      #     filters:
-      #       branches:
-      #         only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
-      # ------------------------------------------- this is a working config -----------------------------------------------------------------
-      - run-cypress-e2e:
-          requires:
-            - install-dependencies
-          filters:
-            branches:
-              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:
-            - tests
+            - run-tests
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,19 @@ jobs:
   #     - store_artifacts:
   #         path: cypress/reports
 
+  run-cypress-in-specified-node-version:
+    executor:
+      name: cypress/default
+      node-version: '16.20.2'
+    steps:
+      - cypress/install:
+          package-manager: npm
+          install-command: npm install
+          post-install: npm run build
+      - cypress/run-tests:
+          start-command: npm run start
+          cypress-command: npx cypress run
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
   version: 2
@@ -224,6 +237,7 @@ workflows:
           filters:
             branches:
               only: development
+      #--------------------------------------------- this is a working config -----------------------------------------------------------------
       - cypress/run:
           name: cypress-e2e-chrome
           requires:
@@ -242,6 +256,13 @@ workflows:
                 path: cypress/screenshots
             - store_artifacts:
                 path: cypress/reports
+          filters:
+            branches:
+              only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app
+      # ------------------------------------------- this is a working config -----------------------------------------------------------------
+      - run-cypress-in-specified-node-version:
+          requires:
+            - install-dependencies
           filters:
             branches:
               only: TS-1585-Housing-reg-view-only-Implement-new-view-only-group-in-the-app

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@ node_modules
 build
 next.config.js
 db
+coverage
+mocks

--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,6 @@
       "version": "detect"
     }
   },
-  "ignorePatterns": ["mocks/**", "coverage/**", "next.config.js"],
   "rules": {
     "linebreak-style": ["error", "unix"],
     "require-atomic-updates": "off",

--- a/components/admin/SearchBox.tsx
+++ b/components/admin/SearchBox.tsx
@@ -1,16 +1,19 @@
-import { useRouter } from 'next/router';
 import React, { useState } from 'react';
+
+import { useRouter } from 'next/router';
 
 interface SearchBoxProps {
   title: string;
   watermark: string;
   buttonTitle: string;
+  dataTestId?: string;
 }
 
 export default function SearchBox({
   title,
   watermark,
   buttonTitle,
+  dataTestId,
 }: SearchBoxProps): JSX.Element {
   const [searchInputValue, setsearchInputValue] = useState('');
   const router = useRouter();
@@ -33,7 +36,7 @@ export default function SearchBox({
 
   return (
     <form onSubmit={onSearchSubmit}>
-      <div className="govuk-form-group c-flex">
+      <div className="govuk-form-group c-flex" data-testid={dataTestId}>
         <label className="govuk-visually-hidden" htmlFor="input-search">
           Search {title}
         </label>

--- a/components/admin/sidebar.tsx
+++ b/components/admin/sidebar.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React from 'react';
 
 export default function Sidebar(): JSX.Element {
   const router = useRouter();
@@ -24,24 +25,22 @@ export default function Sidebar(): JSX.Element {
   ];
 
   return (
-    <>
-      <nav className="lbh-link-group-vertical">
-        <ul>
-          {sidebarNavRoutes.map(({ name, path }) => (
-            <li key={path} className="lbh-link-group__item">
-              <Link href={path}>
-                <a
-                  className={`lbh-link lbh-link--no-visited-state lbh-!-font-weight-bold lbh-body-m ${
-                    router.pathname === path ? 'active' : ''
-                  }`}
-                >
-                  {name}
-                </a>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </nav>
-    </>
+    <nav className="lbh-link-group-vertical" data-testid="test-admin-sidebar">
+      <ul>
+        {sidebarNavRoutes.map(({ name, path }) => (
+          <li key={path} className="lbh-link-group__item">
+            <Link href={path}>
+              <a
+                className={`lbh-link lbh-link--no-visited-state lbh-!-font-weight-bold lbh-body-m ${
+                  router.pathname === path ? 'active' : ''
+                }`}
+              >
+                {name}
+              </a>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
 }

--- a/components/layout/staff-layout.tsx
+++ b/components/layout/staff-layout.tsx
@@ -1,6 +1,8 @@
+import React, { ReactNode } from 'react';
+
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { ReactNode } from 'react';
+
 import { useUser } from '../../lib/contexts/user-context';
 import { hasPhaseBanner } from '../../lib/utils/phase-banner';
 import Header from '../header';
@@ -11,11 +13,13 @@ import SkipLink from '../skip-link';
 interface StaffLayoutProps {
   pageName?: string;
   children: ReactNode;
+  dataTestId?: string;
 }
 
 export default function StaffLayout({
   pageName,
   children,
+  dataTestId,
 }: StaffLayoutProps): JSX.Element {
   const { user } = useUser();
   const router = useRouter();
@@ -46,7 +50,7 @@ export default function StaffLayout({
         <div className="lbh-container">
           <nav>
             <strong className="lbh-heading-h5">
-              <Link href={`/applications/`}>
+              <Link href="/applications/">
                 <a className="lbh-link lbh-link--no-visited-state">
                   Back to dashboard
                 </a>
@@ -67,7 +71,11 @@ export default function StaffLayout({
         </div>
       )}
 
-      <main id="main-content" className="lbh-main-wrapper">
+      <main
+        id="main-content"
+        className="lbh-main-wrapper"
+        data-testid={dataTestId}
+      >
         <div className="lbh-container">{children}</div>
       </main>
     </>

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,17 +2,6 @@ import { defineConfig } from 'cypress';
 import 'dotenv/config';
 import { sign } from 'jsonwebtoken';
 
-// type Environment = 'localdev' | 'development';
-
-// const environment: Environment =
-//   (process.env.NEXT_PUBLIC_ENV as Environment) || 'development';
-
-// const baseUrlSites: Record<Environment, string> = {
-//   localdev: 'http://localhost:3000',
-//   development: 'https://housing-register-development.hackney.gov.uk/',
-// };
-
-// const baseUrl = baseUrlSites[environment];
 const baseUrl = 'http://localhost:3000';
 
 export default defineConfig({

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'cypress';
 import 'dotenv/config';
+import { sign } from 'jsonwebtoken';
 
 type Environment = 'localdev' | 'development';
 
@@ -17,9 +18,16 @@ export default defineConfig({
   e2e: {
     baseUrl,
     experimentalWebKitSupport: true,
-    setupNodeEvents() // on, config
-    {
-      // implement node event listeners here
+    setupNodeEvents(on, config) {
+      on('task', {
+        generateToken({ user, secret }) {
+          return sign(user, secret);
+        },
+      });
+      config.env = {
+        ...process.env,
+      };
+      return config;
     },
     video: true,
     screenshotOnRunFailure: true,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,17 +2,18 @@ import { defineConfig } from 'cypress';
 import 'dotenv/config';
 import { sign } from 'jsonwebtoken';
 
-type Environment = 'localdev' | 'development';
+// type Environment = 'localdev' | 'development';
 
-const environment: Environment =
-  (process.env.NEXT_PUBLIC_ENV as Environment) || 'development';
+// const environment: Environment =
+//   (process.env.NEXT_PUBLIC_ENV as Environment) || 'development';
 
-const baseUrlSites: Record<Environment, string> = {
-  localdev: 'http://localhost:3000',
-  development: 'https://housing-register-development.hackney.gov.uk/',
-};
+// const baseUrlSites: Record<Environment, string> = {
+//   localdev: 'http://localhost:3000',
+//   development: 'https://housing-register-development.hackney.gov.uk/',
+// };
 
-const baseUrl = baseUrlSites[environment];
+// const baseUrl = baseUrlSites[environment];
+const baseUrl = 'http://localhost:3000';
 
 export default defineConfig({
   e2e: {

--- a/cypress/e2e/makeAnApplication.cy.ts
+++ b/cypress/e2e/makeAnApplication.cy.ts
@@ -17,13 +17,11 @@ describe('Housing application', () => {
       cy.clearCookies();
 
       HomePage.visit();
-      // accept cookies
+
       HomePage.getCookiesButton().click();
 
-      // start application
       HomePage.getStartApplicationButton().scrollIntoView().click();
 
-      // give an email address for verification code
       const generateEmailAddress = faker.internet.email({
         provider: 'hackneyTEST.gov.uk',
       });
@@ -33,8 +31,6 @@ describe('Housing application', () => {
       SignInPage.getSubmitButton().scrollIntoView().click();
 
       cy.get('button[type="submit"]').click();
-
-      // confirmation verification code has been sent
 
       ApplyPage.getVerifyCodePage().should('be.visible');
       const generateCode = faker.number
@@ -47,8 +43,6 @@ describe('Housing application', () => {
       interceptApplicatonApi();
 
       ApplyPage.getVerifySubmitButton().scrollIntoView().click();
-
-      // application has been started
 
       StartPage.getStartApplicationPage().should('be.visible');
     });

--- a/cypress/e2e/searchForAnApplication.cy.ts
+++ b/cypress/e2e/searchForAnApplication.cy.ts
@@ -4,6 +4,7 @@ import ApplicationsPage from '../pages/applications';
 
 describe('Search for an application', () => {
   it('as a read only user I only see the search results', () => {
+    cy.clearAllCookies();
     cy.loginAsUser('readOnly');
     ApplicationsPage.visit();
 
@@ -27,6 +28,7 @@ describe('Search for an application', () => {
     ApplicationsPage.getWorktraySidebar().should('not.exist');
   });
   it('as an officer I can engage with worktray', () => {
+    cy.clearAllCookies();
     cy.loginAsUser('officer');
     ApplicationsPage.visit();
 

--- a/cypress/e2e/searchForAnApplication.cy.ts
+++ b/cypress/e2e/searchForAnApplication.cy.ts
@@ -1,0 +1,52 @@
+import { faker } from '@faker-js/faker/locale/en_GB';
+
+import ApplicationsPage from '../pages/applications';
+
+describe('Search for an application', () => {
+  it('as a read only user I only see the search results', () => {
+    cy.loginAsUser('readOnly');
+    ApplicationsPage.visit();
+
+    ApplicationsPage.getApplicationsPage().should('be.visible');
+
+    // can see the application page and search bar
+    ApplicationsPage.getSearchInput().should('be.visible');
+    // doesn't see the worktray
+    ApplicationsPage.getWorktray().should('not.exist');
+    ApplicationsPage.getWorktraySidebar().should('not.exist');
+
+    // can search for an application
+    ApplicationsPage.getSearchInput().type(faker.lorem.words(2));
+    ApplicationsPage.getSearchSubmitButton().click();
+
+    // can see the search results
+    ApplicationsPage.getSearchResults().should('be.visible');
+
+    // doesn't see the sidebar
+
+    ApplicationsPage.getWorktraySidebar().should('not.exist');
+  });
+  it('as an officer I can engage with worktray', () => {
+    cy.loginAsUser('officer');
+    ApplicationsPage.visit();
+
+    ApplicationsPage.getApplicationsPage().should('be.visible');
+
+    // can see the application page and search bar
+    ApplicationsPage.getSearchInput().should('be.visible');
+
+    // can see the worktray
+    ApplicationsPage.getWorktray().should('be.visible');
+    ApplicationsPage.getWorktraySidebar().should('be.visible');
+
+    // can search for an application
+    ApplicationsPage.getSearchInput().type(faker.lorem.words(2));
+    ApplicationsPage.getSearchSubmitButton().click();
+
+    // can see the search results
+    ApplicationsPage.getSearchResults().should('be.visible');
+
+    // can see the sidebar
+    ApplicationsPage.getWorktraySidebar().should('be.visible');
+  });
+});

--- a/cypress/e2e/searchForAnApplication.cy.ts
+++ b/cypress/e2e/searchForAnApplication.cy.ts
@@ -1,54 +1,53 @@
 import { faker } from '@faker-js/faker/locale/en_GB';
 
 import ApplicationsPage from '../pages/applications';
+import { screenPresets } from '../support/helpers';
 
 describe('Search for an application', () => {
-  it('as a read only user I only see the search results', () => {
-    // cy.clearAllCookies();
-    cy.loginAsUser('readOnly');
-    ApplicationsPage.visit();
+  screenPresets.forEach((screenPreset) => {
+    it('as a read only user I only see the search results', () => {
+      cy.viewport(screenPreset);
+      cy.clearCookies();
 
-    ApplicationsPage.getApplicationsPage().should('be.visible');
+      cy.loginAsUser('readOnly');
+      ApplicationsPage.visit();
 
-    // can see the application page and search bar
-    ApplicationsPage.getSearchInput().should('be.visible');
-    // doesn't see the worktray
-    ApplicationsPage.getWorktray().should('not.exist');
-    ApplicationsPage.getWorktraySidebar().should('not.exist');
+      ApplicationsPage.getApplicationsPage().should('be.visible');
 
-    // can search for an application
-    ApplicationsPage.getSearchInput().type(faker.lorem.words(2));
-    ApplicationsPage.getSearchSubmitButton().click();
+      ApplicationsPage.getSearchInput().should('be.visible');
 
-    // can see the search results
-    ApplicationsPage.getSearchResults().should('be.visible');
+      ApplicationsPage.getWorktray().should('not.exist');
+      ApplicationsPage.getWorktraySidebar().should('not.exist');
 
-    // doesn't see the sidebar
+      ApplicationsPage.getSearchInput().type(faker.lorem.words(2));
+      ApplicationsPage.getSearchSubmitButton().click();
 
-    ApplicationsPage.getWorktraySidebar().should('not.exist');
+      ApplicationsPage.getSearchResults().should('be.visible');
+
+      ApplicationsPage.getWorktraySidebar().should('not.exist');
+    });
   });
-  it('as an officer I can engage with worktray', () => {
-    // cy.clearAllCookies();
-    cy.loginAsUser('officer');
-    ApplicationsPage.visit();
+  screenPresets.forEach((screenPreset) => {
+    it('as an officer I can engage with worktray', () => {
+      cy.viewport(screenPreset);
+      cy.clearCookies();
 
-    ApplicationsPage.getApplicationsPage().should('be.visible');
+      cy.loginAsUser('officer');
+      ApplicationsPage.visit();
 
-    // can see the application page and search bar
-    ApplicationsPage.getSearchInput().should('be.visible');
+      ApplicationsPage.getApplicationsPage().should('be.visible');
 
-    // can see the worktray
-    ApplicationsPage.getWorktray().should('be.visible');
-    ApplicationsPage.getWorktraySidebar().should('be.visible');
+      ApplicationsPage.getSearchInput().should('be.visible');
 
-    // can search for an application
-    ApplicationsPage.getSearchInput().type(faker.lorem.words(2));
-    ApplicationsPage.getSearchSubmitButton().click();
+      ApplicationsPage.getWorktray().should('be.visible');
+      ApplicationsPage.getWorktraySidebar().should('be.visible');
 
-    // can see the search results
-    ApplicationsPage.getSearchResults().should('be.visible');
+      ApplicationsPage.getSearchInput().type(faker.lorem.words(2));
+      ApplicationsPage.getSearchSubmitButton().click();
 
-    // can see the sidebar
-    ApplicationsPage.getWorktraySidebar().should('be.visible');
+      ApplicationsPage.getSearchResults().should('be.visible');
+
+      ApplicationsPage.getWorktraySidebar().should('be.visible');
+    });
   });
 });

--- a/cypress/e2e/searchForAnApplication.cy.ts
+++ b/cypress/e2e/searchForAnApplication.cy.ts
@@ -4,7 +4,7 @@ import ApplicationsPage from '../pages/applications';
 
 describe('Search for an application', () => {
   it('as a read only user I only see the search results', () => {
-    cy.clearAllCookies();
+    // cy.clearAllCookies();
     cy.loginAsUser('readOnly');
     ApplicationsPage.visit();
 
@@ -28,7 +28,7 @@ describe('Search for an application', () => {
     ApplicationsPage.getWorktraySidebar().should('not.exist');
   });
   it('as an officer I can engage with worktray', () => {
-    cy.clearAllCookies();
+    // cy.clearAllCookies();
     cy.loginAsUser('officer');
     ApplicationsPage.visit();
 

--- a/cypress/pages/applications.ts
+++ b/cypress/pages/applications.ts
@@ -1,0 +1,34 @@
+class ApplicationsPage {
+  static visit() {
+    cy.visit('/applications');
+  }
+
+  static getApplicationsPage() {
+    const testId = 'test-applications-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getSearchInput() {
+    return this.getApplicationsPage().find('input[name="search"]');
+  }
+
+  static getSearchSubmitButton() {
+    return this.getApplicationsPage().find('button[type="submit"]');
+  }
+
+  static getWorktray() {
+    const testId = 'test-applications-worktray';
+    return this.getApplicationsPage().get(`[data-testid="${testId}"]`);
+  }
+
+  static getWorktraySidebar() {
+    const testId = 'test-admin-sidebar';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getSearchResults() {
+    const testId = 'test-search-box';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+}
+export default ApplicationsPage;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -69,36 +69,21 @@ Cypress.Commands.add('loginAsUser', (userType: string) => {
       email: faker.internet.email({ provider: 'hackneyTEST.gov.uk' }),
       name: faker.person.fullName(),
       groups: Cypress.env('AUTHORISED_OFFICER_GROUP'),
-      // groups:
-      //   Cypress.env('NEXT_PUBLIC_ENV') === 'localdev'
-      //     ? [Cypress.env('AUTHORISED_OFFICER_GROUP')]
-      //     : ['WHATEVA'],
     },
     manager: {
       email: faker.internet.email({ provider: 'hackneyTEST.gov.uk' }),
       name: faker.person.fullName(),
       groups: Cypress.env('AUTHORISED_MANAGER_GROUP'),
-      // Cypress.env('NEXT_PUBLIC_ENV') === 'localdev'
-      //   ? [Cypress.env('AUTHORISED_MANAGER_GROUP')]
-      //   : ['WHATEVA'],
     },
     admin: {
       email: faker.internet.email({ provider: 'hackneyTEST.gov.uk' }),
       name: faker.person.fullName(),
       groups: Cypress.env('AUTHORISED_ADMIN_GROUP'),
-      // groups:
-      //   Cypress.env('NEXT_PUBLIC_ENV') === 'localdev'
-      //     ? [Cypress.env('AUTHORISED_ADMIN_GROUP')]
-      //     : ['WHATEVA'],
     },
     readOnly: {
       email: faker.internet.email({ provider: 'hackneyTEST.gov.uk' }),
       name: faker.person.fullName(),
       groups: Cypress.env('AUTHORISED_READONLY_GROUP'),
-      // groups:
-      //   Cypress.env('NEXT_PUBLIC_ENV') === 'localdev'
-      //     ? [Cypress.env('AUTHORISED_READONLY_GROUP')]
-      //     : ['WHATEVA'],
     },
   };
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,11 @@
 import { faker } from '@faker-js/faker/locale/en_GB';
 import { mount } from 'cypress/react';
+// import 'dotenv/config';
+
+// type Environment = 'localdev' | 'development';
+
+// const environment: Environment =
+//   (process.env.NEXT_PUBLIC_ENV as Environment) || 'development';
 
 // ***********************************************
 // This example commands.ts shows you how to
@@ -53,5 +59,59 @@ Cypress.Commands.add('generateEmptyApplication', () => {
     otherMembers: [],
     assessment: null,
     importedFromLegacyDatabase: false,
+  });
+});
+
+Cypress.Commands.add('loginAsUser', (userType: string) => {
+  // if it's running against the local env then should be set from the env vaars, otherwise match the congg.
+  const users = {
+    officer: {
+      email: faker.internet.email({ provider: 'hackneyTEST.gov.uk' }),
+      name: faker.person.fullName(),
+      groups: Cypress.env('AUTHORISED_OFFICER_GROUP'),
+      // groups:
+      //   Cypress.env('NEXT_PUBLIC_ENV') === 'localdev'
+      //     ? [Cypress.env('AUTHORISED_OFFICER_GROUP')]
+      //     : ['WHATEVA'],
+    },
+    manager: {
+      email: faker.internet.email({ provider: 'hackneyTEST.gov.uk' }),
+      name: faker.person.fullName(),
+      groups: Cypress.env('AUTHORISED_MANAGER_GROUP'),
+      // Cypress.env('NEXT_PUBLIC_ENV') === 'localdev'
+      //   ? [Cypress.env('AUTHORISED_MANAGER_GROUP')]
+      //   : ['WHATEVA'],
+    },
+    admin: {
+      email: faker.internet.email({ provider: 'hackneyTEST.gov.uk' }),
+      name: faker.person.fullName(),
+      groups: Cypress.env('AUTHORISED_ADMIN_GROUP'),
+      // groups:
+      //   Cypress.env('NEXT_PUBLIC_ENV') === 'localdev'
+      //     ? [Cypress.env('AUTHORISED_ADMIN_GROUP')]
+      //     : ['WHATEVA'],
+    },
+    readOnly: {
+      email: faker.internet.email({ provider: 'hackneyTEST.gov.uk' }),
+      name: faker.person.fullName(),
+      groups: Cypress.env('AUTHORISED_READONLY_GROUP'),
+      // groups:
+      //   Cypress.env('NEXT_PUBLIC_ENV') === 'localdev'
+      //     ? [Cypress.env('AUTHORISED_READONLY_GROUP')]
+      //     : ['WHATEVA'],
+    },
+  };
+
+  const user = users[userType];
+  if (!user) {
+    throw new Error(`No user data found for user type "${userType}"`);
+  }
+  const secret = 'aDummySecret';
+
+  cy.task('generateToken', { user, secret }).then((token) => {
+    const cookieName = 'hackneyToken';
+    cy.getCookies().should('be.empty');
+    cy.setCookie(cookieName, token as string);
+    cy.getCookie(cookieName).should('have.property', 'value', token);
   });
 });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,11 +1,5 @@
 import { faker } from '@faker-js/faker/locale/en_GB';
 import { mount } from 'cypress/react';
-// import 'dotenv/config';
-
-// type Environment = 'localdev' | 'development';
-
-// const environment: Environment =
-//   (process.env.NEXT_PUBLIC_ENV as Environment) || 'development';
 
 // ***********************************************
 // This example commands.ts shows you how to
@@ -32,6 +26,8 @@ import { mount } from 'cypress/react';
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+// ***********************************************
+
 Cypress.Commands.add('mount', mount);
 
 Cypress.Commands.add('generateEmptyApplication', () => {
@@ -63,7 +59,6 @@ Cypress.Commands.add('generateEmptyApplication', () => {
 });
 
 Cypress.Commands.add('loginAsUser', (userType: string) => {
-  // if it's running against the local env then should be set from the env vaars, otherwise match the congg.
   const users = {
     officer: {
       email: faker.internet.email({ provider: 'hackneyTEST.gov.uk' }),

--- a/cypress/support/helpers.ts
+++ b/cypress/support/helpers.ts
@@ -1,14 +1,10 @@
 export const screenPresets: Cypress.ViewportPreset[] = [
   // Desktops
-  'macbook-16', // set viewport to 1536 x	960
-  // 'macbook-15', // Set viewport to 1440px x 900px
+  'macbook-16', // set viewport to 1536px x	960px
   'macbook-13', // Set viewport to 1280px x 800px
   // Tablets
   'ipad-2', // Set viewport to 768px x 1024px
   // Cell phones
-  // 'samsung-note9', // Set viewport to 414px x 846px
   'iphone-xr', // Set viewport to 414px x 896px
-  // 'samsung-s10', // Set viewport to 360px x 760px
-  // 'iphone-6', // Set viewport to 375px x 667px
   'iphone-3', // Set viewport to 320px x 480px
 ];

--- a/cypress/support/helpers.ts
+++ b/cypress/support/helpers.ts
@@ -1,13 +1,14 @@
 export const screenPresets: Cypress.ViewportPreset[] = [
   // Desktops
-  'macbook-15', // Set viewport to 1440px x 900px
+  'macbook-16', // set viewport to 1536 x	960
+  // 'macbook-15', // Set viewport to 1440px x 900px
   'macbook-13', // Set viewport to 1280px x 800px
   // Tablets
   'ipad-2', // Set viewport to 768px x 1024px
   // Cell phones
+  // 'samsung-note9', // Set viewport to 414px x 846px
   'iphone-xr', // Set viewport to 414px x 896px
-  'iphone-6', // Set viewport to 375px x 667px
+  // 'samsung-s10', // Set viewport to 360px x 760px
+  // 'iphone-6', // Set viewport to 375px x 667px
   'iphone-3', // Set viewport to 320px x 480px
-  'samsung-note9', // Set viewport to 414px x 846px
-  'samsung-s10', // Set viewport to 360px x 760px
 ];

--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,9 @@
 
 const { withSentryConfig } = require('@sentry/nextjs');
 
-const moduleExports = {
+// @ts-check
+/** @type {import('next').NextConfig} */
+const nextConfig = {
   distDir: 'build/_next',
   poweredByHeader: false,
   reactStrictMode: true,
@@ -34,7 +36,6 @@ const moduleExports = {
     // Warning: This allows production builds to successfully complete even if
     // your project has ESLint errors. This is due to the current ESLint setup
     // for staged files only as we clear the linting errors as we work.
-    // eslint-disable-next-line
     ignoreDuringBuilds: true,
   },
 
@@ -56,10 +57,11 @@ const sentryWebpackPluginOptions = {
   //   urlPrefix, include, ignore
 
   silent: true, // Suppresses all logs
+  dryRun: process.env.NEXT_PUBLIC_ENV !== 'production',
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.
 };
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
-module.exports = withSentryConfig(moduleExports, sentryWebpackPluginOptions);
+module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,8 +71,7 @@
         "playwright-webkit": "^1.46.0",
         "prettier": "2.2.1",
         "sass": "^1.32.12",
-        "typescript": "^4.2.4",
-        "wait-on": "^7.2.0"
+        "typescript": "^4.2.4"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1061,15 +1060,6 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "dev": true
-    },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -3147,27 +3137,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "dev": true
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "dev": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",
@@ -11925,19 +11894,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
-      "dev": true,
-      "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -16684,59 +16640,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/wait-on": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
-      "dev": true,
-      "dependencies": {
-        "axios": "^1.6.1",
-        "joi": "^17.11.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
-      },
-      "bin": {
-        "wait-on": "bin/wait-on"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/wait-on/node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/wait-on/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/wait-on/node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -18096,15 +17999,6 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "dev": true
-    },
-    "@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -19630,27 +19524,6 @@
       "requires": {
         "@sentry/cli": "^1.73.0"
       }
-    },
-    "@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "dev": true
-    },
-    "@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.6",
@@ -26193,19 +26066,6 @@
         }
       }
     },
-    "joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
-      "dev": true,
-      "requires": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -29699,52 +29559,6 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
-      }
-    },
-    "wait-on": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
-      "dev": true,
-      "requires": {
-        "axios": "^1.6.1",
-        "joi": "^17.11.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-          "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "rxjs": {
-          "version": "7.8.1",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
       }
     },
     "walker": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,8 @@
         "playwright-webkit": "^1.46.0",
         "prettier": "2.2.1",
         "sass": "^1.32.12",
-        "typescript": "^4.2.4"
+        "typescript": "^4.2.4",
+        "wait-on": "^7.2.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1060,6 +1061,15 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "dev": true
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -3137,6 +3147,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",
@@ -8315,9 +8346,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -11892,6 +11923,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/js-tokens": {
@@ -16640,6 +16684,59 @@
         "node": ">=10"
       }
     },
+    "node_modules/wait-on": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/wait-on/node_modules/axios": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/wait-on/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/wait-on/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -17999,6 +18096,15 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
       "dev": true
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -19524,6 +19630,27 @@
       "requires": {
         "@sentry/cli": "^1.73.0"
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.6",
@@ -23466,9 +23593,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -26064,6 +26191,19 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "js-tokens": {
@@ -29559,6 +29699,52 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^3.0.0"
+      }
+    },
+    "wait-on": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
+      "requires": {
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+          "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.15.6",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "rxjs": {
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cypress:open": "cypress open --browser electron",
     "e2e:run": "cypress run --e2e --browser electron",
     "component:run": "cypress run --component --browser electron",
-    "wait-on": "wait-on http-get://localhost:3000/api/ping -v"
+    "wait-on": "wait-on http-get://localhost:3000 -v"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "mocks": "mocks-server",
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx",
-    "lint:fix": "eslint . --fix --max-warnings 0",
+    "lint:fix": "eslint . --fix --max-warnings 0 --ext .js,.jsx,.ts,.tsx",
     "prettier:test": "npx prettier -c .",
     "prettier:fix": "npx prettier --write .",
     "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit && tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev --hostname=localdev.hackney.gov.uk",
-    "start": "next start -p $PORT",
+    "start": "next start",
     "mocks": "mocks-server",
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --fix --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --fix --max-warnings 0 --no-ignore",
+      "eslint --fix --max-warnings 0",
       "prettier --ignore-unknown --write"
     ],
     "!(*.js|*.jsx|*.ts|*.tsx|package-lock.json)": "prettier --ignore-unknown --write"

--- a/package.json
+++ b/package.json
@@ -4,10 +4,8 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "build:ci": "next build",
     "dev": "next dev --hostname=localdev.hackney.gov.uk",
     "start": "next start",
-    "start:ci": "next start",
     "mocks": "mocks-server",
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --fix --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "private": true,
   "scripts": {
     "build": "next build",
+    "build:ci": "next build",
     "dev": "next dev --hostname=localdev.hackney.gov.uk",
     "start": "next start",
+    "start:ci": "next start",
     "mocks": "mocks-server",
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --fix --max-warnings 0",
@@ -102,6 +104,7 @@
     "playwright-webkit": "^1.46.0",
     "prettier": "2.2.1",
     "sass": "^1.32.12",
-    "typescript": "^4.2.4"
+    "typescript": "^4.2.4",
+    "wait-on": "^7.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start -p $PORT",
     "mocks": "mocks-server",
     "lint": "eslint . --max-warnings 0 --ext .js,.jsx,.ts,.tsx",
-    "lint:fix": "eslint . --fix --max-warnings 0 --ext .js,.jsx,.ts,.tsx",
+    "lint:fix": "eslint . --fix --max-warnings 0",
     "prettier:test": "npx prettier -c .",
     "prettier:fix": "npx prettier --write .",
     "test:ci": "jest --ci --coverage --reporters=default --reporters=jest-junit && tsc --noEmit",
@@ -20,8 +20,11 @@
     "component:run": "cypress run --component --browser electron"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "eslint --fix --max-warnings 0",
-    "!package-lock.json": "prettier --ignore-unknown --write"
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix --max-warnings 0 --no-ignore",
+      "prettier --ignore-unknown --write"
+    ],
+    "!(*.js|*.jsx|*.ts|*.tsx|package-lock.json)": "prettier --ignore-unknown --write"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "prepare": "husky",
     "cypress:open": "cypress open --browser electron",
     "e2e:run": "cypress run --e2e --browser electron",
-    "component:run": "cypress run --component --browser electron"
+    "component:run": "cypress run --component --browser electron",
+    "wait-on": "wait-on http-get://localhost:3000/api/ping -v"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "prepare": "husky",
     "cypress:open": "cypress open --browser electron",
     "e2e:run": "cypress run --e2e --browser electron",
-    "component:run": "cypress run --component --browser electron",
-    "wait-on": "wait-on http-get://localhost:3000 -v"
+    "component:run": "cypress run --component --browser electron"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
@@ -105,7 +104,6 @@
     "playwright-webkit": "^1.46.0",
     "prettier": "2.2.1",
     "sass": "^1.32.12",
-    "typescript": "^4.2.4",
-    "wait-on": "^7.2.0"
+    "typescript": "^4.2.4"
   }
 }

--- a/pages/applications/search-results.tsx
+++ b/pages/applications/search-results.tsx
@@ -1,16 +1,22 @@
 import { GetServerSideProps } from 'next';
+
+import ApplicationsTable from '../../components/admin/ApplicationsTable';
 import SearchBox from '../../components/admin/SearchBox';
 import Sidebar from '../../components/admin/sidebar';
 import { HeadingOne } from '../../components/content/headings';
+import Paragraph from '../../components/content/paragraph';
 import Layout from '../../components/layout/staff-layout';
+import SimplePaginationSearch from '../../components/SimplePaginationSearch';
 import { HackneyGoogleUser } from '../../domain/HackneyGoogleUser';
 import { PaginatedSearchResultsResponse } from '../../domain/HousingApi';
 import { UserContext } from '../../lib/contexts/user-context';
 import { searchAllApplications } from '../../lib/gateways/applications-api';
-import { getRedirect, getSession } from '../../lib/utils/googleAuth';
-import ApplicationsTable from '../../components/admin/ApplicationsTable';
-import SimplePaginationSearch from '../../components/SimplePaginationSearch';
-import Paragraph from '../../components/content/paragraph';
+import {
+  HackneyGoogleUserWithPermissions,
+  canViewWorktray,
+  getRedirect,
+  getSession,
+} from '../../lib/utils/googleAuth';
 
 interface PageProps {
   user?: HackneyGoogleUser;
@@ -26,43 +32,43 @@ export default function ApplicationListPage({
   pageSize,
 }: PageProps): JSX.Element {
   return (
+    // noting here the possibility of unecessary re-renders that will need some investigation.
+    // eslint-disable-next-line react/jsx-no-constructed-context-values
     <UserContext.Provider value={{ user }}>
       <Layout pageName="My worktray">
         <SearchBox
           title="Housing Register"
           buttonTitle="Search"
           watermark="Search all applications (name, reference, bidding number)"
+          dataTestId="test-search-box"
         />
         <div className="govuk-grid-row">
-          <div className="govuk-grid-column-one-quarter">
-            <Sidebar />
-          </div>
+          {canViewWorktray(user as HackneyGoogleUserWithPermissions) && (
+            <div className="govuk-grid-column-one-quarter">
+              <Sidebar />
+            </div>
+          )}
           <div className="govuk-grid-column-three-quarters">
             <HeadingOne content="Results" />
-            <>
-              {applications ? (
-                <>
-                  {applications.totalResults !== 0 ? (
-                    <>
-                      <ApplicationsTable
-                        applications={applications}
-                        showStatus={true}
-                        page={page}
-                        pageSize={pageSize}
-                      />
 
-                      <SimplePaginationSearch
-                        totalItems={applications.totalResults}
-                        page={applications.page}
-                        numberOfItemsPerPage={applications.pageSize}
-                      />
-                    </>
-                  ) : (
-                    <Paragraph>No applications to show</Paragraph>
-                  )}
-                </>
-              ) : null}
-            </>
+            {applications && applications.totalResults !== 0 ? (
+              <>
+                <ApplicationsTable
+                  applications={applications}
+                  showStatus
+                  page={page}
+                  pageSize={pageSize}
+                />
+
+                <SimplePaginationSearch
+                  totalItems={applications.totalResults}
+                  page={applications.page}
+                  numberOfItemsPerPage={applications.pageSize}
+                />
+              </>
+            ) : (
+              <Paragraph>No applications to show</Paragraph>
+            )}
           </div>
         </div>
       </Layout>
@@ -84,11 +90,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async (
     };
   }
 
-  const {
-    searchString = '',
-    page = '',
-    pageSize = '',
-  } = context.query as {
+  const { searchString = '', page = '', pageSize = '' } = context.query as {
     searchString: string;
     page: string;
     pageSize: string;

--- a/serverless.yml
+++ b/serverless.yml
@@ -38,6 +38,7 @@ functions:
       AUTHORISED_ADMIN_GROUP: ${ssm:/housing-register/${self:provider.stage}/authorised_admin_group}
       AUTHORISED_MANAGER_GROUP: ${ssm:/housing-register/${self:provider.stage}/authorised_manager_group}
       AUTHORISED_OFFICER_GROUP: ${ssm:/housing-register/${self:provider.stage}/authorised_officer_group}
+      AUTHORISED_READONLY_GROUP: ${ssm:/housing-register/${self:provider.stage}/authorised_readonly_group}
       HACKNEY_JWT_SECRET: ${ssm:/housing-register/${self:provider.stage}/hackney-jwt-secret}
       HOUSING_REGISTER_API: ${ssm:/housing-register/${self:provider.stage}/housing-register-api-url}
       HOUSING_REGISTER_KEY: ${ssm:/housing-register/${self:provider.stage}/housing-register-api-key}

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -2,6 +2,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       generateEmptyApplication(): Chainable<void>;
+      loginAsUser(userType: string): Chainable<void>;
       mount: typeof mount;
     }
   }


### PR DESCRIPTION
https://hackney.atlassian.net/browse/TS-1585?atlOrigin=eyJpIjoiNmUyMTk4ZjkzNGI3NDllZjkyYjgxZDhmNDc3ZGJhNWIiLCJwIjoiaiJ9

*Note utility function changes outlined in ticket will be addressed in a seperate PR.

**What** 
- Implements a readOnly user type in googleAuth.ts that can be used to show or hide features based on cookie status. This follows a similar pattern to the way other features are shown for different user groups. If a user has readOnly group which isn't superseded by another higher group (any other group) then it will apply the readOnly status.
- Implements an e2e tests to prove this case, 
- As a product of this implementation, where linting errors have been raised components have been refactored to account for this,
- Updates the pipeline to run e2e tests against a build rather than the dev environment,
- Adds a Sentry option to the next.config that ensures sentry is run only in production. 

**Why**
- Service wants a read-only user to search for applications but have no other functionality

**Future**
- Investigate further the best way to mock SeverSide props on a next app in Cypress. Currently it's pointing to the dev env api. 