### PR TITLE
TS-1571 lock down pages for read only users

### DIFF
--- a/cypress/e2e/addCase.cy.ts
+++ b/cypress/e2e/addCase.cy.ts
@@ -1,0 +1,8 @@
+describe('Add case', () => {
+  it('shows access denied page for user with read only permissions', () => {
+    cy.clearAllCookies();
+    cy.loginAsUser('readOnly');
+    cy.visit('applications/add-case');
+    cy.contains('Access denied');
+  });
+});

--- a/cypress/e2e/addHouseholdMember.cy.ts
+++ b/cypress/e2e/addHouseholdMember.cy.ts
@@ -1,0 +1,12 @@
+import { faker } from '@faker-js/faker';
+
+describe('Add household member', () => {
+  it('shows access denied page for user with read only permissions', () => {
+    const applicationId = faker.string.uuid();
+
+    cy.clearAllCookies();
+    cy.loginAsUser('readOnly');
+    cy.visit(`applications/edit/${applicationId}/add-household-member`);
+    cy.contains('Access denied');
+  });
+});

--- a/cypress/e2e/editHouseholdMember.cy.ts
+++ b/cypress/e2e/editHouseholdMember.cy.ts
@@ -1,0 +1,15 @@
+import { faker } from '@faker-js/faker';
+
+describe('Edit household member', () => {
+  it('shows access denied page for user with read only permissions', () => {
+    const applicationId = faker.string.uuid();
+    const personId = faker.string.uuid();
+
+    cy.clearAllCookies();
+    cy.loginAsUser('readOnly');
+    cy.visit(
+      `applications/edit/${applicationId}/${personId}/edit-household-member`
+    );
+    cy.contains('Access denied');
+  });
+});

--- a/cypress/e2e/unassigned.cy.ts
+++ b/cypress/e2e/unassigned.cy.ts
@@ -1,0 +1,8 @@
+describe('Unassigned - Group worktray', () => {
+  it('shows access denied page for user with read only permissions', () => {
+    cy.clearAllCookies();
+    cy.loginAsUser('readOnly');
+    cy.visit('applications/unassigned');
+    cy.contains('Access denied');
+  });
+});

--- a/cypress/e2e/viewRegister.cy.ts
+++ b/cypress/e2e/viewRegister.cy.ts
@@ -1,0 +1,8 @@
+describe('View register - All applications', () => {
+  it('shows access denied page for user with read only permissions', () => {
+    cy.clearAllCookies();
+    cy.loginAsUser('readOnly');
+    cy.visit('applications/view-register');
+    cy.contains('Access denied');
+  });
+});

--- a/lib/utils/googleAuth.spec.ts
+++ b/lib/utils/googleAuth.spec.ts
@@ -409,11 +409,20 @@ describe('googleAuth', () => {
       const expectedResponse = '/login';
       expect(getRedirect()).toBe(expectedResponse);
     });
-    it("return /access-denied when user is provided but they don't have any HR permissions", () => {
+
+    it("returns /access-denied when user is provided but they don't have any HR permissions", () => {
       const user: HackneyGoogleUserWithPermissions = generateHRUserWithPermissions();
 
       const expectedResponse = '/access-denied';
       expect(getRedirect(user)).toBe(expectedResponse);
+    });
+
+    it('returns /access-denied when user is provided but they only have read only HR permissions', () => {
+      const user: HackneyGoogleUserWithPermissions = generateHRUserWithPermissions(
+        UserRole.ReadOnly
+      );
+      const expectedResponse = '/access-denied';
+      expect(getRedirect(user, true)).toBe(expectedResponse);
     });
 
     it('returns undefined when user is provided and has HR permissions', () => {

--- a/lib/utils/googleAuth.ts
+++ b/lib/utils/googleAuth.ts
@@ -133,12 +133,16 @@ export const hasReadOnlyPermissionOnly = (
 };
 
 export const getRedirect = (
-  user?: HackneyGoogleUserWithPermissions
+  user?: HackneyGoogleUserWithPermissions,
+  checkForReadOnlyPermissions?: boolean
 ): string | undefined => {
   if (!user) {
     return '/login';
   }
-  if (!hasAnyPermissions(user)) {
+  if (
+    !hasAnyPermissions(user) ||
+    (checkForReadOnlyPermissions && hasReadOnlyPermissionOnly(user))
+  ) {
     return '/access-denied';
   }
 };

--- a/lib/utils/googleAuth.ts
+++ b/lib/utils/googleAuth.ts
@@ -134,14 +134,14 @@ export const hasReadOnlyPermissionOnly = (
 
 export const getRedirect = (
   user?: HackneyGoogleUserWithPermissions,
-  checkForReadOnlyPermissions?: boolean
+  writePermissionsRequired?: boolean
 ): string | undefined => {
   if (!user) {
     return '/login';
   }
   if (
     !hasAnyPermissions(user) ||
-    (checkForReadOnlyPermissions && hasReadOnlyPermissionOnly(user))
+    (writePermissionsRequired && hasReadOnlyPermissionOnly(user))
   ) {
     return '/access-denied';
   }

--- a/pages/applications/edit/[id]/[person]/edit-household-member.tsx
+++ b/pages/applications/edit/[id]/[person]/edit-household-member.tsx
@@ -1,19 +1,23 @@
 import { useState } from 'react';
+
+import { FormikValues } from 'formik';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import { FormikValues } from 'formik';
+
+import HouseholdMemberForm from '../../../../../components/admin/HouseholdMemberForm';
+import { HackneyGoogleUser } from '../../../../../domain/HackneyGoogleUser';
 import { Application } from '../../../../../domain/HousingApi';
 import { getApplication } from '../../../../../lib/gateways/applications-api';
-import { getRedirect, getSession } from '../../../../../lib/utils/googleAuth';
 import { updateApplication } from '../../../../../lib/gateways/internal-api';
-import Custom404 from '../../../../404';
-import { HackneyGoogleUser } from '../../../../../domain/HackneyGoogleUser';
 import {
   Address,
   generateQuestionArray,
 } from '../../../../../lib/utils/adminHelpers';
+import { getRedirect, getSession } from '../../../../../lib/utils/googleAuth';
 import { scrollToTop } from '../../../../../lib/utils/scroll';
-import HouseholdMemberForm from '../../../../../components/admin/HouseholdMemberForm';
+import Custom404 from '../../../../404';
+
+/* eslint-disable react/no-unused-prop-types */
 interface PageProps {
   user: HackneyGoogleUser;
   data: Application;
@@ -44,6 +48,7 @@ export default function EditApplicant({
     const questionValues = generateQuestionArray(values, addresses);
     const addressToSubmit = addresses.length > 0 ? addresses[0] : {};
 
+    /*  eslint-disable @typescript-eslint/no-explicit-any */
     const householdMemberFormData = {
       person: {
         id: person,
@@ -82,7 +87,7 @@ export default function EditApplicant({
       });
     });
   };
-
+  /*  eslint-disable @typescript-eslint/no-explicit-any */
   const handleSaveApplication = (isValid: any, touched: any) => {
     const isTouched = Object.keys(touched).length !== 0;
     if (!isValid || !isTouched) {
@@ -91,12 +96,12 @@ export default function EditApplicant({
 
     setIsSubmitted(true);
   };
-
+  /*  eslint-disable react/jsx-no-useless-fragment */
   return (
     <>
       {data.id ? (
         <HouseholdMemberForm
-          isEditing={true}
+          isEditing={true} /* eslint-disable-line */
           user={user}
           onSubmit={onSubmit}
           isSubmitted={isSubmitted}
@@ -114,7 +119,7 @@ export default function EditApplicant({
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const user = getSession(context.req);
-  const redirect = getRedirect(user);
+  const redirect = getRedirect(user, true);
   if (redirect) {
     return {
       props: {},

--- a/pages/applications/edit/[id]/add-household-member.tsx
+++ b/pages/applications/edit/[id]/add-household-member.tsx
@@ -1,20 +1,22 @@
 import React, { useState } from 'react';
-import { useRouter } from 'next/router';
-import { GetServerSideProps } from 'next';
+
 import { FormikValues } from 'formik';
-import { getRedirect, getSession } from '../../../../lib/utils/googleAuth';
+import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
+
+import HouseholdMemberForm from '../../../../components/admin/HouseholdMemberForm';
 import { HackneyGoogleUser } from '../../../../domain/HackneyGoogleUser';
 import { Application } from '../../../../domain/HousingApi';
 import { getApplication } from '../../../../lib/gateways/applications-api';
 import { updateApplication } from '../../../../lib/gateways/internal-api';
 import {
-  generateQuestionArray,
   Address,
+  generateQuestionArray,
 } from '../../../../lib/utils/adminHelpers';
-
+import { getRedirect, getSession } from '../../../../lib/utils/googleAuth';
 import { scrollToTop } from '../../../../lib/utils/scroll';
 import Custom404 from '../../../404';
-import HouseholdMemberForm from '../../../../components/admin/HouseholdMemberForm';
+
 interface PageProps {
   user: HackneyGoogleUser;
   data: Application;
@@ -32,6 +34,7 @@ export default function AddHouseholdMember({
     const questionValues = generateQuestionArray(values, addresses);
     const addressToSubmit = addresses.length > 0 ? addresses[0] : {};
 
+    /*  eslint-disable @typescript-eslint/no-explicit-any */
     const householdMemberFormData = {
       person: {
         title: values.personalDetails_title,
@@ -66,7 +69,7 @@ export default function AddHouseholdMember({
       });
     });
   };
-
+  /*  eslint-disable @typescript-eslint/no-explicit-any */
   const handleSaveApplication = (isValid: any, touched: any) => {
     const isTouched = Object.keys(touched).length !== 0;
     if (!isValid || !isTouched) {
@@ -75,7 +78,7 @@ export default function AddHouseholdMember({
 
     setIsSubmitted(true);
   };
-
+  /*  eslint-disable react/jsx-no-useless-fragment */
   return (
     <>
       {data.id ? (
@@ -97,7 +100,7 @@ export default function AddHouseholdMember({
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const user = getSession(context.req);
-  const redirect = getRedirect(user);
+  const redirect = getRedirect(user, true);
   if (redirect) {
     return {
       props: {},

--- a/pages/applications/unassigned.tsx
+++ b/pages/applications/unassigned.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect, SyntheticEvent } from 'react';
+import { SyntheticEvent, useEffect, useState } from 'react';
+
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import ApplicationsTable from '../../components/admin/ApplicationsTable';
-import SimplePaginationSearch from '../../components/SimplePaginationSearch';
 
+import ApplicationsTable from '../../components/admin/ApplicationsTable';
 import {
   HorizontalNav,
   HorizontalNavItem,
@@ -12,6 +12,7 @@ import SearchBox from '../../components/admin/SearchBox';
 import Sidebar from '../../components/admin/sidebar';
 import { HeadingOne } from '../../components/content/headings';
 import Layout from '../../components/layout/staff-layout';
+import SimplePaginationSearch from '../../components/SimplePaginationSearch';
 import { HackneyGoogleUser } from '../../domain/HackneyGoogleUser';
 import {
   APPLICATION_UNNASIGNED,
@@ -48,7 +49,7 @@ export default function ApplicationListPage({
     const { name } = event.target as HTMLButtonElement;
     setActiveNavItem(name);
   };
-
+  /*  eslint-disable react/jsx-no-constructed-context-values */
   return (
     <UserContext.Provider value={{ user }}>
       <Layout pageName="Group worktray">
@@ -84,7 +85,7 @@ export default function ApplicationListPage({
               <>
                 <ApplicationsTable
                   applications={applications}
-                  showStatus={true}
+                  showStatus={true} /* eslint-disable-line */
                   page={page}
                   pageSize={pageSize}
                 />
@@ -107,7 +108,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async (
   context
 ) => {
   const user = getSession(context.req);
-  const redirect = getRedirect(user);
+  const redirect = getRedirect(user, true);
   if (redirect) {
     return {
       redirect: {

--- a/pages/applications/view-register.tsx
+++ b/pages/applications/view-register.tsx
@@ -1,21 +1,23 @@
 import { ChangeEvent, MouseEvent, useEffect, useState } from 'react';
+
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
+
 import ApplicationsTable from '../../components/admin/ApplicationsTable';
-import SimplePaginationSearch from '../../components/SimplePaginationSearch';
 import SearchBox from '../../components/admin/SearchBox';
 import Sidebar from '../../components/admin/sidebar';
 import Button from '../../components/button';
-import Details from '../../components/details';
 import { HeadingOne } from '../../components/content/headings';
+import Details from '../../components/details';
 import Layout from '../../components/layout/staff-layout';
+import SimplePaginationSearch from '../../components/SimplePaginationSearch';
 import { HackneyGoogleUser } from '../../domain/HackneyGoogleUser';
 import { PaginatedSearchResultsResponse } from '../../domain/HousingApi';
 import { UserContext } from '../../lib/contexts/user-context';
 import {
+  getApplicationStatusCounts,
   getApplications,
   getApplicationsByStatus,
-  getApplicationStatusCounts,
 } from '../../lib/gateways/applications-api';
 import {
   ApplicationStatus,
@@ -63,7 +65,7 @@ export default function ViewAllApplicationsPage({
     event.preventDefault();
     setSelectedFilter('');
   };
-
+  /*  eslint-disable react/jsx-no-constructed-context-values */
   return (
     <UserContext.Provider value={{ user }}>
       <Layout pageName="All applications">
@@ -80,6 +82,7 @@ export default function ViewAllApplicationsPage({
           <div className="govuk-grid-column-three-quarters">
             <div className="lbh-flex-heading">
               <HeadingOne content="All applications" />
+              {/* eslint-disable-next-line */}
               <Button secondary={true} onClick={() => addCase()}>
                 + Add new case
               </Button>
@@ -128,7 +131,7 @@ export default function ViewAllApplicationsPage({
               <>
                 <ApplicationsTable
                   applications={applications}
-                  showStatus={true}
+                  showStatus={true} /* eslint-disable-line */
                   page={page}
                   pageSize={pageSize}
                 />
@@ -151,7 +154,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async (
   context
 ) => {
   const user = getSession(context.req);
-  const redirect = getRedirect(user);
+  const redirect = getRedirect(user, true);
   if (redirect) {
     return {
       redirect: {
@@ -161,11 +164,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async (
     };
   }
 
-  const {
-    status = '',
-    page = '1',
-    pageSize = '10',
-  } = context.query as {
+  const { status = '', page = '1', pageSize = '10' } = context.query as {
     status: string;
     page: string;
     pageSize: string;


### PR DESCRIPTION
## WHAT
Currently read only users can access certain edit and other pages directly. They should not be able to access these pages at all.

## WHY
Read only users are authorized to view only certain pages and data. This update locks down the pages they shouldn't be able to access.

## HOW
1. Update `getRedirect ` function with additional read only authorization check that'll direct users to access denied page if they are not allowed direct access to the page
2. Update the following pages by implementing the read only authorization check
2.1  `applications/edit/{applicationId}/{personId}/edit-household-member`
2.2 `applications/edit/{applicationId}/add-household-member`
2.3 `applications/View-register`
2.4 `applications/unassigned`
2.5 `applications/add-case`
3. Disable eslint rules where fixing the issue would require refactoring or changes to existing variable values

## FUTURE
Address the eslint issues by updating the code where required.