### PR TITLE
TS- 1567 Make money and health sections visible for ro users

### DIFF
--- a/cypress/e2e/pages/reviewApplicant.cy.ts
+++ b/cypress/e2e/pages/reviewApplicant.cy.ts
@@ -19,15 +19,16 @@ describe('Review applicant details', () => {
     );
   });
 
-  it("doesn't show the money section for read only users", () => {
+  it('shows the money section for read only users', () => {
     ReviewApplicantPage.visit(applicationId, personId);
-    ReviewApplicantPage.getMoneySectionNavLink().should('not.exist');
+    ReviewApplicantPage.getMoneySectionNavLink().should('be.visible');
   });
 
-  it("doesn't show the health section for read only users", () => {
+  it('shows the health section for read only users', () => {
     ReviewApplicantPage.visit(applicationId, personId);
-    ReviewApplicantPage.getHealthSectionNavLink().should('not.exist');
+    ReviewApplicantPage.getHealthSectionNavLink().should('be.visible');
   });
+
   it("doesn't show the view documents button for read only users", () => {
     ReviewApplicantPage.visit(applicationId, personId);
     ReviewApplicantPage.getViewDocumentsButton().should('not.exist');

--- a/pages/applications/view/[id]/[person]/index.tsx
+++ b/pages/applications/view/[id]/[person]/index.tsx
@@ -159,26 +159,22 @@ export default function ApplicationPersonPage({
                   >
                     Living Situation
                   </HorizontalNavItem>
-                  {!hasReadOnlyPermissionOnly(user) && (
-                    <HorizontalNavItem
-                      handleSelectNavItem={handleSelectNavItem}
-                      itemName="money"
-                      isActive={activeNavItem === 'money'}
-                      dataTestId="test-applicant-money-section-navigation"
-                    >
-                      Money
-                    </HorizontalNavItem>
-                  )}
-                  {!hasReadOnlyPermissionOnly(user) && (
-                    <HorizontalNavItem
-                      handleSelectNavItem={handleSelectNavItem}
-                      itemName="health"
-                      isActive={activeNavItem === 'health'}
-                      dataTestId="test-applicant-health-section-navigation"
-                    >
-                      Health
-                    </HorizontalNavItem>
-                  )}
+                  <HorizontalNavItem
+                    handleSelectNavItem={handleSelectNavItem}
+                    itemName="money"
+                    isActive={activeNavItem === 'money'}
+                    dataTestId="test-applicant-money-section-navigation"
+                  >
+                    Money
+                  </HorizontalNavItem>
+                  <HorizontalNavItem
+                    handleSelectNavItem={handleSelectNavItem}
+                    itemName="health"
+                    isActive={activeNavItem === 'health'}
+                    dataTestId="test-applicant-health-section-navigation"
+                  >
+                    Health
+                  </HorizontalNavItem>
                   {/*
                   <HorizontalNavItem
                     handleSelectNavItem={handleSelectNavItem}


### PR DESCRIPTION
This update reverts the changes made in https://github.com/LBHackney-IT/lbh-housing-register/pull/403 to ensure read only users can see the money and health details for the applicant.