### PR TITLE
Ts 1635 housing reg view only viewport testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,14 +173,32 @@ workflows:
             - run-tests
       - run-cypress-e2e:
           matrix:
-            name: E2E Tests
             parameters:
               browser: [chrome, firefox]
-              height: [800, 1000]
-              width: [1280, 200]
-            requires:
-              - install-dependencies
-            # browser: chrome
+              # mobile, tablet, chromebook/desktop
+              height: [480, 768, 960]
+              # mobile, tablet, chromebook, desktop
+              width: [320, 1024, 1366, 1536]
+            exclude:
+              - height: 480
+                width: 1536
+              - height: 480
+                width: 1366
+              - height: 480
+                width: 1024
+              - height: 768
+                width: 320
+              - height: 768
+                width: 1366
+              - height: 768
+                width: 1536
+              - height: 960
+                width: 1366
+              - height: 960
+                width: 1024
+              - height: 960
+                width: 320
+            requires: install-dependencies
             filters:
               branches:
                 only: TS-1635-Housing-reg-view-only-viewport-testing
@@ -244,8 +262,12 @@ workflows:
           context: api-assume-role-housing-development-context
           requires:
             - run-cypress-e2e
-            # - E2E Tests - Chrome
-            # - E2E Tests - Firefox
+            # - E2E Tests - Chrome - Desktop
+            # - E2E Tests - Firefox - Desktop
+            # - E2E Tests - Chrome - Mobile
+            # - E2E Tests - Firefox - Mobile
+            # - E2E Tests - Chrome - Tablet
+            # - E2E Tests - Firefox - Tablet
           filters:
             branches:
               only: development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ workflows:
               height: [480, 768, 960]
               # mobile, tablet, chromebook, desktop
               width: [320, 1024, 1366, 1536]
-            exclude:
+            excludes:
               - browser: [chrome, firefox]
                 height: 480
                 width: [1536, 1366, 1024]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
           install-command: npm install
           post-install: npm run build
       - cypress/run-tests:
-          cypress-command: npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >> viewportWidth=<< parameters.width >> --reporter cypress-circleci-reporter
+          cypress-command: npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter cypress-circleci-reporter
       - store_test_results:
           path: test_results
 
@@ -233,7 +233,7 @@ workflows:
                 width: 320
           filters:
             branches:
-              only: development
+              only: TS-1635-Housing-reg-view-only-viewport-testing
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ workflows:
                 width: 320
           filters:
             branches:
-              only: TS-1635-Housing-reg-view-only-viewport-testing
+              only: development
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           install-command: npm install
           post-install: npm run build
       - cypress/run-tests:
-          cypress-command: npx cypress run --browser=<< parameters.browser >> --viewportHeight="1000" --viewportWidth="1920" --reporter cypress-circleci-reporter
+          cypress-command: npx cypress run --browser=<< parameters.browser >> --viewportHeight=1000 --viewportWidth=1920 --reporter cypress-circleci-reporter
       - store_test_results:
           path: test_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,16 +179,55 @@ workflows:
               height: [480, 768, 960]
               # mobile, tablet, chromebook, desktop
               width: [320, 1024, 1366, 1536]
-            excludes:
-              - browser: [chrome, firefox]
+            exclude:
+              - browser: chrome
                 height: 480
-                width: [1536, 1366, 1024]
-              - browser: [chrome, firefox]
+                width: 1536
+              - browser: chrome
+                height: 480
+                width: 1366
+              - browser: chrome
+                height: 480
+                width: 1024
+              - browser: firefox
+                height: 480
+                width: 1536
+              - browser: firefox
+                height: 480
+                width: 1366
+              - browser: firefox
+                height: 480
+                width: 1024
+              - browser: chrome
                 height: 768
-                width: [1536, 1366, 320]
-              - browser: [chrome, firefox]
+                width: 1536
+              - browser: chrome
+                height: 768
+                width: 1366
+              - browser: chrome
+                height: 768
+                width: 320
+              - browser: firefox
+                height: 768
+                width: 1536
+              - browser: firefox
+                height: 768
+                width: 1366
+              - browser: firefox
+                height: 768
+                width: 320
+              - browser: chrome
                 height: 960
-                width: [1024, 320]
+                width: 1024
+              - browser: chrome
+                height: 960
+                width: 320
+              - browser: firefox
+                height: 960
+                width: 1024
+              - browser: firefox
+                height: 960
+                width: 320
             requires: install-dependencies
             filters:
               branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,8 @@ workflows:
           requires:
             - run-tests
       - run-cypress-e2e:
+          requires:
+            - install-dependencies
           matrix:
             parameters:
               browser: [chrome, firefox]
@@ -228,10 +230,9 @@ workflows:
               - browser: firefox
                 height: 960
                 width: 320
-            requires: install-dependencies
-            filters:
-              branches:
-                only: TS-1635-Housing-reg-view-only-viewport-testing
+          filters:
+            branches:
+              only: TS-1635-Housing-reg-view-only-viewport-testing
       # - run-cypress-e2e:
       #     name: E2E Tests - Chrome - Desktop
       #     requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,7 @@ workflows:
               # mobile, tablet, chromebook, desktop
               width: [320, 1024, 1366, 1536]
             exclude:
+              # exclude screen combinations that don't make sense
               - browser: chrome
                 height: 480
                 width: 1536
@@ -232,73 +233,11 @@ workflows:
                 width: 320
           filters:
             branches:
-              only: TS-1635-Housing-reg-view-only-viewport-testing
-      # - run-cypress-e2e:
-      #     name: E2E Tests - Chrome - Desktop
-      #     requires:
-      #       - install-dependencies
-      #     browser: chrome
-      #     filters:
-      #       branches:
-      #         only: TS-1635-Housing-reg-view-only-viewport-testing
-      # - run-cypress-e2e:
-      #     name: E2E Tests - Firefox - Desktop
-      #     requires:
-      #       - install-dependencies
-      #     browser: firefox
-      #     filters:
-      #       branches:
-      #         only: TS-1635-Housing-reg-view-only-viewport-testing
-      # - run-cypress-e2e:
-      #     name: E2E Tests - Chrome - Mobile
-      #     requires:
-      #       - install-dependencies
-      #     browser: chrome
-      #     height: 480
-      #     width: 320
-      #     filters:
-      #       branches:
-      #         only: TS-1635-Housing-reg-view-only-viewport-testing
-      # - run-cypress-e2e:
-      #     name: E2E Tests - Firefox - Mobile
-      #     requires:
-      #       - install-dependencies
-      #     browser: firefox
-      #     height: 480
-      #     width: 320
-      #     filters:
-      #       branches:
-      #         only: TS-1635-Housing-reg-view-only-viewport-testing
-      # - run-cypress-e2e:
-      #     name: E2E Tests - Chrome - Tablet
-      #     requires:
-      #       - install-dependencies
-      #     browser: chrome
-      #     height: 768
-      #     width: 1024
-      #     filters:
-      #       branches:
-      #         only: TS-1635-Housing-reg-view-only-viewport-testing
-      # - run-cypress-e2e:
-      #     name: E2E Tests - Firefox - Tablet
-      #     requires:
-      #       - install-dependencies
-      #     browser: firefox
-      #     height: 768
-      #     width: 1024
-      #     filters:
-      #       branches:
-      #         only: TS-1635-Housing-reg-view-only-viewport-testing
+              only: development
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
             - run-cypress-e2e
-            # - E2E Tests - Chrome - Desktop
-            # - E2E Tests - Firefox - Desktop
-            # - E2E Tests - Chrome - Mobile
-            # - E2E Tests - Firefox - Mobile
-            # - E2E Tests - Chrome - Tablet
-            # - E2E Tests - Firefox - Tablet
           filters:
             branches:
               only: development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           install-command: npm install
           post-install: npm run build
       - cypress/run-tests:
-          cypress-command: npx cypress run --browser=<< parameters.browser >> --viewportHeight=1000 --viewportWidth=1920 --reporter cypress-circleci-reporter
+          cypress-command: npx cypress run --browser=<< parameters.browser >> --config viewportHeight=1000 viewportWidth=1920 --reporter cypress-circleci-reporter
       - store_test_results:
           path: test_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,24 +180,15 @@ workflows:
               # mobile, tablet, chromebook, desktop
               width: [320, 1024, 1366, 1536]
             exclude:
-              - height: 480
-                width: 1536
-              - height: 480
-                width: 1366
-              - height: 480
-                width: 1024
-              - height: 768
-                width: 320
-              - height: 768
-                width: 1366
-              - height: 768
-                width: 1536
-              - height: 960
-                width: 1366
-              - height: 960
-                width: 1024
-              - height: 960
-                width: 320
+              - browser: [chrome, firefox]
+                height: 480
+                width: [1536, 1366, 1024]
+              - browser: [chrome, firefox]
+                height: 768
+                width: [1536, 1366, 320]
+              - browser: [chrome, firefox]
+                height: 960
+                width: [1024, 320]
             requires: install-dependencies
             filters:
               branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,12 @@ jobs:
       browser:
         type: string
         default: chrome
+      height:
+        type: integer
+        default: 768
+      width:
+        type: integer
+        default: 1366
     steps:
       - cypress/install:
           package-manager: npm
@@ -85,7 +91,7 @@ jobs:
           install-command: npm install
           post-install: npm run build
       - cypress/run-tests:
-          cypress-command: npx cypress run --browser=<< parameters.browser >> --config viewportHeight=1000 viewportWidth=1920 --reporter cypress-circleci-reporter
+          cypress-command: npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >> viewportWidth=<< parameters.width >> --reporter cypress-circleci-reporter
       - store_test_results:
           path: test_results
 
@@ -166,26 +172,80 @@ workflows:
           requires:
             - run-tests
       - run-cypress-e2e:
-          name: E2E Tests - Chrome
-          requires:
-            - install-dependencies
-          browser: chrome
-          filters:
-            branches:
-              only: TS-1635-Housing-reg-view-only-viewport-testing
-      - run-cypress-e2e:
-          name: E2E Tests - Firefox
-          requires:
-            - install-dependencies
-          browser: firefox
-          filters:
-            branches:
-              only: TS-1635-Housing-reg-view-only-viewport-testing
+          matrix:
+            name: E2E Tests
+            parameters:
+              browser: [chrome, firefox]
+              height: [800, 1000]
+              width: [1280, 200]
+            requires:
+              - install-dependencies
+            # browser: chrome
+            filters:
+              branches:
+                only: TS-1635-Housing-reg-view-only-viewport-testing
+      # - run-cypress-e2e:
+      #     name: E2E Tests - Chrome - Desktop
+      #     requires:
+      #       - install-dependencies
+      #     browser: chrome
+      #     filters:
+      #       branches:
+      #         only: TS-1635-Housing-reg-view-only-viewport-testing
+      # - run-cypress-e2e:
+      #     name: E2E Tests - Firefox - Desktop
+      #     requires:
+      #       - install-dependencies
+      #     browser: firefox
+      #     filters:
+      #       branches:
+      #         only: TS-1635-Housing-reg-view-only-viewport-testing
+      # - run-cypress-e2e:
+      #     name: E2E Tests - Chrome - Mobile
+      #     requires:
+      #       - install-dependencies
+      #     browser: chrome
+      #     height: 480
+      #     width: 320
+      #     filters:
+      #       branches:
+      #         only: TS-1635-Housing-reg-view-only-viewport-testing
+      # - run-cypress-e2e:
+      #     name: E2E Tests - Firefox - Mobile
+      #     requires:
+      #       - install-dependencies
+      #     browser: firefox
+      #     height: 480
+      #     width: 320
+      #     filters:
+      #       branches:
+      #         only: TS-1635-Housing-reg-view-only-viewport-testing
+      # - run-cypress-e2e:
+      #     name: E2E Tests - Chrome - Tablet
+      #     requires:
+      #       - install-dependencies
+      #     browser: chrome
+      #     height: 768
+      #     width: 1024
+      #     filters:
+      #       branches:
+      #         only: TS-1635-Housing-reg-view-only-viewport-testing
+      # - run-cypress-e2e:
+      #     name: E2E Tests - Firefox - Tablet
+      #     requires:
+      #       - install-dependencies
+      #     browser: firefox
+      #     height: 768
+      #     width: 1024
+      #     filters:
+      #       branches:
+      #         only: TS-1635-Housing-reg-view-only-viewport-testing
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:
-            - E2E Tests - Chrome
-            - E2E Tests - Firefox
+            - run-cypress-e2e
+            # - E2E Tests - Chrome
+            # - E2E Tests - Firefox
           filters:
             branches:
               only: development

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           install-command: npm install
           post-install: npm run build
       - cypress/run-tests:
-          cypress-command: npx cypress run --browser=<< parameters.browser >> --reporter cypress-circleci-reporter
+          cypress-command: npx cypress run --browser=<< parameters.browser >> --viewportHeight="1000" --viewportWidth="1920" --reporter cypress-circleci-reporter
       - store_test_results:
           path: test_results
 
@@ -172,7 +172,7 @@ workflows:
           browser: chrome
           filters:
             branches:
-              only: development
+              only: TS-1635-Housing-reg-view-only-viewport-testing
       - run-cypress-e2e:
           name: E2E Tests - Firefox
           requires:
@@ -180,7 +180,7 @@ workflows:
           browser: firefox
           filters:
             branches:
-              only: development
+              only: TS-1635-Housing-reg-view-only-viewport-testing
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/cypress/e2e/cookies.cy.ts
+++ b/cypress/e2e/cookies.cy.ts
@@ -1,26 +1,21 @@
 import HomePage from '../pages/home';
-import { screenPresets } from '../support/helpers';
 
 context('Cookies', () => {
-  screenPresets.forEach((screenPreset) => {
-    it(`user successfully selects accept cookies button on ${screenPreset}`, () => {
-      cy.viewport(screenPreset);
+  it('user successfully selects accept cookies button', () => {
+    HomePage.visit();
 
-      HomePage.visit();
+    cy.clearCookies();
 
-      cy.clearCookies();
+    HomePage.getCookiesButton().scrollIntoView();
+    HomePage.getCookiesBanner().should('be.visible');
 
-      HomePage.getCookiesButton().scrollIntoView();
-      HomePage.getCookiesBanner().should('be.visible');
-
-      HomePage.getCookiesButton().click();
-      HomePage.getCookiesBanner().should('not.be.visible');
-      cy.getCookie('seen_cookie_message').should('exist');
-      cy.getCookie('seen_cookie_message').should(
-        'have.property',
-        'value',
-        'true'
-      );
-    });
+    HomePage.getCookiesButton().click();
+    HomePage.getCookiesBanner().should('not.be.visible');
+    cy.getCookie('seen_cookie_message').should('exist');
+    cy.getCookie('seen_cookie_message').should(
+      'have.property',
+      'value',
+      'true'
+    );
   });
 });


### PR DESCRIPTION
***To be merged after https://github.com/LBHackney-IT/lbh-housing-register/pull/407 is successfully deployed to staging***

https://hackney.atlassian.net/browse/TS-1635?atlOrigin=eyJpIjoiODczNzk3MjM4ZGFhNGVhMDlhNmY2NjY0NDEwZDgwMjciLCJwIjoiaiJ9

**What**
- Adds view port testing pipeline configuration for e2e testing,
- Remove viewport inside tests.

**Why**
- As this is a public facing app we want to ensure that our tests can run on many browsers and screen sizes without error. 

**How**
- Configures viewportSize and viewportWidth as parameters to the --config flag in cypress job. Then a matrix workflow is setup to pass the various browsers and screen sizes required. 

**Future**
- As we expand test coverage, will look ensuring some tests start using touch based interactions.