### PR TITLE
TS-1595 Fix test jet covarege config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,10 @@ jobs:
           path: test_results
       - store_artifacts:
           path: coverage
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - .
 
   sonar-scan:
     executor: node-executor

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=LBHackney-IT_lbh-housing-register
 sonar.organization=lbhackney-it
-sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sources=pages,components,lib
 sonar.tests=pages,components,lib
 # exclude test files


### PR DESCRIPTION
## WHAT
Currently SonarCloud is not reporting code coverage even though the reporting has been setup in jest. This update fixes the configuration to make the jest coverage reports available to sonar-scan job.

## WHY
We want to see code coverage reports for exisitng code base and new changes

## HOW
Persist the test coverage reports to make them available to sonar-scan job

## FUTURE
Implement cypress code coverage to further improve coverage reporting