### PR TITLE
Ts 1561 housing reg view only hide remove household member edit household member assign and mark as sensitive from application overview page

### DIFF
--- a/components/admin/CaseDetailsItem.tsx
+++ b/components/admin/CaseDetailsItem.tsx
@@ -1,9 +1,12 @@
+import React from 'react';
+
 import { HeadingFour } from '../content/headings';
 
 interface CaseDetailsProps {
   itemHeading: string;
   itemValue: string | undefined;
   buttonText?: string;
+  dataTestId?: string;
   onClick?: () => void;
 }
 
@@ -12,6 +15,7 @@ export default function CaseDetailsItem({
   itemValue,
   buttonText,
   onClick,
+  dataTestId,
 }: CaseDetailsProps): JSX.Element {
   return (
     <>
@@ -21,6 +25,7 @@ export default function CaseDetailsItem({
         <button
           onClick={onClick}
           className="lbh-link lbh-link--no-visited-state lbh-!-margin-top-0"
+          data-testid={dataTestId}
         >
           {buttonText}
         </button>

--- a/components/admin/HorizontalNav.tsx
+++ b/components/admin/HorizontalNav.tsx
@@ -1,4 +1,4 @@
-import { SyntheticEvent } from 'react';
+import React, { SyntheticEvent } from 'react';
 
 interface HorizontalNavProps {
   spaced?: boolean;
@@ -20,6 +20,7 @@ interface HorizontalNavItemProps {
   itemName: string;
   isActive?: boolean;
   children: string;
+
   handleSelectNavItem: (event: SyntheticEvent) => void;
 }
 
@@ -34,6 +35,7 @@ export function HorizontalNavItem({
       <button
         name={itemName}
         onClick={handleSelectNavItem}
+        data-testid={`test-nav-item-${itemName}`}
         className={`lbh-link lbh-link--no-visited-state lbh-!-font-weight-bold ${
           isActive ? 'active' : ''
         }`}

--- a/components/admin/assign-user.tsx
+++ b/components/admin/assign-user.tsx
@@ -1,6 +1,8 @@
-import { useRouter } from 'next/router';
 import React, { useState } from 'react';
-import { Application, APPLICATION_UNNASIGNED } from '../../domain/HousingApi';
+
+import { useRouter } from 'next/router';
+
+import { APPLICATION_UNNASIGNED, Application } from '../../domain/HousingApi';
 import { updateApplication } from '../../lib/gateways/internal-api';
 import { HackneyGoogleUserWithPermissions } from '../../lib/utils/googleAuth';
 import ErrorMessage from '../form/error-message';
@@ -42,7 +44,7 @@ export default function AssignUser({
     setDisableControls(true);
 
     const request: Application = {
-      id: id,
+      id,
       assignedTo: updateTo,
     };
     await updateApplication(request).then(() => {
@@ -60,36 +62,32 @@ export default function AssignUser({
   };
 
   return (
-    <div>
+    <div data-testid="test-assign-user">
       <label className="govuk-label lbh-label" htmlFor="input-assignee">
         <ul className="lbh-list lbh-list--compressed">
           <li>
             <strong>Assigned to</strong>
           </li>
-          {!showControls ? (
-            <>
-              {assignee !== APPLICATION_UNNASIGNED ? (
-                <li>
-                  This application is currently assigned to{' '}
-                  {assignedTo === user.email ? (
-                    <>
-                      <span>you</span> (<strong>{assignee}</strong>)
-                    </>
-                  ) : (
-                    <strong>{assignee}</strong>
-                  )}
-                </li>
-              ) : (
-                <li>
-                  This application is currently <strong>unassigned</strong>
-                </li>
-              )}
-            </>
-          ) : null}
+          {!showControls &&
+            (assignee !== APPLICATION_UNNASIGNED ? (
+              <li>
+                This application is currently assigned to{' '}
+                {assignedTo === user.email ? (
+                  <>
+                    <span>you</span> (<strong>{assignee}</strong>)
+                  </>
+                ) : (
+                  <strong>{assignee}</strong>
+                )}
+              </li>
+            ) : (
+              <li>
+                This application is currently <strong>unassigned</strong>
+              </li>
+            ))}
         </ul>
       </label>
-
-      {showControls ? (
+      {showControls && (
         <>
           <ErrorMessage
             message={!isValidEmail ? 'Please enter a valid email address' : ''}
@@ -119,11 +117,12 @@ export default function AssignUser({
             Cancel
           </button>
         </>
-      ) : // For now, allow all user groups to reassign cases
-      user.hasAdminPermissions ||
+      )}
+      {/* For now, allow all user groups to reassign cases */}
+      {(user.hasAdminPermissions ||
         user.hasManagerPermissions ||
-        user.hasOfficerPermissions ? (
-        <>
+        user.hasOfficerPermissions) && (
+        <div data-testid="test-assign-user-button">
           <button
             onClick={() => handleClickAssignToAnother(true)}
             className="lbh-link lbh-link--no-visited-state lbh-!-margin-top-1"
@@ -138,35 +137,31 @@ export default function AssignUser({
             <span className="lbh-body-m">, </span>
           )}
 
-          {assignee !== user.email ? (
-            <>
-              <button
-                onClick={() => updateAssignee(user.email)}
-                className="lbh-link lbh-link--no-visited-state lbh-!-margin-top-0"
-                disabled={disableControls}
-              >
-                assign to me
-              </button>
-            </>
-          ) : null}
+          {assignee !== user.email && (
+            <button
+              onClick={() => updateAssignee(user.email)}
+              className="lbh-link lbh-link--no-visited-state lbh-!-margin-top-0"
+              disabled={disableControls}
+            >
+              assign to me
+            </button>
+          )}
 
-          {assignee !== APPLICATION_UNNASIGNED && assignee !== user.email ? (
+          {assignee !== APPLICATION_UNNASIGNED && assignee !== user.email && (
             <span className="lbh-body-m"> or </span>
-          ) : null}
+          )}
 
-          {assignee !== APPLICATION_UNNASIGNED ? (
-            <>
-              <button
-                onClick={() => updateAssignee(APPLICATION_UNNASIGNED)}
-                className="lbh-link lbh-link--no-visited-state lbh-!-margin-top-0"
-                disabled={disableControls}
-              >
-                unassign
-              </button>
-            </>
-          ) : null}
-        </>
-      ) : null}
+          {assignee !== APPLICATION_UNNASIGNED && (
+            <button
+              onClick={() => updateAssignee(APPLICATION_UNNASIGNED)}
+              className="lbh-link lbh-link--no-visited-state lbh-!-margin-top-0"
+              disabled={disableControls}
+            >
+              unassign
+            </button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/admin/other-members.tsx
+++ b/components/admin/other-members.tsx
@@ -35,7 +35,11 @@ export default function OtherMembers({
   return (
     <>
       <HeadingThree content={heading} />
-      <table className="govuk-table lbh-table" style={{ marginTop: '1em' }}>
+      <table
+        className="govuk-table lbh-table"
+        style={{ marginTop: '1em' }}
+        data-testid="test-other-household-members"
+      >
         <tbody className="govuk-table__body">
           {others.map((applicant, index) => (
             <tr key={index} className="govuk-table__row">
@@ -90,6 +94,7 @@ export default function OtherMembers({
                   <ButtonLink
                     additionalCssClasses="govuk-secondary lbh-button--secondary lbh-button--inline"
                     href={`/applications/edit/${applicationId}/${applicant.person?.id}/edit-household-member`}
+                    dataTestId={`test-edit-household-member-button-${applicant.person?.id}`}
                   >
                     Edit
                   </ButtonLink>

--- a/components/admin/personal-details.tsx
+++ b/components/admin/personal-details.tsx
@@ -1,9 +1,11 @@
+import React from 'react';
+
+import Link from 'next/link';
+
 import { Applicant } from '../../domain/HousingApi';
 import { formatDob } from '../../lib/utils/dateOfBirth';
 import { getGenderName } from '../../lib/utils/gender';
 import { ButtonLink } from '../button';
-import Link from 'next/link';
-import React from 'react';
 import { HeadingThree } from '../content/headings';
 
 interface SummaryProps {
@@ -22,7 +24,11 @@ export default function PersonalDetails({
   return (
     <>
       <HeadingThree content={heading} />
-      <table className="govuk-table lbh-table" style={{ marginTop: '1em' }}>
+      <table
+        className="govuk-table lbh-table"
+        style={{ marginTop: '1em' }}
+        data-testid="test-applicant-table"
+      >
         <tbody className="govuk-table__body">
           <tr className="govuk-table__row">
             <td className="govuk-table__cell">
@@ -49,15 +55,13 @@ export default function PersonalDetails({
                 </li>
                 <li>
                   {applicant.contactInformation?.emailAddress && (
-                    <>
-                      <Link
-                        href={`mailto:${applicant.contactInformation.emailAddress}`}
-                      >
-                        <a className="lbh-link">
-                          {applicant.contactInformation.emailAddress}
-                        </a>
-                      </Link>
-                    </>
+                    <Link
+                      href={`mailto:${applicant.contactInformation.emailAddress}`}
+                    >
+                      <a className="lbh-link">
+                        {applicant.contactInformation.emailAddress}
+                      </a>
+                    </Link>
                   )}
                 </li>
               </ul>
@@ -67,6 +71,7 @@ export default function PersonalDetails({
                 <ButtonLink
                   additionalCssClasses="govuk-secondary lbh-button--secondary lbh-button--inline"
                   href={`/applications/edit/${applicationId}/${applicant.person?.id}`}
+                  dataTestId={`test-edit-applicant-button-${applicant.person?.id}`}
                 >
                   Edit
                 </ButtonLink>

--- a/components/admin/sensitive-data.tsx
+++ b/components/admin/sensitive-data.tsx
@@ -1,10 +1,11 @@
+import React, { useState } from 'react';
+
 import { Application } from '../../domain/HousingApi';
-import { useState } from 'react';
 import { updateApplication } from '../../lib/gateways/internal-api';
 import { HackneyGoogleUserWithPermissions } from '../../lib/utils/googleAuth';
 import { HeadingFour } from '../content/headings';
 
-interface sensitiveDataPageProps {
+interface SensitiveDataPageProps {
   id: string;
   isSensitive: boolean;
   user: HackneyGoogleUserWithPermissions;
@@ -14,13 +15,13 @@ export default function SensitiveData({
   id,
   isSensitive,
   user,
-}: sensitiveDataPageProps): JSX.Element {
+}: SensitiveDataPageProps): JSX.Element {
   const [sensitive, setSensitive] = useState<boolean>(isSensitive);
 
   const updateSensitiveDataStatus = async (markAs: boolean) => {
     setSensitive(markAs);
     const request: Application = {
-      id: id,
+      id,
       sensitiveData: markAs,
     };
     updateApplication(request);
@@ -38,6 +39,7 @@ export default function SensitiveData({
         <button
           onClick={() => updateSensitiveDataStatus(!sensitive)}
           className="govuk-button lbh-button lbh-button--secondary lbh-!-margin-top-1"
+          data-testid="test-sensitive-data-button"
         >
           Mark as {sensitive ? 'not' : ''} sensitive
         </button>

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -48,16 +48,17 @@ export default defineConfig({
       on('task', {
         nock: async ({ hostname, method, path, statusCode, body }) => {
           nock.activate();
-          console.log(
-            'nock will: %s %s%s respond with %d %o',
-            method,
-            hostname,
-            path,
-            statusCode,
-            body
-          );
+          // leving this here for debugging purposes.
+          // console.log(
+          //   'nock will: %s %s%s respond with %d %o',
+          //   method,
+          //   hostname,
+          //   path,
+          //   statusCode,
+          //   body
+          // );
           method = method.toLowerCase();
-          nock(hostname)[method](path).reply(statusCode, 'body');
+          nock(hostname)[method](path).reply(statusCode, body);
 
           return null;
         },

--- a/cypress/e2e/searchForAnApplication.cy.ts
+++ b/cypress/e2e/searchForAnApplication.cy.ts
@@ -5,7 +5,7 @@ import { screenPresets } from '../support/helpers';
 
 describe('Search for an application', () => {
   screenPresets.forEach((screenPreset) => {
-    it('as a read only user I only see the search results', () => {
+    it(`as a user in the read only group I only see the search results on ${screenPreset}`, () => {
       cy.viewport(screenPreset);
       cy.clearCookies();
       cy.loginAsUser('readOnly');
@@ -21,7 +21,7 @@ describe('Search for an application', () => {
     });
   });
   screenPresets.forEach((screenPreset) => {
-    it('as an officer I can engage with worktray', () => {
+    it(`as a user in the officer group I can engage with worktray on ${screenPreset}`, () => {
       cy.viewport(screenPreset);
       cy.clearCookies();
       cy.loginAsUser('officer');

--- a/cypress/e2e/viewAnApplication.cy.ts
+++ b/cypress/e2e/viewAnApplication.cy.ts
@@ -1,34 +1,90 @@
 import ApplicationsPage from '../pages/applications';
+import { screenPresets } from '../support/helpers';
 
-describe('View an application', () => {
-  it('as a read only user I cannot see edit buttons', () => {
-    cy.task('clearNock');
-    cy.clearCookies();
-    cy.loginAsUser('readOnly');
+describe('Application view page', () => {
+  screenPresets.forEach((screenPreset) => {
+    it(`as a read only group user I cannot edit application details on ${screenPreset}`, () => {
+      cy.viewport(screenPreset);
 
-    ApplicationsPage.visit();
-    ApplicationsPage.getSearchInput().should('be.visible');
-    ApplicationsPage.getSearchInput().type('1');
-    ApplicationsPage.getSearchSubmitButton().click();
-    ApplicationsPage.getSearchResultsBox().should('be.visible');
+      cy.task('clearNock');
+      cy.clearCookies();
+      cy.loginAsUser('readOnly');
 
-    ApplicationsPage.getViewApplicationLink()
-      .first()
-      .invoke('attr', 'href')
-      .then((href) => {
-        const targetId = href.split('/').pop();
-        cy.task('nock', {
-          hostname: Cypress.env('ACTIVITY_HISTORY_API'),
-          method: 'GET',
-          path: `/activityhistory?targetId=${targetId}&pageSize=100`,
-          status: 200,
-          body: {
-            results: [{}],
-            paginationDetails: { hasNext: false, nextToken: '' },
-          },
+      ApplicationsPage.visit();
+      ApplicationsPage.getSearchInput().should('be.visible');
+      ApplicationsPage.getSearchInput().type('1');
+      ApplicationsPage.getSearchSubmitButton().click();
+      ApplicationsPage.getSearchResultsBox().should('be.visible');
+
+      ApplicationsPage.getViewApplicationLink()
+        .first()
+        .invoke('attr', 'href')
+        .then((href) => {
+          const targetId = href.split('/').pop();
+          cy.task('nock', {
+            hostname: Cypress.env('ACTIVITY_HISTORY_API'),
+            method: 'GET',
+            path: `/activityhistory?targetId=${targetId}&pageSize=100`,
+            status: 200,
+            body: {
+              results: [{}],
+              paginationDetails: { hasNext: false, nextToken: '' },
+            },
+          });
+
+          ApplicationsPage.getViewApplicationLink().first().click();
         });
 
-        ApplicationsPage.getViewApplicationLink().first().click();
-      });
+      ApplicationsPage.getEditApplicantButton().should('not.exist');
+      ApplicationsPage.getEditHouseholdMemberButton().should('not.exist');
+      ApplicationsPage.getSensitiveDataButton().should('not.exist');
+      ApplicationsPage.getChangeApplicationDateButton().should('not.exist');
+      ApplicationsPage.getChangeApplicationStatusButton().should('not.exist');
+      ApplicationsPage.getAddHouseholdMemberButton().should('not.exist');
+
+      cy.task('clearNock');
+    });
+  });
+  screenPresets.forEach((screenPreset) => {
+    it(`as a manager group user I can edit all application details on ${screenPreset}`, () => {
+      cy.viewport(screenPreset);
+
+      cy.task('clearNock');
+      cy.clearCookies();
+      cy.loginAsUser('manager');
+
+      ApplicationsPage.visit();
+      ApplicationsPage.getSearchInput().should('be.visible');
+      ApplicationsPage.getSearchInput().type('1');
+      ApplicationsPage.getSearchSubmitButton().click();
+      ApplicationsPage.getSearchResultsBox().should('be.visible');
+
+      ApplicationsPage.getViewApplicationLink()
+        .first()
+        .invoke('attr', 'href')
+        .then((href) => {
+          const targetId = href.split('/').pop();
+          cy.task('nock', {
+            hostname: Cypress.env('ACTIVITY_HISTORY_API'),
+            method: 'GET',
+            path: `/activityhistory?targetId=${targetId}&pageSize=100`,
+            status: 200,
+            body: {
+              results: [{}],
+              paginationDetails: { hasNext: false, nextToken: '' },
+            },
+          });
+
+          ApplicationsPage.getViewApplicationLink().first().click();
+        });
+
+      ApplicationsPage.getEditApplicantButton().should('be.visible');
+      ApplicationsPage.getEditHouseholdMemberButton().should('be.visible');
+      ApplicationsPage.getSensitiveDataButton().should('be.visible');
+      ApplicationsPage.getChangeApplicationDateButton().should('be.visible');
+      ApplicationsPage.getChangeApplicationStatusButton().should('be.visible');
+      ApplicationsPage.getAddHouseholdMemberButton().should('be.visible');
+      cy.task('clearNock');
+    });
   });
 });

--- a/cypress/pages/applications.ts
+++ b/cypress/pages/applications.ts
@@ -40,5 +40,65 @@ class ApplicationsPage {
     const testIdPrefix = 'test-view-application-link-';
     return this.getSearchResultsBox().get(`[data-testid^="${testIdPrefix}"]`);
   }
+
+  // applications/view/:id
+  static getApplicantTable() {
+    const testId = 'test-applicant-table';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getEditApplicantButton() {
+    const testIdPrefix = 'test-edit-applicant-button-';
+    return this.getApplicantTable().get(`[data-testid^="${testIdPrefix}"]`);
+  }
+
+  static getOtherHouseholdMembersTable() {
+    const testId = 'test-other-household-members';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getEditHouseholdMemberButton() {
+    const testIdPrefix = 'test-edit-household-member-button-';
+    return this.getOtherHouseholdMembersTable().get(
+      `[data-testid^="${testIdPrefix}"]`
+    );
+  }
+
+  static getAddHouseholdMemberButton() {
+    const testId = 'test-add-household-member-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getNavItem(menuItem: string) {
+    const testId = `test-nav-item-${menuItem}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  // sidebar
+  static getViewApplicationSidebar() {
+    const testId = 'test-view-application-sidebar';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getAssignUserButton() {
+    const testId = 'test-assign-user-button';
+    return this.getViewApplicationSidebar().get(`[data-testid="${testId}"]`);
+  }
+
+  static getSensitiveDataButton() {
+    const testId = 'test-sensitive-data-button';
+    return this.getViewApplicationSidebar().get(`[data-testid="${testId}"]`);
+  }
+
+  static getChangeApplicationDateButton() {
+    const testId = 'test-change-application-date-button';
+    return this.getViewApplicationSidebar().get(`[data-testid="${testId}"]`);
+  }
+
+  static getChangeApplicationStatusButton() {
+    const testId = 'test-change-application-status-button';
+    return this.getViewApplicationSidebar().get(`[data-testid="${testId}"]`);
+  }
 }
+
 export default ApplicationsPage;

--- a/pages/applications/view/[id]/index.tsx
+++ b/pages/applications/view/[id]/index.tsx
@@ -213,12 +213,16 @@ export default function ApplicationPage({
                           <ButtonLink
                             additionalCssClasses="govuk-secondary lbh-button--secondary"
                             href={`/applications/edit/${data.id}/add-household-member`}
+                            dataTestId="test-add-household-member-button"
                           >
                             + Add household member
                           </ButtonLink>
                         )}
                       </div>
-                      <div className="govuk-grid-column-one-third">
+                      <div
+                        className="govuk-grid-column-one-third"
+                        data-testid="test-view-application-sidebar"
+                      >
                         <HeadingThree content="Case details" />
 
                         <CaseDetailsItem
@@ -243,6 +247,7 @@ export default function ApplicationPage({
                               ? 'Change'
                               : undefined
                           }
+                          dataTestId="test-change-application-status-button"
                           onClick={() => handleTabChange('assessment')}
                         />
 
@@ -264,6 +269,7 @@ export default function ApplicationPage({
                                 ? 'Change'
                                 : undefined
                             }
+                            dataTestId="test-change-application-date-button"
                             onClick={() => handleTabChange('assessment')}
                           />
                         )}


### PR DESCRIPTION
https://hackney.atlassian.net/browse/TS-1561?atlOrigin=eyJpIjoiYmU3MTRkNmU5YTJjNDRjNjg5YTZiZmU0MDkyYWQwYWUiLCJwIjoiaiJ9

**What**
- Extends e2e Test to make sure a read-only user cannot see edit items in the view page.
- Refactors AssignUser to avoid nested ternary, and some other minor refactoring where linting was required.  

**Why** 
We want to ensure a user with a read-only token cannot see edit buttons, or make changes.

**How**
Extends the page model to cover required items and expands the view an application test.

**Future**
Mock the API so we're not calling the dev database for search. 
