### PR TITLE
TS-1564 hide assessment section from read only users

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -47,7 +47,9 @@ export default defineConfig({
       });
       on('task', {
         nock: async ({ hostname, method, path, statusCode, body }) => {
-          nock.activate();
+          if (!nock.isActive()) {
+            nock.activate();
+          }
           // leving this here for debugging purposes.
           // console.log(
           //   'nock will: %s %s%s respond with %d %o',

--- a/cypress/e2e/pages/viewApplication.cy.ts
+++ b/cypress/e2e/pages/viewApplication.cy.ts
@@ -1,0 +1,28 @@
+import { faker } from '@faker-js/faker';
+
+import { ApplicationStatus } from '../../../lib/types/application-status';
+import { generateApplication } from '../../../testUtils/applicationHelper';
+import ViewApplicationPage from '../../pages/viewApplication';
+
+describe('View a resident application', () => {
+  it('does not show the assessment area for read only users', () => {
+    const applicationId = faker.string.uuid();
+    const personId = faker.string.uuid();
+    const application = generateApplication(applicationId, personId);
+    //ensure application requires assessment
+    application.status = ApplicationStatus.SUBMITTED;
+
+    cy.task('clearNock');
+    cy.clearAllCookies();
+    cy.loginAsUser('readOnly');
+
+    ViewApplicationPage.mockActivityHistoryApi(applicationId);
+    ViewApplicationPage.mockHousingRegisterApiGetApplications(
+      applicationId,
+      application
+    );
+
+    ViewApplicationPage.visit(applicationId);
+    ViewApplicationPage.getAssessmentNavLink().should('not.exist');
+  });
+});

--- a/cypress/pages/viewApplication.ts
+++ b/cypress/pages/viewApplication.ts
@@ -1,0 +1,45 @@
+import { Application } from '../../domain/HousingApi';
+
+class ViewApplicationPage {
+  static visit(applicationId: string) {
+    cy.visit(`/applications/view/${applicationId}`);
+  }
+
+  static getAssessmentNavLink() {
+    const testId = 'test-applicant-assessment-section-navigation';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static mockHousingRegisterApiGetApplications(
+    applicationId: string,
+    application: Application
+  );
+
+  static mockHousingRegisterApiGetApplications(
+    applicationId: string,
+    application: Application
+  ) {
+    cy.task('nock', {
+      hostname: `${Cypress.env('HOUSING_REGISTER_API')}`,
+      method: 'GET',
+      path: `/applications/${applicationId}`,
+      status: 200,
+      body: application,
+    });
+  }
+
+  static mockActivityHistoryApi(targetId) {
+    cy.task('nock', {
+      hostname: `${Cypress.env('ACTIVITY_HISTORY_API')}`,
+      method: 'GET',
+      path: `/activityhistory?targetId=${targetId}&pageSize=100`,
+      status: 200,
+      body: {
+        results: [{}],
+        paginationDetails: { hasNext: false, nextToken: '' },
+      },
+    });
+  }
+}
+
+export default ViewApplicationPage;

--- a/pages/applications/view/[id]/index.tsx
+++ b/pages/applications/view/[id]/index.tsx
@@ -143,6 +143,7 @@ export default function ApplicationPage({
                       handleSelectNavItem={() => handleTabChange('assessment')}
                       itemName="assessment"
                       isActive={tab === 'assessment'}
+                      dataTestId="test-applicant-assessment-section-navigation"
                     >
                       Assessment
                     </HorizontalNavItem>


### PR DESCRIPTION
## WHAT
Hide assessment section from read only users.

## WHY
Read only users shouldn't be able to see any of the details or features related to assessments.

## HOW
Stop assessment section from rendering when user has read only permissions only. Also update the cypress command for nock to enable multiple APIs to be mocked at the same time.

## FUTURE
Refactor test setups to keep things DRY and share as much of the setup functionality as possible. For example move API mocks from page models to Cypress comands. 
