### PR TITLE
TS-1573 Add auth tests for complete and evidence endpoints

### DIFF
--- a/__tests__/pages/api/applications/[id]/complete.spec.ts
+++ b/__tests__/pages/api/applications/[id]/complete.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+
+import { faker } from '@faker-js/faker';
+import { StatusCodes } from 'http-status-codes';
+
+import { Application } from 'domain/HousingApi';
+
+import * as applicationApi from '../../../../../lib/gateways/applications-api';
+import * as requestAuth from '../../../../../lib/utils/requestAuth';
+import endpoint from '../../../../../pages/api/applications/[id]/complete';
+import { generateMockRequestResponseWithHackneyToken } from '../../../../../testUtils/apiHelper';
+import {
+  UserRole,
+  generateSignedTokenByRole,
+} from '../../../../../testUtils/userHelper';
+
+const applicationId = faker.string.uuid();
+const mockApplicationData: Application = {
+  id: applicationId,
+};
+
+describe('authorization', () => {
+  //claims in the token don't matter in these tests, it just need to exist
+  const { signedToken } = generateSignedTokenByRole(UserRole.Officer);
+  jest
+    .spyOn(applicationApi, 'completeApplication')
+    .mockResolvedValue({ ...mockApplicationData });
+
+  it('returns status code 403 and error message when canUpdateApplication returns false', async () => {
+    jest.spyOn(requestAuth, 'canUpdateApplication').mockReturnValue(false);
+
+    const { req, res } = generateMockRequestResponseWithHackneyToken({
+      hackneyToken: signedToken,
+      requestBody: undefined,
+      method: 'PATCH',
+    });
+
+    req.query.id = applicationId;
+
+    const expectedErrorMessage = { message: 'Unable to update application' };
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
+    expect(res._getJSONData()).toStrictEqual(expectedErrorMessage);
+  });
+
+  it('returns status code 200 when canUpdateApplication returns true', async () => {
+    jest.spyOn(requestAuth, 'canUpdateApplication').mockReturnValue(true);
+
+    const { req, res } = generateMockRequestResponseWithHackneyToken({
+      hackneyToken: signedToken,
+      requestBody: undefined,
+      method: 'PATCH',
+    });
+
+    req.query.id = applicationId;
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.OK);
+  });
+});

--- a/__tests__/pages/api/applications/[id]/evidence.spec.ts
+++ b/__tests__/pages/api/applications/[id]/evidence.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ */
+
+import { faker } from '@faker-js/faker';
+import { StatusCodes } from 'http-status-codes';
+
+import * as applicationApi from '../../../../../lib/gateways/applications-api';
+import * as requestAuth from '../../../../../lib/utils/requestAuth';
+import endpoint from '../../../../../pages/api/applications/[id]/evidence';
+import { generateMockRequestResponseWithHackneyToken } from '../../../../../testUtils/apiHelper';
+import {
+  UserRole,
+  generateSignedTokenByRole,
+} from '../../../../../testUtils/userHelper';
+
+const applicationId = faker.string.uuid();
+
+describe('authorization', () => {
+  //claims in the token don't matter in these tests, it just need to exist
+  const { signedToken } = generateSignedTokenByRole(UserRole.Officer);
+  jest.spyOn(applicationApi, 'createEvidenceRequest').mockResolvedValue(null);
+
+  it('returns status code 403 and error message when canUpdateApplication returns false', async () => {
+    jest.spyOn(requestAuth, 'canUpdateApplication').mockReturnValue(false);
+
+    const { req, res } = generateMockRequestResponseWithHackneyToken({
+      hackneyToken: signedToken,
+      requestBody: undefined,
+      method: 'POST',
+    });
+
+    req.query.id = applicationId;
+
+    const expectedErrorMessage = { message: 'Unable to update application' };
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
+    expect(res._getJSONData()).toStrictEqual(expectedErrorMessage);
+  });
+
+  it('returns status code 200 when canUpdateApplication returns true', async () => {
+    jest.spyOn(requestAuth, 'canUpdateApplication').mockReturnValue(true);
+
+    const { req, res } = generateMockRequestResponseWithHackneyToken({
+      hackneyToken: signedToken,
+      requestBody: undefined,
+      method: 'POST',
+    });
+
+    req.query.id = applicationId;
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.OK);
+  });
+});


### PR DESCRIPTION
## WHAT
There are two additional PATCH and POST endpoints that weren't covered in previous read only feature related tickets. These are:
POST: `/applications/[id]/evidence`
PATCH: `/applications/[id]/complete`

The `canUpdateApplication` function used for authorization in both endpoints has been covered already elsewhere, so this update just adds authorization related tests to ensure endpoints return correct status code based on the result of `canUpdateApplication` authorization function.

## WHY
Read only users should not have access to perform either of those operations i.e. create evidence requests or complete applications.

## HOW
Add tests to check that correct status code is returned based on the `canUpdateApplication` response.

# FUTURE
Add full test coverage to both end points to cover error handling etc.