### PR TITLE
TS-1585 add test coverage for auth utils

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,8 @@
         "devDependencies": [
           "**/*.+(test|spec|cy).+(j|t)s?(x)",
           "cypress.config.ts",
-          "cypress/support/commands.ts"
+          "cypress/support/commands.ts",
+          "testUtils/*"
         ]
       }
     ]

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -26,9 +26,7 @@ export default {
   coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: ['/node_modules/', '/testUtils'],
 
   // Indicates which provider should be used to instrument code for coverage
   // coverageProvider: "babel",

--- a/lib/types/application-status.spec.ts
+++ b/lib/types/application-status.spec.ts
@@ -1,0 +1,60 @@
+import { ApplicationStatus, lookupStatus } from './application-status';
+
+describe('lookupStatus', () => {
+  it('returns Incomplete for ApplicationStatus.DRAFT', () => {
+    expect(lookupStatus(ApplicationStatus.DRAFT)).toBe('Incomplete');
+  });
+
+  it('returns Added by officer for ApplicationStatus.MANUAL_DRAFT', () => {
+    expect(lookupStatus(ApplicationStatus.MANUAL_DRAFT)).toBe(
+      'Added by officer'
+    );
+  });
+
+  it('returns Awaiting assessment for ApplicationStatus.SUBMITTED', () => {
+    expect(lookupStatus(ApplicationStatus.SUBMITTED)).toBe(
+      'Awaiting assessment'
+    );
+  });
+
+  it('returns Referred for approval for ApplicationStatus.REFERRED', () => {
+    expect(lookupStatus(ApplicationStatus.REFERRED)).toBe(
+      'Referred for approval'
+    );
+  });
+
+  it('returns Rejected by officer for ApplicationStatus.REJECTED', () => {
+    expect(lookupStatus(ApplicationStatus.REJECTED)).toBe(
+      'Rejected by officer'
+    );
+  });
+
+  it('returns Rejected by system for ApplicationStatus.DISQUALIFIED', () => {
+    expect(lookupStatus(ApplicationStatus.DISQUALIFIED)).toBe(
+      'Rejected by system'
+    );
+  });
+
+  it('returns Active and under appeal for ApplicationStatus.ACTIVE_UNDER_APPEAL', () => {
+    expect(lookupStatus(ApplicationStatus.ACTIVE_UNDER_APPEAL)).toBe(
+      'Active and under appeal'
+    );
+  });
+
+  it('returns Inactive and under appeal for ApplicationStatus.INACTIVE_UNDER_APPEAL', () => {
+    expect(lookupStatus(ApplicationStatus.INACTIVE_UNDER_APPEAL)).toBe(
+      'Inactive and under appeal'
+    );
+  });
+
+  it('returns Awaiting reassessment for ApplicationStatus.AWAITING_REASSESSMENT', () => {
+    expect(lookupStatus(ApplicationStatus.AWAITING_REASSESSMENT)).toBe(
+      'Awaiting reassessment'
+    );
+  });
+
+  it('returns given status when not match found', () => {
+    const nonMatchingString = 'non matching string';
+    expect(lookupStatus(nonMatchingString)).toBe(nonMatchingString);
+  });
+});

--- a/lib/utils/googleAuth.spec.ts
+++ b/lib/utils/googleAuth.spec.ts
@@ -1,0 +1,438 @@
+/* eslint-disable import/no-duplicates */
+import cookie from 'cookie';
+import jwt from 'jsonwebtoken';
+import jsonwebtoken from 'jsonwebtoken';
+import { createRequest, createResponse } from 'node-mocks-http';
+
+import { envVarsFixture } from '../../testUtils/envVarsHelper';
+import { generateJWTTokenTestData } from '../../testUtils/jwtTokenHelper';
+import {
+  ApiRequest,
+  ApiResponse,
+  GetAuthTestResponse,
+} from '../../testUtils/types';
+import {
+  AUTHORISED_ADMIN_GROUP_TEST,
+  AUTHORISED_MANAGER_GROUP_TEST,
+  AUTHORISED_OFFICER_GROUP_TEST,
+  UserRole,
+  generateHRUserWithPermissions,
+  generateSignedTokenByRole,
+  getClaimsByRole,
+} from '../../testUtils/userHelper';
+import {
+  HackneyGoogleUserWithPermissions,
+  canViewSensitiveApplication,
+  getAuth,
+  getPermissions,
+  getRedirect,
+  getSession,
+  hasAnyPermissions,
+  hasUserGroup,
+  removeHackneyToken,
+} from './googleAuth';
+
+const nonHRGroup = 'any-group';
+const issuedAt = new Date().getMilliseconds();
+
+describe('googleAuth', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getSession', () => {
+    describe('headers and cookies', () => {
+      it('calls parse with the cookie from the headers when provided', () => {
+        const req: ApiRequest = createRequest();
+        const parseSpy = jest.spyOn(cookie, 'parse');
+        req.headers = {
+          cookie: 'abc123',
+        };
+
+        getSession(req);
+
+        expect(parseSpy).toHaveBeenCalledTimes(1);
+        expect(parseSpy).toHaveBeenCalledWith(req.headers.cookie);
+      });
+
+      it('calls parse with empty string when cookie is not provided in the header', () => {
+        const req: ApiRequest = createRequest();
+        const parseSpy = jest.spyOn(cookie, 'parse');
+
+        getSession(req);
+
+        expect(parseSpy).toHaveBeenCalledTimes(1);
+        expect(parseSpy).toHaveBeenCalledWith('');
+      });
+
+      it('throws when request not provided', () => {
+        const expectedErrorMessage =
+          "Cannot read properties of undefined (reading 'headers')";
+        expect(getSession).toThrow(expectedErrorMessage);
+      });
+
+      it('returns undefined when cookie is not provided', () => {
+        const req: ApiRequest = createRequest();
+        const response = getSession(req);
+        expect(response).toBeUndefined();
+      });
+
+      it("returns undefined when cookie is provided but it's not hackneyToken", () => {
+        const req: ApiRequest = createRequest();
+        req.headers = {
+          cookie: 'someToken=123',
+        };
+
+        const response = getSession(req);
+        expect(response).toBeUndefined();
+      });
+    });
+
+    describe('token verification', () => {
+      const secretFixture = envVarsFixture('HACKNEY_JWT_SECRET');
+      const skipTokenVerifyFixture = envVarsFixture('SKIP_VERIFY_TOKEN');
+      const req: ApiRequest = createRequest();
+      const parsedToken = 'abc123';
+      const tokenSecret = 'secret';
+      const verifyFunctionName = 'verify';
+      const decodeFunctionName = 'decode';
+
+      req.headers = {
+        cookie: `hackneyToken=${parsedToken}`,
+      };
+
+      beforeEach(() => {
+        secretFixture.mock(tokenSecret);
+      });
+
+      afterEach(() => {
+        secretFixture.restore();
+        skipTokenVerifyFixture.restore();
+      });
+
+      it('returns undefined when cookie parse throws JsonWebTokenError', () => {
+        jest.spyOn(cookie, 'parse').mockImplementationOnce(() => {
+          throw new jwt.JsonWebTokenError('token parse error');
+        });
+
+        expect(getSession(req)).toBeUndefined();
+      });
+
+      it('verifies token when SKIP_VERIFY_TOKEN is not set', () => {
+        skipTokenVerifyFixture.delete();
+
+        const verifySpy = jest.spyOn(jsonwebtoken, verifyFunctionName);
+        const decodeSpy = jest.spyOn(jsonwebtoken, decodeFunctionName);
+
+        getSession(req);
+
+        expect(verifySpy).toHaveBeenCalledTimes(1);
+        expect(verifySpy).toHaveBeenCalledWith(parsedToken, tokenSecret);
+        expect(decodeSpy).toHaveBeenCalledTimes(0);
+      });
+
+      it('verifies token when SKIP_VERIFY_TOKEN is set to false', () => {
+        skipTokenVerifyFixture.mock('false');
+
+        const verifySpy = jest.spyOn(jsonwebtoken, verifyFunctionName);
+        const decodeSpy = jest.spyOn(jsonwebtoken, decodeFunctionName);
+
+        getSession(req);
+
+        expect(verifySpy).toHaveBeenCalledTimes(1);
+        expect(verifySpy).toHaveBeenCalledWith(parsedToken, tokenSecret);
+        expect(decodeSpy).toHaveBeenCalledTimes(0);
+      });
+
+      it('does not verify token when SKIP_VERIFY_TOKEN is set to true', () => {
+        skipTokenVerifyFixture.mock('true');
+
+        const verifySpy = jest.spyOn(jsonwebtoken, verifyFunctionName);
+        const decodeSpy = jest.spyOn(jsonwebtoken, decodeFunctionName);
+
+        getSession(req);
+
+        expect(decodeSpy).toHaveBeenCalledTimes(1);
+        expect(decodeSpy).toHaveBeenCalledWith(parsedToken);
+        expect(verifySpy).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('Authorization groups', () => {
+      const skipVerifyToken = 'true';
+      const jwtSecret = 'secret';
+
+      const skipTokenFixture = envVarsFixture('SKIP_VERIFY_TOKEN');
+      const secretFixture = envVarsFixture('HACKNEY_JWT_SECRET');
+      const adminGroupFixture = envVarsFixture('AUTHORISED_ADMIN_GROUP');
+      const managerGroupFixture = envVarsFixture('AUTHORISED_MANAGER_GROUP');
+      const officerGroupFixture = envVarsFixture('AUTHORISED_OFFICER_GROUP');
+
+      //set default environment variables
+      beforeEach(() => {
+        skipTokenFixture.mock(skipVerifyToken);
+        secretFixture.mock(jwtSecret);
+        adminGroupFixture.mock(AUTHORISED_ADMIN_GROUP_TEST);
+        managerGroupFixture.mock(AUTHORISED_MANAGER_GROUP_TEST);
+        officerGroupFixture.mock(AUTHORISED_OFFICER_GROUP_TEST);
+      });
+
+      //restore default environment variables
+      afterEach(() => {
+        secretFixture.restore();
+        skipTokenFixture.restore();
+        adminGroupFixture.restore();
+        managerGroupFixture.restore();
+        officerGroupFixture.restore();
+      });
+
+      const req: ApiRequest = createRequest();
+
+      it('returns correct session details when valid hackney cookie provided', () => {
+        const { signedToken, tokenData } = generateSignedTokenByRole();
+
+        req.headers = {
+          cookie: `hackneyToken=${signedToken}`,
+        };
+
+        const session = getSession(req);
+        const expectedSession: HackneyGoogleUserWithPermissions = {
+          ...tokenData,
+          ...getClaimsByRole(),
+        };
+        expect(session).toStrictEqual(expectedSession);
+      });
+
+      it('returns matching authorization groups for admin claims', () => {
+        const { signedToken, tokenData } = generateSignedTokenByRole(
+          UserRole.Admin
+        );
+
+        req.headers = {
+          cookie: `hackneyToken=${signedToken}`,
+        };
+
+        const session = getSession(req);
+        const expectedSession: HackneyGoogleUserWithPermissions = {
+          ...tokenData,
+          ...getClaimsByRole(UserRole.Admin),
+        };
+        expect(session).toStrictEqual(expectedSession);
+      });
+
+      it('returns matching authorization groups for manager claims', () => {
+        const { signedToken, tokenData } = generateSignedTokenByRole(
+          UserRole.Manager
+        );
+
+        req.headers = {
+          cookie: `hackneyToken=${signedToken}`,
+        };
+
+        const session = getSession(req);
+        const expectedSession: HackneyGoogleUserWithPermissions = {
+          ...tokenData,
+          ...getClaimsByRole(UserRole.Manager),
+        };
+        expect(session).toEqual(expectedSession);
+      });
+
+      it('returns matching authorization groups for officer claims', () => {
+        const { signedToken, tokenData } = generateSignedTokenByRole(
+          UserRole.Officer
+        );
+
+        req.headers = {
+          cookie: `hackneyToken=${signedToken}`,
+        };
+
+        const session = getSession(req);
+        const expectedSession: HackneyGoogleUserWithPermissions = {
+          ...tokenData,
+          ...getClaimsByRole(UserRole.Officer),
+        };
+        expect(session).toEqual(expectedSession);
+      });
+    });
+  });
+
+  describe('removeHackneyToken', () => {
+    it('sets correct Set-Cookie header', () => {
+      const expectedCookieHeader =
+        'hackneyToken=; Max-Age=-1; Domain=.hackney.gov.uk; Path=/';
+      const res: ApiResponse = createResponse();
+
+      removeHackneyToken(res);
+
+      const newCookieHeader = res.getHeader('Set-Cookie');
+      expect(newCookieHeader).toBe(expectedCookieHeader);
+    });
+  });
+
+  describe('getPermissions', () => {
+    it("returns permissions based on user's group claims", () => {
+      const adminGroupFixture = envVarsFixture('AUTHORISED_ADMIN_GROUP');
+      const managerGroupFixture = envVarsFixture('AUTHORISED_MANAGER_GROUP');
+      const officerGroupFixture = envVarsFixture('AUTHORISED_OFFICER_GROUP');
+      adminGroupFixture.mock(AUTHORISED_ADMIN_GROUP_TEST);
+      managerGroupFixture.mock(AUTHORISED_MANAGER_GROUP_TEST);
+      officerGroupFixture.mock(AUTHORISED_OFFICER_GROUP_TEST);
+
+      const groupClaims = [
+        AUTHORISED_ADMIN_GROUP_TEST,
+        AUTHORISED_MANAGER_GROUP_TEST,
+        AUTHORISED_OFFICER_GROUP_TEST,
+      ];
+
+      const user = generateJWTTokenTestData(groupClaims, issuedAt);
+
+      const expectedPermissions = {
+        hasAdminPermissions: true,
+        hasManagerPermissions: true,
+        hasOfficerPermissions: true,
+      };
+
+      expect(getPermissions(user)).toStrictEqual(expectedPermissions);
+    });
+  });
+
+  describe('hasUserGroup', () => {
+    it('returns true when user is in the given group', () => {
+      const groupToCheck = AUTHORISED_ADMIN_GROUP_TEST;
+      const user = generateJWTTokenTestData(
+        [AUTHORISED_ADMIN_GROUP_TEST],
+        issuedAt
+      );
+      expect(hasUserGroup(groupToCheck, user)).toBeTruthy();
+    });
+
+    it('returns false when user is not in the given group', () => {
+      const groupToCheck = AUTHORISED_ADMIN_GROUP_TEST;
+      const user = generateJWTTokenTestData([nonHRGroup], issuedAt);
+      expect(hasUserGroup(groupToCheck, user)).toBeFalsy();
+    });
+  });
+
+  describe('hasAnyPermissions', () => {
+    it('returns true when user has officer permissions', () => {
+      const tokenData = generateJWTTokenTestData();
+      const user: HackneyGoogleUserWithPermissions = {
+        ...tokenData,
+        ...getClaimsByRole(UserRole.Officer),
+      };
+      expect(hasAnyPermissions(user)).toBeTruthy();
+    });
+
+    it('returns true when user has manager permissions', () => {
+      const tokenData = generateJWTTokenTestData();
+      const user: HackneyGoogleUserWithPermissions = {
+        ...tokenData,
+        ...getClaimsByRole(UserRole.Manager),
+      };
+      expect(hasAnyPermissions(user)).toBeTruthy();
+    });
+
+    it('returns true when user has admin permissions', () => {
+      const tokenData = generateJWTTokenTestData();
+      const user: HackneyGoogleUserWithPermissions = {
+        ...tokenData,
+        ...getClaimsByRole(UserRole.Admin),
+      };
+      expect(hasAnyPermissions(user)).toBeTruthy();
+    });
+
+    it('returns false when user has no officer, manager or admin permissions', () => {
+      const tokenData = generateJWTTokenTestData();
+      const user: HackneyGoogleUserWithPermissions = {
+        ...tokenData,
+        ...getClaimsByRole(),
+      };
+      expect(hasAnyPermissions(user)).toBeFalsy();
+    });
+  });
+
+  describe('canViewSensitiveApplication', () => {
+    it('returns true when user has admin permissions', () => {
+      const user: HackneyGoogleUserWithPermissions = generateHRUserWithPermissions(
+        UserRole.Admin
+      );
+      expect(canViewSensitiveApplication('', user)).toBeTruthy();
+    });
+
+    it('returns true when user has manager permissions', () => {
+      const user: HackneyGoogleUserWithPermissions = generateHRUserWithPermissions(
+        UserRole.Manager
+      );
+      expect(canViewSensitiveApplication('', user)).toBeTruthy();
+    });
+
+    it('returns false when user has officer permissions', () => {
+      const user: HackneyGoogleUserWithPermissions = generateHRUserWithPermissions(
+        UserRole.Officer
+      );
+      expect(canViewSensitiveApplication('', user)).toBeFalsy();
+    });
+
+    it('returns true when user has officer permissions and the application is assigned to them', () => {
+      const user: HackneyGoogleUserWithPermissions = generateHRUserWithPermissions(
+        UserRole.Officer
+      );
+      expect(canViewSensitiveApplication(user.email, user)).toBeTruthy();
+    });
+  });
+
+  describe('getRedirect', () => {
+    it('returns /login when user is not provided', () => {
+      const expectedResponse = '/login';
+      expect(getRedirect()).toBe(expectedResponse);
+    });
+    it("return /access-denied when user is provided but they don't have any HR permissions", () => {
+      const user: HackneyGoogleUserWithPermissions = generateHRUserWithPermissions();
+
+      const expectedResponse = '/access-denied';
+      expect(getRedirect(user)).toBe(expectedResponse);
+    });
+
+    it('returns undefined when user is provided and has HR permissions', () => {
+      const officer: HackneyGoogleUserWithPermissions = generateHRUserWithPermissions(
+        UserRole.Officer
+      );
+      expect(getRedirect(officer)).toBeUndefined();
+    });
+  });
+
+  describe('getAuth', () => {
+    it('returns correct login Redirect object when user is not provided', () => {
+      const expectedResponse: GetAuthTestResponse = {
+        redirect: {
+          statusCode: 302,
+          destination: '/login',
+        },
+      };
+      expect(getAuth('')).toStrictEqual(expectedResponse);
+    });
+
+    it('returns correct access denied Redirect object when user is not in the correct group', () => {
+      const expectedResponse: GetAuthTestResponse = {
+        redirect: {
+          statusCode: 302,
+          destination: '/access-denied',
+        },
+      };
+
+      const tokenData = generateJWTTokenTestData(['user-group']);
+
+      expect(getAuth('required-group', tokenData)).toStrictEqual(
+        expectedResponse
+      );
+    });
+
+    it('returns user when provided and they have access to a given group', () => {
+      const requiredGroup = 'user-group';
+      const user = generateJWTTokenTestData([requiredGroup]);
+      const expectedResponse = { user };
+
+      expect(getAuth(requiredGroup, user)).toStrictEqual(expectedResponse);
+    });
+  });
+});

--- a/lib/utils/googleAuth.ts
+++ b/lib/utils/googleAuth.ts
@@ -4,7 +4,7 @@ import { Redirect } from 'next';
 
 import { HackneyGoogleUser } from '../../domain/HackneyGoogleUser';
 
-type Permissions = {
+export type Permissions = {
   hasAdminPermissions: boolean;
   hasManagerPermissions: boolean;
   hasOfficerPermissions: boolean;

--- a/lib/utils/requestAuth.spec.ts
+++ b/lib/utils/requestAuth.spec.ts
@@ -97,6 +97,15 @@ describe('requestAuth', () => {
 
       expect(hasStaffPermissions(req)).toBeFalsy();
     });
+
+    it('returns true when user is staff member and has HR permissions', () => {
+      const { signedToken } = generateSignedTokenByRole(UserRole.Manager);
+      req.headers = {
+        cookie: `hackneyToken=${signedToken}`,
+      };
+
+      expect(hasStaffPermissions(req)).toBeTruthy();
+    });
   });
 
   describe('isStaffAction', () => {

--- a/lib/utils/requestAuth.spec.ts
+++ b/lib/utils/requestAuth.spec.ts
@@ -1,0 +1,138 @@
+import { faker } from '@faker-js/faker';
+import { createRequest } from 'node-mocks-http';
+
+import { Application } from '../../domain/HousingApi';
+import { envVarsFixture } from '../../testUtils/envVarsHelper';
+import { ApiRequest } from '../../testUtils/types';
+import {
+  AUTHORISED_ADMIN_GROUP_TEST,
+  AUTHORISED_MANAGER_GROUP_TEST,
+  AUTHORISED_OFFICER_GROUP_TEST,
+  UserRole,
+  generateSignedResidentToken,
+  generateSignedTokenByRole,
+} from '../../testUtils/userHelper';
+import { ApplicationStatus } from '../types/application-status';
+import {
+  canUpdateApplication,
+  hasStaffPermissions,
+  isStaffAction,
+} from './requestAuth';
+
+const req: ApiRequest = createRequest();
+const applicationId = faker.string.uuid();
+
+describe('requestAuth', () => {
+  //testing with real implementations since the current requestAuth structure doesn't allow mocking as usual
+  // due to functions calling other functions within the module without specific export setup
+  const skipTokenVerifyFixture = envVarsFixture('SKIP_VERIFY_TOKEN');
+  const adminGroupFixture = envVarsFixture('AUTHORISED_ADMIN_GROUP');
+  const managerGroupFixture = envVarsFixture('AUTHORISED_MANAGER_GROUP');
+  const officerGroupFixture = envVarsFixture('AUTHORISED_OFFICER_GROUP');
+
+  beforeEach(() => {
+    skipTokenVerifyFixture.mock('true');
+    adminGroupFixture.mock(AUTHORISED_ADMIN_GROUP_TEST);
+    managerGroupFixture.mock(AUTHORISED_MANAGER_GROUP_TEST);
+    officerGroupFixture.mock(AUTHORISED_OFFICER_GROUP_TEST);
+  });
+
+  afterEach(() => {
+    skipTokenVerifyFixture.restore();
+    adminGroupFixture.restore();
+    managerGroupFixture.restore();
+    officerGroupFixture.restore();
+  });
+
+  describe('canUpdateApplication', () => {
+    //member of staff
+    it('returns true when user has staff permissions', () => {
+      const { signedToken } = generateSignedTokenByRole(UserRole.Admin);
+
+      req.headers = {
+        cookie: `hackneyToken=${signedToken}`,
+      };
+
+      expect(canUpdateApplication(req, applicationId)).toBeTruthy();
+    });
+
+    //resident
+    it('returns true when user does not have staff permissions, but have claims to the application with given id', () => {
+      const { signedToken, tokenData } = generateSignedResidentToken();
+
+      req.headers = {
+        cookie: `housing_user=${signedToken}`,
+      };
+
+      expect(canUpdateApplication(req, tokenData.application_id)).toBeTruthy();
+    });
+
+    it('returns false when user does not have staff permissions or correct claims', () => {
+      const { signedToken } = generateSignedResidentToken('random-id');
+
+      req.headers = {
+        cookie: `housing_user=${signedToken}`,
+      };
+
+      expect(canUpdateApplication(req, 'different-id')).toBeFalsy();
+    });
+  });
+
+  describe('hasStaffPermissions', () => {
+    it('returns false when user is not staff member', () => {
+      const { signedToken } = generateSignedResidentToken();
+
+      req.headers = {
+        cookie: `housing_user=${signedToken}`,
+      };
+
+      expect(hasStaffPermissions(req)).toBeFalsy();
+    });
+
+    it('returns false when user is staff member but does not have HR permissions', () => {
+      const { signedToken } = generateSignedTokenByRole();
+      req.headers = {
+        cookie: `hackneyToken=${signedToken}`,
+      };
+
+      expect(hasStaffPermissions(req)).toBeFalsy();
+    });
+  });
+
+  describe('isStaffAction', () => {
+    it('returns true when application is flagged to contain sensitive data', () => {
+      const application: Application = {
+        sensitiveData: true,
+      };
+      expect(isStaffAction(application)).toBeTruthy();
+    });
+
+    it('returns true when application has assessment', () => {
+      const application: Application = {
+        assessment: {
+          reason: 'test',
+        },
+      };
+      expect(isStaffAction(application)).toBeTruthy();
+    });
+
+    it('returns true when application is assigned to staff member', () => {
+      const application: Application = {
+        assignedTo: 'member of staff',
+      };
+      expect(isStaffAction(application)).toBeTruthy();
+    });
+
+    it('returns true when application has status and it is not draft', () => {
+      const application: Application = {
+        status: ApplicationStatus.ACTIVE,
+      };
+      expect(isStaffAction(application)).toBeTruthy();
+    });
+
+    it('returns false when application does not have sensitive data, assessment, assigned to or status set', () => {
+      const application: Application = {};
+      expect(isStaffAction(application)).toBeFalsy();
+    });
+  });
+});

--- a/lib/utils/users.spec.ts
+++ b/lib/utils/users.spec.ts
@@ -1,0 +1,228 @@
+/* eslint-disable import/no-duplicates */
+import { faker } from '@faker-js/faker';
+import cookie from 'cookie';
+import jsonwebtoken from 'jsonwebtoken';
+import jwt from 'jsonwebtoken';
+import { createRequest, createResponse } from 'node-mocks-http';
+
+import { VerifyAuthResponse } from '../../domain/HousingApi';
+import { envVarsFixture } from '../../testUtils/envVarsHelper';
+import { ApiRequest, ApiResponse } from '../../testUtils/types';
+import { generateSignedResidentToken } from '../../testUtils/userHelper';
+import { getUser, removeAuthCookie, setAuthCookie } from './users';
+
+describe('users', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getUser', () => {
+    describe('token parse', () => {
+      it('calls parse on cookie with cookie header value when provided', () => {
+        const parseSpy = jest.spyOn(cookie, 'parse');
+        const req: ApiRequest = createRequest();
+        req.headers = {
+          cookie: `someToken=abc123`,
+        };
+
+        getUser(req);
+
+        expect(parseSpy).toHaveBeenCalledTimes(1);
+        expect(parseSpy).toHaveBeenCalledWith(req.headers.cookie);
+      });
+
+      it('calls parse on cookie with empty string when cookie not present in the header', () => {
+        const parseSpy = jest.spyOn(cookie, 'parse');
+        const req: ApiRequest = createRequest();
+
+        getUser(req);
+
+        expect(parseSpy).toHaveBeenCalledTimes(1);
+        expect(parseSpy).toHaveBeenCalledWith('');
+      });
+
+      it('returns undefined when housing_user cookie not found in the headers', () => {
+        const req: ApiRequest = createRequest();
+        req.headers = {
+          cookie: `someToken=abc123`,
+        };
+
+        expect(getUser(req)).toBeUndefined();
+      });
+    });
+
+    describe('token verification', () => {
+      const secretFixture = envVarsFixture('HACKNEY_JWT_SECRET');
+      const skipTokenVerifyFixture = envVarsFixture('SKIP_VERIFY_TOKEN');
+      const req: ApiRequest = createRequest();
+      const parsedToken = 'abc123';
+      const tokenSecret = 'secret';
+      const verifyFunctionName = 'verify';
+      const decodeFunctionName = 'decode';
+
+      req.headers = {
+        cookie: `housing_user=${parsedToken}`,
+      };
+
+      beforeEach(() => {
+        secretFixture.mock(tokenSecret);
+      });
+
+      afterEach(() => {
+        secretFixture.restore();
+        skipTokenVerifyFixture.restore();
+      });
+
+      it('returns undefined when cookie parse throws JsonWebTokenError', () => {
+        jest.spyOn(cookie, 'parse').mockImplementationOnce(() => {
+          throw new jwt.JsonWebTokenError('token parse error');
+        });
+
+        expect(getUser(req)).toBeUndefined();
+      });
+
+      it('verifies token when SKIP_VERIFY_TOKEN is not set', () => {
+        skipTokenVerifyFixture.delete();
+
+        const verifySpy = jest.spyOn(jsonwebtoken, verifyFunctionName);
+        const decodeSpy = jest.spyOn(jsonwebtoken, decodeFunctionName);
+
+        getUser(req);
+
+        expect(verifySpy).toHaveBeenCalledTimes(1);
+        expect(verifySpy).toHaveBeenCalledWith(parsedToken, tokenSecret);
+        expect(decodeSpy).toHaveBeenCalledTimes(0);
+      });
+
+      it('verifies token when SKIP_VERIFY_TOKEN is set to false', () => {
+        skipTokenVerifyFixture.mock('false');
+
+        const verifySpy = jest.spyOn(jsonwebtoken, verifyFunctionName);
+        const decodeSpy = jest.spyOn(jsonwebtoken, decodeFunctionName);
+
+        getUser(req);
+
+        expect(verifySpy).toHaveBeenCalledTimes(1);
+        expect(verifySpy).toHaveBeenCalledWith(parsedToken, tokenSecret);
+        expect(decodeSpy).toHaveBeenCalledTimes(0);
+      });
+
+      it('does not verify token when SKIP_VERIFY_TOKEN is set to true', () => {
+        skipTokenVerifyFixture.mock('true');
+
+        const verifySpy = jest.spyOn(jsonwebtoken, verifyFunctionName);
+        const decodeSpy = jest.spyOn(jsonwebtoken, decodeFunctionName);
+
+        getUser(req);
+
+        expect(decodeSpy).toHaveBeenCalledTimes(1);
+        expect(decodeSpy).toHaveBeenCalledWith(parsedToken);
+        expect(verifySpy).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe('resident claims', () => {
+      const secretFixture = envVarsFixture('HACKNEY_JWT_SECRET');
+      const skipTokenVerifyFixture = envVarsFixture('SKIP_VERIFY_TOKEN');
+      const tokenSecret = 'secret';
+
+      beforeEach(() => {
+        secretFixture.mock(tokenSecret);
+        skipTokenVerifyFixture.mock('false');
+      });
+
+      afterEach(() => {
+        secretFixture.restore();
+        skipTokenVerifyFixture.restore();
+      });
+
+      it('returns user with correct claims when valid token is provided', () => {
+        const applicationId = faker.string.uuid();
+        const { signedToken } = generateSignedResidentToken(applicationId);
+        const req: ApiRequest = createRequest();
+
+        req.headers = {
+          cookie: `housing_user=${signedToken}`,
+        };
+
+        jest
+          .spyOn(cookie, 'parse')
+          .mockReturnValueOnce({ housing_user: signedToken });
+
+        const user = getUser(req);
+        expect(user?.application_id).toBe(applicationId);
+      });
+    });
+
+    describe('error handling', () => {
+      it('throws when error occurs and it is not JsonWebTokenError', () => {
+        const errorMessage = 'not JsonWebTokenError';
+
+        const parseSpy = jest
+          .spyOn(cookie, 'parse')
+          .mockImplementationOnce(() => {
+            throw new Error(errorMessage);
+          });
+
+        const req: ApiRequest = createRequest();
+
+        expect(() => getUser(req)).toThrow(errorMessage);
+        expect(parseSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('setAuthCookie', () => {
+    const cookieName = 'housing_user';
+    const { signedToken } = generateSignedResidentToken();
+    const domain = '.hackney.gov.uk';
+    const path = '/';
+    const verifyAuthResponse: VerifyAuthResponse = {
+      accessToken: signedToken,
+    };
+    const res: ApiResponse = createResponse();
+
+    it('calls serialize on cookie with correct values', () => {
+      const serializeSpy = jest.spyOn(cookie, 'serialize');
+
+      setAuthCookie(res, verifyAuthResponse);
+
+      expect(serializeSpy).toHaveBeenCalledTimes(1);
+      expect(serializeSpy).toHaveBeenCalledWith(
+        cookieName,
+        verifyAuthResponse.accessToken,
+        {
+          domain,
+          path,
+        }
+      );
+    });
+
+    it('sets Set-Cookie header with correct jwt cookie value', () => {
+      const expectedJWTToken = cookie.serialize(
+        'housing_user',
+        verifyAuthResponse.accessToken,
+        {
+          domain: '.hackney.gov.uk',
+          path: '/',
+        }
+      );
+      setAuthCookie(res, verifyAuthResponse);
+      expect(res.getHeader('Set-Cookie')).toBe(expectedJWTToken);
+    });
+  });
+
+  describe('removeAuthCookie', () => {
+    it('sets correct Set-cookie header', () => {
+      const exp = 'Thu, 01 Jan 1970 00:00:00 GMT';
+
+      const expectedCookie = `housing_user=; Domain=.hackney.gov.uk; Path=/; Expires=${exp}`;
+      const res: ApiResponse = createResponse();
+
+      removeAuthCookie(res);
+
+      const newCookieHeader = res.getHeader('Set-Cookie');
+      expect(newCookieHeader).toBe(expectedCookie);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "lint-staged": "^14.0.1",
         "mocha": "^10.7.3",
         "mockdate": "^3.0.5",
+        "node-mocks-http": "^1.15.1",
         "playwright-webkit": "^1.46.0",
         "prettier": "2.2.1",
         "sass": "^1.32.12",
@@ -3475,11 +3476,54 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
       "dev": true
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -3498,6 +3542,12 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -3568,6 +3618,12 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "14.14.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
@@ -3590,6 +3646,18 @@
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "17.0.5",
@@ -3614,6 +3682,27 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -13560,6 +13649,29 @@
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
     },
+    "node_modules/node-mocks-http": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.15.1.tgz",
+      "integrity": "sha512-X/GpUpNNiPDYUeUD183W8V4OW6OHYWI29w/QDyb+c/GzOfVEAlo6HjbW9++eXT2aV2lGg+uS+XqTD2q0pNREQA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "^4.17.21",
+        "@types/node": "*",
+        "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
@@ -19805,11 +19917,54 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/cookie": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
       "dev": true
+    },
+    "@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
     },
     "@types/graceful-fs": {
       "version": "4.1.9",
@@ -19828,6 +19983,12 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
       }
+    },
+    "@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -19898,6 +20059,12 @@
         "@types/lodash": "*"
       }
     },
+    "@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.14.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
@@ -19920,6 +20087,18 @@
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
+    "@types/qs": {
+      "version": "6.9.15",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
+      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
     },
     "@types/react": {
       "version": "17.0.5",
@@ -19944,6 +20123,27 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
+    },
+    "@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "requires": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -27287,6 +27487,26 @@
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
       "dev": true
+    },
+    "node-mocks-http": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.15.1.tgz",
+      "integrity": "sha512-X/GpUpNNiPDYUeUD183W8V4OW6OHYWI29w/QDyb+c/GzOfVEAlo6HjbW9++eXT2aV2lGg+uS+XqTD2q0pNREQA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "^4.17.21",
+        "@types/node": "*",
+        "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      }
     },
     "node-releases": {
       "version": "2.0.18",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "lint-staged": "^14.0.1",
     "mocha": "^10.7.3",
     "mockdate": "^3.0.5",
+    "node-mocks-http": "^1.15.1",
     "playwright-webkit": "^1.46.0",
     "prettier": "2.2.1",
     "sass": "^1.32.12",

--- a/testUtils/apiHelper.ts
+++ b/testUtils/apiHelper.ts
@@ -1,0 +1,24 @@
+import { RequestMethod, createMocks } from 'node-mocks-http';
+
+import { ApiRequest, ApiResponse } from './types';
+
+interface APIResponseRequest {
+  req: ApiRequest;
+  res: ApiResponse;
+}
+
+export function generateMockRequestResponse(
+  token: string,
+  method: RequestMethod = 'GET'
+): APIResponseRequest {
+  const { req, res }: { req: ApiRequest; res: ApiResponse } = createMocks({
+    method,
+  });
+
+  req.headers = {
+    'content-type': 'Application/json',
+    cookie: `hackneyToken=${token}`,
+  };
+
+  return { req, res };
+}

--- a/testUtils/envVarsHelper.ts
+++ b/testUtils/envVarsHelper.ts
@@ -1,0 +1,15 @@
+export const envVarsFixture = (key: string) => {
+  const initial = process.env[key];
+
+  return {
+    mock: (value: string) => {
+      process.env[key] = value;
+    },
+    restore: () => {
+      process.env[key] = initial;
+    },
+    delete: () => {
+      delete process.env[key];
+    },
+  };
+};

--- a/testUtils/jwtTokenHelper.ts
+++ b/testUtils/jwtTokenHelper.ts
@@ -1,0 +1,19 @@
+import { faker } from '@faker-js/faker';
+
+import { HackneyGoogleUser } from '../domain/HackneyGoogleUser';
+
+const issuedAtInMilliseconds = new Date().getMilliseconds();
+
+export const generateJWTTokenTestData = (
+  groups: string[] = [],
+  issuedAt: number = issuedAtInMilliseconds
+): HackneyGoogleUser => {
+  return {
+    sub: faker.number.int().toString(),
+    email: faker.internet.email(),
+    iss: 'TestIssuer',
+    name: faker.person.fullName(),
+    groups,
+    iat: issuedAt,
+  };
+};

--- a/testUtils/types.ts
+++ b/testUtils/types.ts
@@ -1,0 +1,9 @@
+import { NextApiRequest, NextApiResponse, Redirect } from 'next';
+import { createRequest, createResponse } from 'node-mocks-http';
+
+export type ApiRequest = NextApiRequest & ReturnType<typeof createRequest>;
+export type ApiResponse = NextApiResponse & ReturnType<typeof createResponse>;
+
+export interface GetAuthTestResponse {
+  redirect: Redirect;
+}

--- a/testUtils/userHelper.ts
+++ b/testUtils/userHelper.ts
@@ -3,7 +3,10 @@ import jwt from 'jsonwebtoken';
 
 import { HackneyGoogleUser } from '../domain/HackneyGoogleUser';
 import { HackneyResident } from '../domain/HackneyResident';
-import { HackneyGoogleUserWithPermissions } from '../lib/utils/googleAuth';
+import {
+  HackneyGoogleUserWithPermissions,
+  Permissions,
+} from '../lib/utils/googleAuth';
 import { generateJWTTokenTestData } from './jwtTokenHelper';
 
 export const AUTHORISED_OFFICER_GROUP_TEST = 'authorized-officer-group';
@@ -19,13 +22,6 @@ export enum UserRole {
   Manager,
   Admin,
   ReadOnly,
-}
-
-interface UserClaims {
-  hasAdminPermissions: boolean;
-  hasManagerPermissions: boolean;
-  hasOfficerPermissions: boolean;
-  hasReadOnlyPermissions: boolean;
 }
 
 export const getGroupByRole = (role: UserRole): string => {
@@ -47,48 +43,36 @@ export const getGroupByRole = (role: UserRole): string => {
   }
 };
 
-export const getClaimsByRole = (role?: UserRole): UserClaims => {
+export const getClaimsByRole = (role?: UserRole): Permissions => {
+  const userPermissions: Permissions = {
+    hasAdminPermissions: false,
+    hasManagerPermissions: false,
+    hasOfficerPermissions: false,
+    hasReadOnlyPermissions: false,
+  };
+
   switch (role) {
     case UserRole.ReadOnly: {
-      return {
-        hasAdminPermissions: false,
-        hasManagerPermissions: false,
-        hasOfficerPermissions: false,
-        hasReadOnlyPermissions: true,
-      };
+      userPermissions.hasReadOnlyPermissions = true;
+      break;
     }
     case UserRole.Officer: {
-      return {
-        hasAdminPermissions: false,
-        hasManagerPermissions: false,
-        hasOfficerPermissions: true,
-        hasReadOnlyPermissions: false,
-      };
+      userPermissions.hasOfficerPermissions = true;
+      break;
     }
     case UserRole.Manager: {
-      return {
-        hasAdminPermissions: false,
-        hasManagerPermissions: true,
-        hasOfficerPermissions: false,
-        hasReadOnlyPermissions: false,
-      };
+      userPermissions.hasManagerPermissions = true;
+      break;
     }
     case UserRole.Admin: {
-      return {
-        hasAdminPermissions: true,
-        hasManagerPermissions: false,
-        hasOfficerPermissions: false,
-        hasReadOnlyPermissions: false,
-      };
+      userPermissions.hasAdminPermissions = true;
+      break;
     }
     default:
-      return {
-        hasAdminPermissions: false,
-        hasManagerPermissions: false,
-        hasOfficerPermissions: false,
-        hasReadOnlyPermissions: false,
-      };
+      break;
   }
+
+  return userPermissions;
 };
 
 export const generateHRUserWithPermissions = (

--- a/testUtils/userHelper.ts
+++ b/testUtils/userHelper.ts
@@ -9,6 +9,7 @@ import { generateJWTTokenTestData } from './jwtTokenHelper';
 export const AUTHORISED_OFFICER_GROUP_TEST = 'authorized-officer-group';
 export const AUTHORISED_MANAGER_GROUP_TEST = 'authorized-manager-group';
 export const AUTHORISED_ADMIN_GROUP_TEST = 'authorized-admin-group';
+export const AUTHORISED_READONLY_GROUP_TEST = 'authorized-readonly-group';
 export const JWT_TEST_SECRET = 'secret';
 
 const issuedAtInMilliseconds = new Date().getMilliseconds();
@@ -17,16 +18,21 @@ export enum UserRole {
   Officer,
   Manager,
   Admin,
+  ReadOnly,
 }
 
 interface UserClaims {
   hasAdminPermissions: boolean;
   hasManagerPermissions: boolean;
   hasOfficerPermissions: boolean;
+  hasReadOnlyPermissions: boolean;
 }
 
 export const getGroupByRole = (role: UserRole): string => {
   switch (role) {
+    case UserRole.ReadOnly: {
+      return AUTHORISED_READONLY_GROUP_TEST;
+    }
     case UserRole.Officer: {
       return AUTHORISED_OFFICER_GROUP_TEST;
     }
@@ -43,11 +49,20 @@ export const getGroupByRole = (role: UserRole): string => {
 
 export const getClaimsByRole = (role?: UserRole): UserClaims => {
   switch (role) {
+    case UserRole.ReadOnly: {
+      return {
+        hasAdminPermissions: false,
+        hasManagerPermissions: false,
+        hasOfficerPermissions: false,
+        hasReadOnlyPermissions: true,
+      };
+    }
     case UserRole.Officer: {
       return {
         hasAdminPermissions: false,
         hasManagerPermissions: false,
         hasOfficerPermissions: true,
+        hasReadOnlyPermissions: false,
       };
     }
     case UserRole.Manager: {
@@ -55,6 +70,7 @@ export const getClaimsByRole = (role?: UserRole): UserClaims => {
         hasAdminPermissions: false,
         hasManagerPermissions: true,
         hasOfficerPermissions: false,
+        hasReadOnlyPermissions: false,
       };
     }
     case UserRole.Admin: {
@@ -62,6 +78,7 @@ export const getClaimsByRole = (role?: UserRole): UserClaims => {
         hasAdminPermissions: true,
         hasManagerPermissions: false,
         hasOfficerPermissions: false,
+        hasReadOnlyPermissions: false,
       };
     }
     default:
@@ -69,6 +86,7 @@ export const getClaimsByRole = (role?: UserRole): UserClaims => {
         hasAdminPermissions: false,
         hasManagerPermissions: false,
         hasOfficerPermissions: false,
+        hasReadOnlyPermissions: false,
       };
   }
 };
@@ -95,7 +113,8 @@ export const generateSignedTokenByRole = (
   switch (role) {
     case UserRole.Admin:
     case UserRole.Manager:
-    case UserRole.Officer: {
+    case UserRole.Officer:
+    case UserRole.ReadOnly: {
       const tokenData = generateJWTTokenTestData(
         [getGroupByRole(role)],
         issuedAtInMilliseconds

--- a/testUtils/userHelper.ts
+++ b/testUtils/userHelper.ts
@@ -1,0 +1,141 @@
+import { faker } from '@faker-js/faker';
+import jwt from 'jsonwebtoken';
+
+import { HackneyGoogleUser } from '../domain/HackneyGoogleUser';
+import { HackneyResident } from '../domain/HackneyResident';
+import { HackneyGoogleUserWithPermissions } from '../lib/utils/googleAuth';
+import { generateJWTTokenTestData } from './jwtTokenHelper';
+
+export const AUTHORISED_OFFICER_GROUP_TEST = 'authorized-officer-group';
+export const AUTHORISED_MANAGER_GROUP_TEST = 'authorized-manager-group';
+export const AUTHORISED_ADMIN_GROUP_TEST = 'authorized-admin-group';
+export const JWT_TEST_SECRET = 'secret';
+
+const issuedAtInMilliseconds = new Date().getMilliseconds();
+
+export enum UserRole {
+  Officer,
+  Manager,
+  Admin,
+}
+
+interface UserClaims {
+  hasAdminPermissions: boolean;
+  hasManagerPermissions: boolean;
+  hasOfficerPermissions: boolean;
+}
+
+export const getGroupByRole = (role: UserRole): string => {
+  switch (role) {
+    case UserRole.Officer: {
+      return AUTHORISED_OFFICER_GROUP_TEST;
+    }
+    case UserRole.Manager: {
+      return AUTHORISED_MANAGER_GROUP_TEST;
+    }
+    case UserRole.Admin: {
+      return AUTHORISED_ADMIN_GROUP_TEST;
+    }
+    default:
+      return '';
+  }
+};
+
+export const getClaimsByRole = (role?: UserRole): UserClaims => {
+  switch (role) {
+    case UserRole.Officer: {
+      return {
+        hasAdminPermissions: false,
+        hasManagerPermissions: false,
+        hasOfficerPermissions: true,
+      };
+    }
+    case UserRole.Manager: {
+      return {
+        hasAdminPermissions: false,
+        hasManagerPermissions: true,
+        hasOfficerPermissions: false,
+      };
+    }
+    case UserRole.Admin: {
+      return {
+        hasAdminPermissions: true,
+        hasManagerPermissions: false,
+        hasOfficerPermissions: false,
+      };
+    }
+    default:
+      return {
+        hasAdminPermissions: false,
+        hasManagerPermissions: false,
+        hasOfficerPermissions: false,
+      };
+  }
+};
+
+export const generateHRUserWithPermissions = (
+  role?: UserRole
+): HackneyGoogleUserWithPermissions => {
+  const userRole = role ? getGroupByRole(role) : '';
+
+  return {
+    ...generateJWTTokenTestData([userRole]),
+    ...getClaimsByRole(role),
+  };
+};
+
+type SignedTokenWithDetails = {
+  signedToken: string;
+  tokenData: HackneyGoogleUser;
+};
+
+export const generateSignedTokenByRole = (
+  role?: UserRole
+): SignedTokenWithDetails => {
+  switch (role) {
+    case UserRole.Admin:
+    case UserRole.Manager:
+    case UserRole.Officer: {
+      const tokenData = generateJWTTokenTestData(
+        [getGroupByRole(role)],
+        issuedAtInMilliseconds
+      );
+      const signedToken = jwt.sign(tokenData, JWT_TEST_SECRET);
+
+      return {
+        signedToken,
+        tokenData,
+      };
+    }
+    default: {
+      const tokenData = generateJWTTokenTestData([], issuedAtInMilliseconds);
+      const signedToken = jwt.sign(tokenData, JWT_TEST_SECRET);
+
+      return {
+        signedToken,
+        tokenData,
+      };
+    }
+  }
+};
+
+type SignedResidentTokenWithDetails = {
+  signedToken: string;
+  tokenData: HackneyResident;
+};
+
+export const generateSignedResidentToken = (
+  applicationId?: string
+): SignedResidentTokenWithDetails => {
+  const id = applicationId || faker.string.uuid();
+  const tokenData: HackneyResident = {
+    application_id: id,
+  };
+
+  return {
+    signedToken: jwt.sign(tokenData, JWT_TEST_SECRET),
+    tokenData: {
+      application_id: id,
+    },
+  };
+};


### PR DESCRIPTION
## WHAT
Add test coverage for googleAuth and related functions.

Files covered:
1. lib/utils/googleAuth.spec.ts
2. lib/utils/requestAuth.spec.ts
3. lib/utils/users.spec.ts

## WHY
Currently we don't have any test coverage for the functions involved in authentication. In order to develop the application further we need to add appropriate test coverage for the functions and components we modify. 

This adds baseline test coverage for the functions that are involved in authentication.

## HOW
Please note these tests are not opinionated about the current implementation, but cover the functionality as is. 

`requestAuth.ts` tests are lacking some mock setups due to the module structure which makes it difficult. Since this initial update is done without any refactoring or changes to the implementation this function is tested mainly against real implementatations.

jest and lint configs have been updated to ignore the new `testUtils` folder. Also some linting overrides have been added to test helpers to overcome some import issues that we haven't been able resolve in any other way yet. 