### PR TITLE
FE Features

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ workflows:
           browser: chrome
           filters:
             branches:
-              only: development
+              only: TS-1558-Housing-reg-view-only-Hide-edit-button-from-application-overview
       - run-cypress-e2e:
           name: E2E Tests - Firefox
           browser: firefox
@@ -180,7 +180,7 @@ workflows:
             - install-dependencies
           filters:
             branches:
-              only: development
+              only: TS-1558-Housing-reg-view-only-Hide-edit-button-from-application-overview
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ workflows:
           browser: chrome
           filters:
             branches:
-              only: TS-1558-Housing-reg-view-only-Hide-edit-button-from-application-overview
+              only: development
       - run-cypress-e2e:
           name: E2E Tests - Firefox
           browser: firefox
@@ -180,7 +180,7 @@ workflows:
             - install-dependencies
           filters:
             branches:
-              only: TS-1558-Housing-reg-view-only-Hide-edit-button-from-application-overview
+              only: development
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,9 @@ jobs:
           install-command: npm install
           post-install: npm run build
       - cypress/run-tests:
-          # start-command: npm run start
           cypress-command: npx cypress run --browser=<< parameters.browser >> --reporter cypress-circleci-reporter
       - store_test_results:
-          path: TS-1558-Housing-reg-view-only-Hide-edit-button-from-application-overview
+          path: test_results
 
   build-deploy-development:
     executor: aws-cli/default
@@ -173,7 +172,7 @@ workflows:
           browser: chrome
           filters:
             branches:
-              only: development
+              only: TS-1558-Housing-reg-view-only-Hide-edit-button-from-application-overview
       - run-cypress-e2e:
           name: E2E Tests - Firefox
           browser: firefox
@@ -181,7 +180,7 @@ workflows:
             - install-dependencies
           filters:
             branches:
-              only: development
+              only: TS-1558-Housing-reg-view-only-Hide-edit-button-from-application-overview
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ executors:
   docker-python:
     docker:
       - image: circleci/python:3.7
+  cypress-e2e-executor:
+    docker:
+      - image: cimg/node:18.20-browsers
 
 references:
   workspace_root: &workspace_root '~'
@@ -70,7 +73,7 @@ jobs:
       - sonarcloud/scan
 
   run-cypress-e2e:
-    executor: node-executor
+    executor: cypress-e2e-executor
     parameters:
       browser:
         type: string
@@ -82,10 +85,10 @@ jobs:
           install-command: npm install
           post-install: npm run build
       - cypress/run-tests:
-          start-command: npm run start
+          # start-command: npm run start
           cypress-command: npx cypress run --browser=<< parameters.browser >> --reporter cypress-circleci-reporter
       - store_test_results:
-          path: test_results
+          path: TS-1558-Housing-reg-view-only-Hide-edit-button-from-application-overview
 
   build-deploy-development:
     executor: aws-cli/default

--- a/.env.sample
+++ b/.env.sample
@@ -8,8 +8,19 @@ NEXT_PUBLIC_ENV=localdev
 # Hackney sign in (Google Auth)
 SKIP_VERIFY_TOKEN=true
 HACKNEY_JWT_SECRET=
-AUTHORISED_ADMIN_GROUP=
 APP_URL=http://localdev.hackney.gov.uk:3000
+
+# Testing locally with cypress it's best to use a unique var for groups. Value is not important.
+# AUTHORISED_ADMIN_GROUP=admin-group
+# AUTHORISED_MANAGER_GROUP=manager-group
+# AUTHORISED_OFFICER_GROUP=officer-group
+# AUTHORISED_READONLY_GROUP=read-only-group
+
+# If testing locally against your own token best to use a value you already have in your group token.
+# AUTHORISED_ADMIN_GROUP=
+# AUTHORISED_MANAGER_GROUP=
+# AUTHORISED_OFFICER_GROUP=
+# AUTHORISED_READONLY_GROUP=
 
 # Housing Register API
 HOUSING_REGISTER_API="http://localhost:5000/api"

--- a/components/admin/ApplicationHistory.tsx
+++ b/components/admin/ApplicationHistory.tsx
@@ -1,37 +1,36 @@
 import React from 'react';
+
 import { Form, Formik, FormikValues } from 'formik';
-import { diff } from 'nested-object-diff';
+import router from 'next/router';
 import * as Yup from 'yup';
+
+import { ActivityHistoryPagedResult } from '../../domain/ActivityHistoryApi';
+import { addNoteToHistory } from '../../lib/gateways/internal-api';
+import Button from '../button';
+import { HeadingFour, HeadingThree } from '../content/headings';
+import Textarea from '../form/textarea';
 import {
-  ActivityEntity,
-  ActivityHistoryPagedResult,
-  ActivityHistoryResponse,
-  ApplicationActivityType,
-  IActivityEntity,
-} from '../../domain/ActivityHistoryApi';
-import { ApplicationStatus } from '../../lib/types/application-status';
-import {
+  SummaryListKey,
   SummaryListNoBorder,
   SummaryListRow,
-  SummaryListKey,
   SummaryListValue,
 } from '../summary-list';
-import { HeadingThree, HeadingFour } from '../content/headings';
-import { addNoteToHistory } from '../../lib/gateways/internal-api';
-import Textarea from '../form/textarea';
-import Button from '../button';
-import router from 'next/router';
-import Details from '../details';
-import { reasonOptions } from '../../lib/utils/assessmentActionsData';
+import {
+  getFormattedDate,
+  renderBody,
+  renderHeading,
+} from './utils/ApplicationHistoryHelpers';
 
 interface ActivityHistoryPageProps {
   history: ActivityHistoryPagedResult;
   id: string;
+  showDetails?: boolean;
 }
 
 export default function ApplicationHistory({
   history,
   id,
+  showDetails,
 }: ActivityHistoryPageProps): JSX.Element | null {
   const initialValues: FormikValues = {
     note: '',
@@ -43,8 +42,8 @@ export default function ApplicationHistory({
 
   const listItems = history
     ? history.results.map((historyItem, index) => {
-        const heading = renderHeading(historyItem);
-        const body = renderBody(historyItem);
+        const heading = renderHeading(historyItem) as unknown;
+        const body = showDetails ? renderBody(historyItem) : null;
         const createdAt = getFormattedDate(historyItem.createdAt);
 
         return (
@@ -85,16 +84,17 @@ export default function ApplicationHistory({
               onSubmit={onSubmit}
               validationSchema={addNoteSchema}
             >
-              {({ isSubmitting, errors, isValid }) => {
+              {({
+                isSubmitting,
+                // , errors, isValid
+              }) => {
                 return (
-                  <>
-                    <Form>
-                      <Textarea name="note" label="" as="textarea" />
-                      <Button disabled={isSubmitting} type="submit">
-                        Save note
-                      </Button>
-                    </Form>
-                  </>
+                  <Form>
+                    <Textarea name="note" label="" as="textarea" />
+                    <Button disabled={isSubmitting} type="submit">
+                      Save note
+                    </Button>
+                  </Form>
                 );
               }}
             </Formik>
@@ -102,318 +102,19 @@ export default function ApplicationHistory({
         </SummaryListRow>
       </SummaryListNoBorder>
       {listItems ? (
-        <>
-          <SummaryListNoBorder>
-            <SummaryListRow>
-              <SummaryListKey>
-                <HeadingThree content="History" />
-              </SummaryListKey>
-              <SummaryListValue>
-                <ol className="lbh-timeline">{listItems}</ol>
-              </SummaryListValue>
-            </SummaryListRow>
-          </SummaryListNoBorder>
-        </>
+        <SummaryListNoBorder>
+          <SummaryListRow>
+            <SummaryListKey>
+              <HeadingThree content="History" />
+            </SummaryListKey>
+            <SummaryListValue>
+              <ol className="lbh-timeline">{listItems}</ol>
+            </SummaryListValue>
+          </SummaryListRow>
+        </SummaryListNoBorder>
       ) : (
         <HeadingThree content="No history to show" />
       )}
     </>
   );
 }
-
-function renderHeading(item: ActivityHistoryResponse) {
-  const historyItem = new ActivityEntity(item);
-  const activityText: {
-    [key in ApplicationActivityType]: (activity: IActivityEntity) => {};
-  } = {
-    [ApplicationActivityType.AssignedToChangedByUser]: assignedToChangedByUser,
-    [ApplicationActivityType.BandChangedByUser]: bandChangedByUser,
-    [ApplicationActivityType.BedroomNeedChangedByUser]:
-      bedroomNeedChangedByUser,
-    [ApplicationActivityType.BiddingNumberChangedByUser]:
-      biddingNumberChangedByUser,
-    [ApplicationActivityType.CaseViewedByUser]: caseViewedByUser,
-    [ApplicationActivityType.Created]: created,
-    [ApplicationActivityType.EffectiveDateChangedByUser]:
-      effectiveDateChangedByUser,
-    [ApplicationActivityType.HouseholdApplicantChangedByUser]:
-      householdApplicantChangedByUser,
-    [ApplicationActivityType.HouseholdApplicantRemovedByUser]:
-      householdApplicantRemovedByUser,
-    [ApplicationActivityType.ImportedFromLegacyDatabase]:
-      importedFromLegacyDatabase,
-    [ApplicationActivityType.InformationReceivedDateChangedByUser]:
-      informationReceivedDateChangedByUser,
-    [ApplicationActivityType.MainApplicantChangedByUser]:
-      mainApplicantChangedByUser,
-    [ApplicationActivityType.NoteAddedByUser]: noteAddedByUser,
-    [ApplicationActivityType.SensitivityChangedByUser]:
-      sensitivityChangedByUser,
-    [ApplicationActivityType.StatusChangedByUser]: statusChangedByUser,
-    [ApplicationActivityType.SubmittedByResident]: submittedByResident,
-  };
-
-  const functionDelegate =
-    activityText[capitalizeFirstLetter(historyItem.activityType)];
-
-  if (functionDelegate) {
-    return functionDelegate(historyItem);
-  }
-}
-
-function renderBody(item: ActivityHistoryResponse) {
-  const skipActivityType = [
-    'Created',
-    'SensitivityChangedByUser',
-    'StatusChangedByUser',
-    'SubmittedByResident',
-  ].includes(capitalizeFirstLetter(item.newData._activityType));
-
-  if (skipActivityType) return;
-
-  const historyItem = new ActivityEntity(item);
-
-  if (!historyItem.newData.activityData) {
-    const differences = diff(historyItem.newData, historyItem.oldData);
-
-    interface Difference {
-      type: string;
-      path: string;
-      lhs: any;
-      rhs: any;
-    }
-
-    return (
-      <Details summary="Show details">
-        <>
-          <table className="govuk-table lbh-table lbh-table--small">
-            <thead className="govuk-table__head">
-              <tr className="govuk-table__row">
-                <th className="govuk-table__header">Field</th>
-                <th className="govuk-table__header">Old value</th>
-                <th className="govuk-table__header">New value</th>
-              </tr>
-            </thead>
-            <tbody className="govuk-table__body">
-              {differences.map((difference: Difference, index: number) => {
-                let { path, lhs, rhs } = difference;
-
-                if (path === '_activityType') return;
-
-                if (path === 'assessment.reason') {
-                  lhs = getReasonFromActivity(lhs);
-                  rhs = getReasonFromActivity(rhs);
-                }
-
-                if (
-                  path === 'assessment.effectiveDate' ||
-                  path === 'assessment.informationReceivedDate'
-                ) {
-                  lhs = getFormattedDate(lhs);
-                  rhs = getFormattedDate(rhs);
-                }
-
-                if (typeof rhs === 'object' || typeof lhs === 'object') {
-                  lhs = JSON.stringify(lhs, undefined, 2);
-                  rhs = JSON.stringify(rhs, undefined, 2);
-
-                  lhs = lhs ? lhs.replace(/\\"/g, '') : '';
-                  rhs = rhs ? rhs.replace(/\\"/g, '') : '';
-                }
-                if (path != 'person.id') {
-                  return (
-                    <tr key={index} className="govuk-table__row">
-                      <td className="govuk-table__cell">{path}</td>
-                      <td className="govuk-table__cell lbh-!-break-word">
-                        <pre className="lbh-audit-history-json">{rhs}</pre>
-                      </td>
-                      <td className="govuk-table__cell lbh-!-break-word">
-                        <pre className="lbh-audit-history-json">{lhs}</pre>
-                      </td>
-                    </tr>
-                  );
-                }
-              })}
-            </tbody>
-          </table>
-        </>
-      </Details>
-    );
-  }
-
-  if (!historyItem.newData.activityData) return false;
-
-  return (
-    <Details summary="Show details">{historyItem.newData.activityData}</Details>
-  );
-}
-
-const getFormattedDate = (
-  dateString: string | null,
-  excludeTime: boolean = false
-) => {
-  if (dateString == null) {
-    return '';
-  }
-
-  let options: any = {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-  };
-
-  if (excludeTime) {
-    options = { year: 'numeric', month: 'short', day: 'numeric' };
-  }
-
-  const dateFormat = new Date(dateString).toLocaleString('en-GB', options);
-  return dateFormat;
-};
-
-const getReasonFromActivity = (reason: string | undefined) => {
-  return reasonOptions.find(
-    (option: { value: string; label: string }) => option.value === reason
-  )?.label;
-};
-
-const capitalizeFirstLetter = (string: any): ApplicationActivityType => {
-  return string.charAt(0).toUpperCase() + string.slice(1);
-};
-
-const assignedToChangedByUser = (activity: IActivityEntity) => {
-  return (
-    <>
-      Assigned to '{activity.newData.assignedTo}' by{' '}
-      {activity.oldData.assignedTo}
-    </>
-  );
-};
-
-const bandChangedByUser = (activity: IActivityEntity) => {
-  return <>Band changed by {activity.authorDetails.fullName}</>;
-};
-
-const bedroomNeedChangedByUser = (activity: IActivityEntity) => {
-  return (
-    <>
-      Bedroom need changed from '{activity.oldData.assessment?.bedroomNeed}' to
-      '{activity.newData.assessment?.bedroomNeed}' by{' '}
-      {activity.authorDetails.fullName}
-    </>
-  );
-};
-
-const biddingNumberChangedByUser = (activity: IActivityEntity) => {
-  return <>Bidding number changed by {activity.authorDetails.fullName}</>;
-};
-
-const caseViewedByUser = (activity: IActivityEntity) => {
-  return <>Case viewed by {activity.authorDetails.fullName}</>;
-};
-
-const created = (activity: IActivityEntity) => {
-  return <>Application created by {activity.authorDetails.fullName}</>;
-};
-
-const effectiveDateChangedByUser = (activity: IActivityEntity) => {
-  return (
-    <>
-      Application date changed from '
-      {getFormattedDate(
-        activity.oldData.assessment?.effectiveDate ?? null,
-        true
-      )}
-      ' to '
-      {getFormattedDate(
-        activity.newData.assessment?.effectiveDate ?? null,
-        true
-      )}
-      ' by {activity.authorDetails.fullName}
-    </>
-  );
-};
-
-const householdApplicantChangedByUser = (activity: IActivityEntity) => {
-  return <>Household applicant changed by {activity.authorDetails.fullName}</>;
-};
-
-const householdApplicantRemovedByUser = (activity: IActivityEntity) => {
-  const householdMember = Object.values(activity.oldData)[0] as any;
-  return (
-    <>
-      Household applicant: "{householdMember?.person?.fullName}" removed by{' '}
-      {activity.authorDetails.fullName}
-    </>
-  );
-};
-
-const importedFromLegacyDatabase = () => {
-  return <>Imported from legacy database</>;
-};
-
-const informationReceivedDateChangedByUser = (activity: IActivityEntity) => {
-  return (
-    <>
-      Information received date changed from '
-      {getFormattedDate(
-        activity.oldData.assessment?.informationReceivedDate ?? null,
-        true
-      )}
-      ' to '
-      {getFormattedDate(
-        activity.newData.assessment?.informationReceivedDate ?? null,
-        true
-      )}
-      ' by {activity.authorDetails.fullName}
-    </>
-  );
-};
-
-const mainApplicantChangedByUser = (activity: IActivityEntity) => {
-  return <>Main applicant changed by {activity.authorDetails.fullName}</>;
-};
-
-const noteAddedByUser = (activity: IActivityEntity) => {
-  return <>Note added by {activity.authorDetails.fullName}</>;
-};
-
-const sensitivityChangedByUser = (activity: IActivityEntity) => {
-  return <>Marked as sensitive by {activity.authorDetails.fullName}</>;
-};
-
-const submittedByResident = (activity: IActivityEntity) => {
-  return <>Application submitted by {activity.authorDetails.fullName}</>;
-};
-
-const statusChangedByUser = (activity: IActivityEntity) => {
-  let message = (
-    <>
-      Status changed from '{activity.oldData.status}' to '
-      {activity.newData.status}' by {activity.authorDetails.fullName}
-      <br></br> Reason:{' '}
-      {getReasonFromActivity(activity.newData.assessment?.reason)}
-    </>
-  );
-
-  if (activity.newData.status == ApplicationStatus.ACTIVE) {
-    message = (
-      <>
-        Case activated in band with reason: '
-        {activity.newData.assessment?.reason}' by{' '}
-        {activity.authorDetails.fullName}
-      </>
-    );
-  } else if (activity.newData.status == ApplicationStatus.REJECTED) {
-    // Just a placeholder, we need to distinuish between user and system rejection
-    message = (
-      <>
-        Case automatically rejected by system with reason: '
-        {activity.newData.assessment?.reason}'
-      </>
-    );
-  }
-
-  return message;
-};

--- a/components/admin/other-members.tsx
+++ b/components/admin/other-members.tsx
@@ -1,12 +1,13 @@
-import { Applicant } from '../../domain/HousingApi';
-import { ButtonLink } from '../button';
-import { formatDob } from '../../lib/utils/dateOfBirth';
 import React, { useState } from 'react';
-import { HeadingThree } from '../content/headings';
-import { getGenderName } from '../../lib/utils/gender';
+
+import { Applicant } from '../../domain/HousingApi';
 import capitalize from '../../lib/utils/capitalize';
-import Dialog from '../dialog';
+import { formatDob } from '../../lib/utils/dateOfBirth';
+import { getGenderName } from '../../lib/utils/gender';
+import { ButtonLink } from '../button';
+import { HeadingThree } from '../content/headings';
 import Paragraph from '../content/paragraph';
+import Dialog from '../dialog';
 
 interface SummaryProps {
   heading: string;
@@ -61,13 +62,14 @@ export default function OtherMembers({
                       capitalize(applicant.person?.relationshipType)}
                   </li>
                 </ul>
-
-                <button
-                  onClick={() => handleDeleteDialog(applicant)}
-                  className="lbh-body-s lbh-link lbh-link--no-visited-state lbh-delete-link"
-                >
-                  Remove household member
-                </button>
+                {canEdit && (
+                  <button
+                    onClick={() => handleDeleteDialog(applicant)}
+                    className="lbh-body-s lbh-link lbh-link--no-visited-state lbh-delete-link"
+                  >
+                    Remove household member
+                  </button>
+                )}
 
                 <Dialog
                   isOpen={showDeleteWarningDialog}

--- a/components/admin/utils/ApplicationHistoryHelpers.tsx
+++ b/components/admin/utils/ApplicationHistoryHelpers.tsx
@@ -1,0 +1,315 @@
+import React from 'react';
+
+import { diff } from 'nested-object-diff';
+
+import {
+  ActivityEntity,
+  ActivityHistoryResponse,
+  ApplicationActivityType,
+  IActivityEntity,
+} from '../../../domain/ActivityHistoryApi';
+import { ApplicationStatus } from '../../../lib/types/application-status';
+import { reasonOptions } from '../../../lib/utils/assessmentActionsData';
+import Details from '../../details';
+
+interface IHouseholdMember {
+  person: {
+    fullName: string;
+  };
+}
+interface Difference {
+  type: string;
+  path: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  lhs: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rhs: any;
+}
+
+const getReasonFromActivity = (reason: string | undefined) => {
+  return reasonOptions.find(
+    (option: { value: string; label: string }) => option.value === reason
+  )?.label;
+};
+
+const capitalizeFirstLetter = (string: string): ApplicationActivityType => {
+  return (string.charAt(0).toUpperCase() +
+    string.slice(1)) as ApplicationActivityType;
+};
+
+const assignedToChangedByUser = (activity: IActivityEntity) => {
+  return (
+    <>
+      Assigned to '{activity.newData.assignedTo}' by{' '}
+      {activity.oldData.assignedTo}
+    </>
+  );
+};
+
+const bandChangedByUser = (activity: IActivityEntity) => {
+  return <>Band changed by {activity.authorDetails.fullName}</>;
+};
+
+const bedroomNeedChangedByUser = (activity: IActivityEntity) => {
+  return (
+    <>
+      Bedroom need changed from '{activity.oldData.assessment?.bedroomNeed}' to
+      '{activity.newData.assessment?.bedroomNeed}' by{' '}
+      {activity.authorDetails.fullName}
+    </>
+  );
+};
+
+const biddingNumberChangedByUser = (activity: IActivityEntity) => {
+  return <>Bidding number changed by {activity.authorDetails.fullName}</>;
+};
+
+const caseViewedByUser = (activity: IActivityEntity) => {
+  return <>Case viewed by {activity.authorDetails.fullName}</>;
+};
+
+const created = (activity: IActivityEntity) => {
+  return <>Application created by {activity.authorDetails.fullName}</>;
+};
+
+export const getFormattedDate = (
+  dateString: string | null,
+  excludeTime = false
+) => {
+  if (dateString == null) {
+    return '';
+  }
+
+  let options: Record<string, unknown> = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  };
+
+  if (excludeTime) {
+    options = { year: 'numeric', month: 'short', day: 'numeric' };
+  }
+
+  const dateFormat = new Date(dateString).toLocaleString('en-GB', options);
+  return dateFormat;
+};
+
+const effectiveDateChangedByUser = (activity: IActivityEntity) => {
+  return (
+    <>
+      Application date changed from '
+      {getFormattedDate(
+        activity.oldData.assessment?.effectiveDate ?? null,
+        true
+      )}
+      ' to '
+      {getFormattedDate(
+        activity.newData.assessment?.effectiveDate ?? null,
+        true
+      )}
+      ' by {activity.authorDetails.fullName}
+    </>
+  );
+};
+
+const householdApplicantChangedByUser = (activity: IActivityEntity) => {
+  return <>Household applicant changed by {activity.authorDetails.fullName}</>;
+};
+
+const householdApplicantRemovedByUser = (activity: IActivityEntity) => {
+  const householdMember = Object.values(
+    activity.oldData
+  )[0] as IHouseholdMember;
+  return (
+    <>
+      Household applicant: "{householdMember.person.fullName}" removed by{' '}
+      {activity.authorDetails.fullName}
+    </>
+  );
+};
+
+const importedFromLegacyDatabase = () => {
+  return <>Imported from legacy database</>;
+};
+
+const informationReceivedDateChangedByUser = (activity: IActivityEntity) => {
+  return (
+    <>
+      Information received date changed from '
+      {getFormattedDate(
+        activity.oldData.assessment?.informationReceivedDate ?? null,
+        true
+      )}
+      ' to '
+      {getFormattedDate(
+        activity.newData.assessment?.informationReceivedDate ?? null,
+        true
+      )}
+      ' by {activity.authorDetails.fullName}
+    </>
+  );
+};
+
+const mainApplicantChangedByUser = (activity: IActivityEntity) => {
+  return <>Main applicant changed by {activity.authorDetails.fullName}</>;
+};
+
+const noteAddedByUser = (activity: IActivityEntity) => {
+  return <>Note added by {activity.authorDetails.fullName}</>;
+};
+
+const sensitivityChangedByUser = (activity: IActivityEntity) => {
+  return <>Marked as sensitive by {activity.authorDetails.fullName}</>;
+};
+
+const submittedByResident = (activity: IActivityEntity) => {
+  return <>Application submitted by {activity.authorDetails.fullName}</>;
+};
+
+const statusChangedByUser = (activity: IActivityEntity) => {
+  let message = (
+    <>
+      Status changed from '{activity.oldData.status}' to '
+      {activity.newData.status}' by {activity.authorDetails.fullName}
+      <br /> Reason:{' '}
+      {getReasonFromActivity(activity.newData.assessment?.reason)}
+    </>
+  );
+
+  if (activity.newData.status === ApplicationStatus.ACTIVE) {
+    message = (
+      <>
+        Case activated in band with reason: '
+        {activity.newData.assessment?.reason}' by{' '}
+        {activity.authorDetails.fullName}
+      </>
+    );
+  } else if (activity.newData.status === ApplicationStatus.REJECTED) {
+    // Just a placeholder, we need to distinuish between user and system rejection
+    message = (
+      <>
+        Case automatically rejected by system with reason: '
+        {activity.newData.assessment?.reason}'
+      </>
+    );
+  }
+
+  return message;
+};
+
+export function renderHeading(item: ActivityHistoryResponse) {
+  const historyItem = new ActivityEntity(item);
+  const activityText: {
+    [key in ApplicationActivityType]: (
+      activity: IActivityEntity
+    ) => JSX.Element;
+  } = {
+    [ApplicationActivityType.AssignedToChangedByUser]: assignedToChangedByUser,
+    [ApplicationActivityType.BandChangedByUser]: bandChangedByUser,
+    [ApplicationActivityType.BedroomNeedChangedByUser]: bedroomNeedChangedByUser,
+    [ApplicationActivityType.BiddingNumberChangedByUser]: biddingNumberChangedByUser,
+    [ApplicationActivityType.CaseViewedByUser]: caseViewedByUser,
+    [ApplicationActivityType.Created]: created,
+    [ApplicationActivityType.EffectiveDateChangedByUser]: effectiveDateChangedByUser,
+    [ApplicationActivityType.HouseholdApplicantChangedByUser]: householdApplicantChangedByUser,
+    [ApplicationActivityType.HouseholdApplicantRemovedByUser]: householdApplicantRemovedByUser,
+    [ApplicationActivityType.ImportedFromLegacyDatabase]: importedFromLegacyDatabase,
+    [ApplicationActivityType.InformationReceivedDateChangedByUser]: informationReceivedDateChangedByUser,
+    [ApplicationActivityType.MainApplicantChangedByUser]: mainApplicantChangedByUser,
+    [ApplicationActivityType.NoteAddedByUser]: noteAddedByUser,
+    [ApplicationActivityType.SensitivityChangedByUser]: sensitivityChangedByUser,
+    [ApplicationActivityType.StatusChangedByUser]: statusChangedByUser,
+    [ApplicationActivityType.SubmittedByResident]: submittedByResident,
+  };
+
+  const functionDelegate =
+    activityText[capitalizeFirstLetter(historyItem.activityType)];
+
+  if (functionDelegate) {
+    return functionDelegate(historyItem);
+  }
+}
+
+export function renderBody(item: ActivityHistoryResponse) {
+  const skipActivityType = [
+    'Created',
+    'SensitivityChangedByUser',
+    'StatusChangedByUser',
+    'SubmittedByResident',
+  ].includes(capitalizeFirstLetter(item.newData._activityType));
+
+  if (skipActivityType) return;
+
+  // if (readOnly) return;
+
+  const historyItem = new ActivityEntity(item);
+
+  if (!historyItem.newData.activityData) {
+    const differences = diff(historyItem.newData, historyItem.oldData);
+
+    return (
+      <Details summary="Show details">
+        <table className="govuk-table lbh-table lbh-table--small">
+          <thead className="govuk-table__head">
+            <tr className="govuk-table__row">
+              <th className="govuk-table__header">Field</th>
+              <th className="govuk-table__header">Old value</th>
+              <th className="govuk-table__header">New value</th>
+            </tr>
+          </thead>
+          <tbody className="govuk-table__body">
+            {differences.map((difference: Difference, index: number) => {
+              const { path } = difference;
+              let { lhs, rhs } = difference;
+
+              if (path === '_activityType') return;
+
+              if (path === 'assessment.reason') {
+                lhs = getReasonFromActivity(lhs);
+                rhs = getReasonFromActivity(rhs);
+              }
+
+              if (
+                path === 'assessment.effectiveDate' ||
+                path === 'assessment.informationReceivedDate'
+              ) {
+                lhs = getFormattedDate(lhs);
+                rhs = getFormattedDate(rhs);
+              }
+
+              if (typeof rhs === 'object' || typeof lhs === 'object') {
+                lhs = JSON.stringify(lhs, undefined, 2);
+                rhs = JSON.stringify(rhs, undefined, 2);
+
+                lhs = lhs ? lhs.replace(/\\"/g, '') : '';
+                rhs = rhs ? rhs.replace(/\\"/g, '') : '';
+              }
+              if (path !== 'person.id') {
+                return (
+                  <tr key={index} className="govuk-table__row">
+                    <td className="govuk-table__cell">{path}</td>
+                    <td className="govuk-table__cell lbh-!-break-word">
+                      <pre className="lbh-audit-history-json">{rhs}</pre>
+                    </td>
+                    <td className="govuk-table__cell lbh-!-break-word">
+                      <pre className="lbh-audit-history-json">{lhs}</pre>
+                    </td>
+                  </tr>
+                );
+              }
+              return null;
+            })}
+          </tbody>
+        </table>
+      </Details>
+    );
+  }
+
+  if (!historyItem.newData.activityData) return false;
+
+  return (
+    <Details summary="Show details">{historyItem.newData.activityData}</Details>
+  );
+}

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -71,7 +71,6 @@ export default defineConfig({
     experimentalWebKitSupport: true,
     video: true,
     screenshotOnRunFailure: true,
-    chromeWebSecurity: false,
   },
 
   component: {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,17 +1,65 @@
+import http from 'http';
+
 import { defineConfig } from 'cypress';
 import 'dotenv/config';
 import { sign } from 'jsonwebtoken';
+import next from 'next';
+import nock from 'nock';
 
 const baseUrl = 'http://localhost:3000';
 
 export default defineConfig({
   e2e: {
-    baseUrl,
-    experimentalWebKitSupport: true,
-    setupNodeEvents(on, config) {
+    // this is configured this way due to server side mocking. See https://glebbahmutov.com/blog/mock-network-from-server/
+    async setupNodeEvents(on, config) {
+      const app = next({ dev: true });
+      const handleNextRequests = app.getRequestHandler();
+      await app.prepare();
+
+      const customServer = new http.Server(async (req, res) => {
+        return handleNextRequests(req, res);
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        customServer
+          .listen(3000, () => {
+            console.log(
+              '> Server opened from Cypress. Ready on http://localhost:3000'
+            );
+            resolve();
+          })
+          .on('error', (error) => {
+            reject(error);
+          });
+      });
       on('task', {
         generateToken({ user, secret }) {
           return sign(user, secret);
+        },
+      });
+      on('task', {
+        clearNock() {
+          nock.restore();
+          nock.cleanAll();
+
+          return null;
+        },
+      });
+      on('task', {
+        nock: async ({ hostname, method, path, statusCode, body }) => {
+          nock.activate();
+          console.log(
+            'nock will: %s %s%s respond with %d %o',
+            method,
+            hostname,
+            path,
+            statusCode,
+            body
+          );
+          method = method.toLowerCase();
+          nock(hostname)[method](path).reply(statusCode, 'body');
+
+          return null;
         },
       });
       config.env = {
@@ -19,8 +67,11 @@ export default defineConfig({
       };
       return config;
     },
+    baseUrl,
+    experimentalWebKitSupport: true,
     video: true,
     screenshotOnRunFailure: true,
+    chromeWebSecurity: false,
   },
 
   component: {

--- a/cypress/e2e/searchForAnApplication.cy.ts
+++ b/cypress/e2e/searchForAnApplication.cy.ts
@@ -8,22 +8,15 @@ describe('Search for an application', () => {
     it('as a read only user I only see the search results', () => {
       cy.viewport(screenPreset);
       cy.clearCookies();
-
       cy.loginAsUser('readOnly');
       ApplicationsPage.visit();
-
       ApplicationsPage.getApplicationsPage().should('be.visible');
-
       ApplicationsPage.getSearchInput().should('be.visible');
-
       ApplicationsPage.getWorktray().should('not.exist');
       ApplicationsPage.getWorktraySidebar().should('not.exist');
-
       ApplicationsPage.getSearchInput().type(faker.lorem.words(2));
       ApplicationsPage.getSearchSubmitButton().click();
-
-      ApplicationsPage.getSearchResults().should('be.visible');
-
+      ApplicationsPage.getSearchInputBox().should('be.visible');
       ApplicationsPage.getWorktraySidebar().should('not.exist');
     });
   });
@@ -31,22 +24,15 @@ describe('Search for an application', () => {
     it('as an officer I can engage with worktray', () => {
       cy.viewport(screenPreset);
       cy.clearCookies();
-
       cy.loginAsUser('officer');
       ApplicationsPage.visit();
-
       ApplicationsPage.getApplicationsPage().should('be.visible');
-
       ApplicationsPage.getSearchInput().should('be.visible');
-
       ApplicationsPage.getWorktray().should('be.visible');
       ApplicationsPage.getWorktraySidebar().should('be.visible');
-
       ApplicationsPage.getSearchInput().type(faker.lorem.words(2));
       ApplicationsPage.getSearchSubmitButton().click();
-
-      ApplicationsPage.getSearchResults().should('be.visible');
-
+      ApplicationsPage.getSearchResultsBox().should('be.visible');
       ApplicationsPage.getWorktraySidebar().should('be.visible');
     });
   });

--- a/cypress/e2e/viewAnApplication.cy.ts
+++ b/cypress/e2e/viewAnApplication.cy.ts
@@ -8,23 +8,27 @@ describe('View an application', () => {
 
     ApplicationsPage.visit();
     ApplicationsPage.getSearchInput().should('be.visible');
-    ApplicationsPage.getSearchInput().type(
-      // faker.number.int({ max: 10 }).toString()
-      '1'
-    );
+    ApplicationsPage.getSearchInput().type('1');
     ApplicationsPage.getSearchSubmitButton().click();
     ApplicationsPage.getSearchResultsBox().should('be.visible');
-    cy.task('nock', {
-      hostname: Cypress.env('ACTIVITY_HISTORY_API'),
-      method: 'GET',
-      path:
-        '/activityhistory?targetId=84d87c59-9c87-4f90-89fa-326b5f14869c&pageSize=100',
-      status: 200,
-      body: {
-        results: [{}],
-        paginationDetails: { hasNext: false, nextToken: '' },
-      },
-    });
-    ApplicationsPage.getViewApplicationLink().first().click();
+
+    ApplicationsPage.getViewApplicationLink()
+      .first()
+      .invoke('attr', 'href')
+      .then((href) => {
+        const targetId = href.split('/').pop();
+        cy.task('nock', {
+          hostname: Cypress.env('ACTIVITY_HISTORY_API'),
+          method: 'GET',
+          path: `/activityhistory?targetId=${targetId}&pageSize=100`,
+          status: 200,
+          body: {
+            results: [{}],
+            paginationDetails: { hasNext: false, nextToken: '' },
+          },
+        });
+
+        ApplicationsPage.getViewApplicationLink().first().click();
+      });
   });
 });

--- a/cypress/e2e/viewAnApplication.cy.ts
+++ b/cypress/e2e/viewAnApplication.cy.ts
@@ -1,0 +1,30 @@
+import ApplicationsPage from '../pages/applications';
+
+describe('View an application', () => {
+  it('as a read only user I cannot see edit buttons', () => {
+    cy.task('clearNock');
+    cy.clearCookies();
+    cy.loginAsUser('readOnly');
+
+    ApplicationsPage.visit();
+    ApplicationsPage.getSearchInput().should('be.visible');
+    ApplicationsPage.getSearchInput().type(
+      // faker.number.int({ max: 10 }).toString()
+      '1'
+    );
+    ApplicationsPage.getSearchSubmitButton().click();
+    ApplicationsPage.getSearchResultsBox().should('be.visible');
+    cy.task('nock', {
+      hostname: Cypress.env('ACTIVITY_HISTORY_API'),
+      method: 'GET',
+      path:
+        '/activityhistory?targetId=84d87c59-9c87-4f90-89fa-326b5f14869c&pageSize=100',
+      status: 200,
+      body: {
+        results: [{}],
+        paginationDetails: { hasNext: false, nextToken: '' },
+      },
+    });
+    ApplicationsPage.getViewApplicationLink().first().click();
+  });
+});

--- a/cypress/pages/applications.ts
+++ b/cypress/pages/applications.ts
@@ -26,9 +26,19 @@ class ApplicationsPage {
     return cy.get(`[data-testid="${testId}"]`);
   }
 
-  static getSearchResults() {
+  static getSearchInputBox() {
     const testId = 'test-search-box';
     return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getSearchResultsBox() {
+    const testId = 'test-search-results-box';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getViewApplicationLink() {
+    const testIdPrefix = 'test-view-application-link-';
+    return this.getSearchResultsBox().get(`[data-testid^="${testIdPrefix}"]`);
   }
 }
 export default ApplicationsPage;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -81,8 +81,9 @@ export default {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
-
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],
 

--- a/lib/utils/googleAuth.spec.ts
+++ b/lib/utils/googleAuth.spec.ts
@@ -25,12 +25,12 @@ import {
   HackneyGoogleUserWithPermissions,
   Permissions,
   canViewSensitiveApplication,
-  canViewWorktray,
   getAuth,
   getPermissions,
   getRedirect,
   getSession,
   hasAnyPermissions,
+  hasReadOnlyPermissionOnly,
   hasUserGroup,
   removeHackneyToken,
 } from './googleAuth';
@@ -459,25 +459,63 @@ describe('googleAuth', () => {
     });
   });
 
-  describe('canViewWorktray', () => {
-    it('return true when user has admin permissions', () => {
+  describe('hasReadOnlyPermissionOnly', () => {
+    it('return false when user has admin permissions', () => {
       const user = generateHRUserWithPermissions(UserRole.Admin);
-      expect(canViewWorktray(user)).toBeTruthy();
+      expect(hasReadOnlyPermissionOnly(user)).toBeFalsy();
     });
 
-    it('return true when user has manager permissions', () => {
+    it('return false when user has admin permissions and readOnly', () => {
+      const user = generateHRUserWithPermissions(UserRole.Admin);
+      const userWithReadOnlyAdded = {
+        ...user,
+        hasReadOnlyPermissions: true,
+      };
+      expect(hasReadOnlyPermissionOnly(userWithReadOnlyAdded)).toBeFalsy();
+    });
+
+    it('return false when user has manager permissions', () => {
       const user = generateHRUserWithPermissions(UserRole.Manager);
-      expect(canViewWorktray(user)).toBeTruthy();
+      expect(hasReadOnlyPermissionOnly(user)).toBeFalsy();
     });
 
-    it('return true when user has officer permissions', () => {
+    it('return false when user has manager permissions and readOnly', () => {
+      const user = generateHRUserWithPermissions(UserRole.Manager);
+      const userWithReadOnlyAdded = {
+        ...user,
+        hasReadOnlyPermissions: true,
+      };
+      expect(hasReadOnlyPermissionOnly(userWithReadOnlyAdded)).toBeFalsy();
+    });
+
+    it('return false when user has officer permissions', () => {
       const user = generateHRUserWithPermissions(UserRole.Officer);
-      expect(canViewWorktray(user)).toBeTruthy();
+      expect(hasReadOnlyPermissionOnly(user)).toBeFalsy();
+    });
+
+    it('return false when user has officer permissions and readOnly', () => {
+      const user = generateHRUserWithPermissions(UserRole.Officer);
+      const userWithReadOnlyAdded = {
+        ...user,
+        hasReadOnlyPermissions: true,
+      };
+      expect(hasReadOnlyPermissionOnly(userWithReadOnlyAdded)).toBeFalsy();
+    });
+
+    it('return false when user has all permissions', () => {
+      const user = generateHRUserWithPermissions(UserRole.Officer);
+      const userWithReadOnlyAdded = {
+        ...user,
+        hasReadOnlyPermissions: true,
+        hasAdminPermissions: true,
+        hasManagerPermissions: true,
+      };
+      expect(hasReadOnlyPermissionOnly(userWithReadOnlyAdded)).toBeFalsy();
     });
 
     it('return true when user has read only permissions', () => {
       const user = generateHRUserWithPermissions(UserRole.ReadOnly);
-      expect(canViewWorktray(user)).toBeFalsy();
+      expect(hasReadOnlyPermissionOnly(user)).toBeTruthy();
     });
   });
 });

--- a/lib/utils/googleAuth.ts
+++ b/lib/utils/googleAuth.ts
@@ -91,6 +91,9 @@ export const removeHackneyToken = (res: any): void => {
 export const hasAnyPermissions = (
   user: HackneyGoogleUserWithPermissions
 ): boolean => {
+  if (!user) {
+    return false;
+  }
   return (
     user.hasAdminPermissions ||
     user.hasManagerPermissions ||
@@ -114,6 +117,9 @@ export const canViewSensitiveApplication = (
 export const hasReadOnlyPermissionOnly = (
   user: HackneyGoogleUserWithPermissions
 ): boolean => {
+  if (!user) {
+    return false;
+  }
   // is not part of the read only group
   if (
     user.hasReadOnlyPermissions &&

--- a/lib/utils/googleAuth.ts
+++ b/lib/utils/googleAuth.ts
@@ -3,6 +3,8 @@ import jsonwebtoken from 'jsonwebtoken';
 import { Redirect } from 'next';
 
 import { HackneyGoogleUser } from '../../domain/HackneyGoogleUser';
+import { Application } from '../../domain/HousingApi';
+import { ApplicationStatus } from '../types/application-status';
 
 type Permissions = {
   hasAdminPermissions: boolean;
@@ -109,14 +111,15 @@ export const canViewSensitiveApplication = (
   return user.hasOfficerPermissions && assignedTo === user.email;
 };
 
-export const canViewWorktray = (
+export const hasReadOnlyPermissionOnly = (
   user: HackneyGoogleUserWithPermissions
 ): boolean => {
   // is not part of the read only group
   if (
-    user.hasAdminPermissions ||
-    user.hasManagerPermissions ||
-    user.hasOfficerPermissions
+    user.hasReadOnlyPermissions &&
+    !user.hasAdminPermissions &&
+    !user.hasManagerPermissions &&
+    !user.hasOfficerPermissions
   ) {
     return true;
   }
@@ -146,3 +149,30 @@ export function getAuth(
   }
   return { user };
 }
+
+// Can edit applications if:
+// - user is a manager (all statuses)
+// - it has a status of manual draft
+// - it has a status of awaiting assessment (SUBMITTED) and current user is assigned to it
+// - it has a status of awaiting reassessment and current user is assigned to it
+export const canEditApplications = (
+  user: HackneyGoogleUserWithPermissions,
+  data: Application
+) => {
+  if (!hasAnyPermissions(user)) return false;
+  if (user.hasManagerPermissions) return true;
+  if (data.status === ApplicationStatus.MANUAL_DRAFT) {
+    return true;
+  }
+  const assignedToCurrentUser = data.assignedTo === user.email;
+  if (data.status === ApplicationStatus.SUBMITTED && assignedToCurrentUser) {
+    return true;
+  }
+  if (
+    data.status === ApplicationStatus.AWAITING_REASSESSMENT &&
+    assignedToCurrentUser
+  ) {
+    return true;
+  }
+  return false;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "eslint-plugin-prettier": "3.4.0",
         "eslint-plugin-testing-library": "4.9.0",
         "husky": "^8.0.3",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^27.5.1",
         "jest-junit": "^16.0.0",
         "lint-staged": "^14.0.1",
@@ -8804,6 +8805,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -9082,6 +9089,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ieee754": {
@@ -23811,6 +23830,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -24011,6 +24036,15 @@
       "peer": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "lint-staged": "^14.0.1",
         "mocha": "^10.7.3",
         "mockdate": "^3.0.5",
+        "nock": "^14.0.0-beta.11",
         "node-mocks-http": "^1.15.1",
         "playwright-webkit": "^1.46.0",
         "prettier": "2.2.1",
@@ -2427,6 +2428,23 @@
         "@mocks-server/core": ">=2.5.2"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.34.3.tgz",
+      "integrity": "sha512-UPi1V51c4+PVVG1lhVK2i29aOyBqXvBF8WBvlXIp2Q0vTVKrm20x2voLfunVC3N5wzocxEoHJyOwAXNdoMqy3Q==",
+      "dev": true,
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@next/env": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.3.tgz",
@@ -2764,6 +2782,28 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -9830,6 +9870,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -13653,6 +13699,20 @@
         "react-redux": "*"
       }
     },
+    "node_modules/nock": {
+      "version": "14.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.11.tgz",
+      "integrity": "sha512-tmImk6btCUcCFHXkhqZnuSe4e/4M/YYs8qYaQGdjZSBloTXgQyuPrgjzn45zmFWpK2bDSEtIcF8olFdFxRaA1g==",
+      "dev": true,
+      "dependencies": {
+        "@mswjs/interceptors": "^0.34.3",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -14063,6 +14123,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
+      "dev": true
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "dev": true
     },
     "node_modules/p-limit": {
@@ -14496,6 +14562,15 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/property-expr": {
@@ -15674,6 +15749,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -19170,6 +19251,20 @@
         "express-http-proxy": "1.6.3"
       }
     },
+    "@mswjs/interceptors": {
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.34.3.tgz",
+      "integrity": "sha512-UPi1V51c4+PVVG1lhVK2i29aOyBqXvBF8WBvlXIp2Q0vTVKrm20x2voLfunVC3N5wzocxEoHJyOwAXNdoMqy3Q==",
+      "dev": true,
+      "requires": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      }
+    },
     "@next/env": {
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-12.2.3.tgz",
@@ -19355,6 +19450,28 @@
       "version": "8.3.8",
       "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
       "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "dev": true
+    },
+    "@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "requires": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
     },
     "@pkgjs/parseargs": {
@@ -24687,6 +24804,12 @@
       "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true
     },
+    "is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -27507,6 +27630,17 @@
       "integrity": "sha512-I9CnIYhQwI/qEoNdc9VAPjIyuq4rFFhCTa4rKhoDHWEVHGB1DXZy8TAyGpwvWizESd8IoTI/OKlP6bFpCbXsOw==",
       "requires": {}
     },
+    "nock": {
+      "version": "14.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0-beta.11.tgz",
+      "integrity": "sha512-tmImk6btCUcCFHXkhqZnuSe4e/4M/YYs8qYaQGdjZSBloTXgQyuPrgjzn45zmFWpK2bDSEtIcF8olFdFxRaA1g==",
+      "dev": true,
+      "requires": {
+        "@mswjs/interceptors": "^0.34.3",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      }
+    },
     "node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -27824,6 +27958,12 @@
       "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
       "dev": true
     },
+    "outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true
+    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -28122,6 +28262,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "property-expr": {
       "version": "2.0.4",
@@ -29003,6 +29149,12 @@
       "requires": {
         "internal-slot": "^1.0.4"
       }
+    },
+    "strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint-plugin-prettier": "3.4.0",
     "eslint-plugin-testing-library": "4.9.0",
     "husky": "^8.0.3",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",
     "jest-junit": "^16.0.0",
     "lint-staged": "^14.0.1",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "lint-staged": "^14.0.1",
     "mocha": "^10.7.3",
     "mockdate": "^3.0.5",
+    "nock": "^14.0.0-beta.11",
     "node-mocks-http": "^1.15.1",
     "playwright-webkit": "^1.46.0",
     "prettier": "2.2.1",

--- a/pages/applications/index.tsx
+++ b/pages/applications/index.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent, useEffect, useState } from 'react';
+import React, { SyntheticEvent, useEffect, useState } from 'react';
 
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
@@ -19,9 +19,9 @@ import { UserContext } from '../../lib/contexts/user-context';
 import { getApplicationsByStatusAndAssignedTo } from '../../lib/gateways/applications-api';
 import {
   HackneyGoogleUserWithPermissions,
-  canViewWorktray,
   getRedirect,
   getSession,
+  hasReadOnlyPermissionOnly,
 } from '../../lib/utils/googleAuth';
 
 interface PageProps {
@@ -62,7 +62,9 @@ export default function ApplicationListPage({
           buttonTitle="Search"
           watermark="Search all applications (name, reference, bidding number)"
         />
-        {canViewWorktray(user as HackneyGoogleUserWithPermissions) && (
+        {!hasReadOnlyPermissionOnly(
+          user as HackneyGoogleUserWithPermissions
+        ) && (
           <div
             className="govuk-grid-row"
             data-testid="test-applications-worktray"

--- a/pages/applications/search-results.tsx
+++ b/pages/applications/search-results.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { GetServerSideProps } from 'next';
 
 import ApplicationsTable from '../../components/admin/ApplicationsTable';
@@ -13,9 +15,9 @@ import { UserContext } from '../../lib/contexts/user-context';
 import { searchAllApplications } from '../../lib/gateways/applications-api';
 import {
   HackneyGoogleUserWithPermissions,
-  canViewWorktray,
   getRedirect,
   getSession,
+  hasReadOnlyPermissionOnly,
 } from '../../lib/utils/googleAuth';
 
 interface PageProps {
@@ -43,12 +45,17 @@ export default function ApplicationListPage({
           dataTestId="test-search-box"
         />
         <div className="govuk-grid-row">
-          {canViewWorktray(user as HackneyGoogleUserWithPermissions) && (
+          {!hasReadOnlyPermissionOnly(
+            user as HackneyGoogleUserWithPermissions
+          ) && (
             <div className="govuk-grid-column-one-quarter">
               <Sidebar />
             </div>
           )}
-          <div className="govuk-grid-column-three-quarters">
+          <div
+            className="govuk-grid-column-three-quarters"
+            data-testid="test-search-results-box"
+          >
             <HeadingOne content="Results" />
 
             {applications && applications.totalResults !== 0 ? (

--- a/types/nested-object-diff.d.ts
+++ b/types/nested-object-diff.d.ts
@@ -1,12 +1,3 @@
-export interface Difference {
-  type: string;
-  path: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  lhs: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  rhs: any;
-}
-
 declare module 'nested-object-diff' {
   export function diff(a: unknown, b: unknown): Difference[];
 }

--- a/types/nested-object-diff.d.ts
+++ b/types/nested-object-diff.d.ts
@@ -1,1 +1,12 @@
-declare module 'nested-object-diff';
+export interface Difference {
+  type: string;
+  path: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  lhs: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  rhs: any;
+}
+
+declare module 'nested-object-diff' {
+  export function diff(a: unknown, b: unknown): Difference[];
+}


### PR DESCRIPTION
https://hackney.atlassian.net/browse/TS-1558?atlOrigin=eyJpIjoiZDQ4NDg0NzM4NThhNDFiN2EwYzc2MGUwZmQ5ZmE3YmEiLCJwIjoiaiJ9

**What**
- Updates the functionality in googleAuth for clarity and accuracy. Renamed to hasReadOnlyPermissionOnly and function explicitly checks for the group rather than knowing that hasAnyPremissions would be true. Also updates and expands tests to cover this,
- This PR doesn't cover the full suite of e2e tests to 'prove' the AC has been met. This will follow case by case. Some inital e2e tests have been added.
- In the relevant parts of the application, this new functionality is used to hide the features that are not available to a readOnly user. In many cases, the edit functionality was already hidden by canEditApplication (user must be a manager),
- Where linting errors have been thrown, and part of cleaning as we go, some refactoring has been necessary. I have also split the helper functions of ApplicationHistory because of linting errors and to help with future testing. The directory structure of this may need consideration,
- env.sample is updated as the groups are needed for application testing,
- Because of the issues intercepting serverside props, this PR implements nock (this was the recommended way of a key Cypress dev [here](https://glebbahmutov.com/blog/mock-network-from-server/). Following the guide means that Cypress now starts next, rather than relying on the local server being already open,
- This also requires node 18 to work, so pipeline config has been updated. Devs will need to run cypress process in node18 locally - thankfully the application is OK with this,
- Adds identity-obj-proxy and config so jest is OK with styling files being imported. This is not being used now on this PR but is necessary for some jest tests to work without error. 

**Future**
- Need to check the behaviour of the application where paths are hit where user is readOnly (i.e. applications/edit/[id]). Should be graceful :)  


