### PR TITLE
TS-1569 - remove edit main applicant access from read only users

### DIFF
--- a/cypress/e2e/editMainApplicant.cy.ts
+++ b/cypress/e2e/editMainApplicant.cy.ts
@@ -1,0 +1,13 @@
+import { faker } from '@faker-js/faker';
+
+describe('Edit main applicant', () => {
+  it('shows access denied page for user with read only permissions', () => {
+    const applicationId = faker.string.uuid();
+    const mainApplicantId = faker.string.uuid();
+
+    cy.clearAllCookies();
+    cy.loginAsUser('readOnly');
+    cy.visit(`applications/edit/${applicationId}/${mainApplicantId}`);
+    cy.contains('Access denied');
+  });
+});

--- a/pages/applications/edit/[id]/[person]/index.tsx
+++ b/pages/applications/edit/[id]/[person]/index.tsx
@@ -1,23 +1,27 @@
 import { useState } from 'react';
+
+import { FormikValues } from 'formik';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import { FormikValues } from 'formik';
-import {
-  Application,
-  Address as ApiAddress,
-} from '../../../../../domain/HousingApi';
-import { getApplication } from '../../../../../lib/gateways/applications-api';
-import { getRedirect, getSession } from '../../../../../lib/utils/googleAuth';
-import { updateApplication } from '../../../../../lib/gateways/internal-api';
-import Custom404 from '../../../../404';
+
+import MainApplicantForm from '../../../../../components/admin/MainApplicantForm';
 import { HackneyGoogleUser } from '../../../../../domain/HackneyGoogleUser';
 import {
+  Address as ApiAddress,
+  Application,
+} from '../../../../../domain/HousingApi';
+import { getApplication } from '../../../../../lib/gateways/applications-api';
+import { updateApplication } from '../../../../../lib/gateways/internal-api';
+import {
   Address,
-  generateQuestionArray,
   convertAddressToPrimary,
+  generateQuestionArray,
 } from '../../../../../lib/utils/adminHelpers';
+import { getRedirect, getSession } from '../../../../../lib/utils/googleAuth';
 import { scrollToTop } from '../../../../../lib/utils/scroll';
-import MainApplicantForm from '../../../../../components/admin/MainApplicantForm';
+import Custom404 from '../../../../404';
+
+/* eslint-disable react/no-unused-prop-types */
 interface PageProps {
   user: HackneyGoogleUser;
   data: Application;
@@ -85,7 +89,7 @@ export default function EditApplicant({ user, data }: PageProps): JSX.Element {
       });
     });
   };
-
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   const handleSaveApplication = (isValid: any, touched: any) => {
     const isTouched = Object.keys(touched).length !== 0;
     if (!isValid || !isTouched) {
@@ -94,12 +98,12 @@ export default function EditApplicant({ user, data }: PageProps): JSX.Element {
 
     setIsSubmitted(true);
   };
-
+  /* eslint-disable react/jsx-no-useless-fragment */
   return (
     <>
       {data.id ? (
         <MainApplicantForm
-          isEditing={true}
+          isEditing={true} //eslint-disable-line
           user={user}
           onSubmit={onSubmit}
           isSubmitted={isSubmitted}
@@ -119,7 +123,7 @@ export default function EditApplicant({ user, data }: PageProps): JSX.Element {
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const user = getSession(context.req);
-  const redirect = getRedirect(user);
+  const redirect = getRedirect(user, true);
   if (redirect) {
     return {
       props: {},


### PR DESCRIPTION
## WHAT
Currently read only users can access the edit main applicant page directly. This access must be removed.

## WHY
We don't want read only users editing main applicant details.

## HOW
Implement updated `getRedirect` function that supports checking for read only permissions.

## FUTURE
Resolve the linting issues