### PR TITLE
Ts 1637 housing reg view only ensure dev api is not being called e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ workflows:
           browser: chrome
           filters:
             branches:
-              only: TS-1637-Housing-reg-view-only-ensure-dev-api-is-not-being-called-e2e
+              only: development
       - run-cypress-e2e:
           name: E2E Tests - Firefox
           requires:
@@ -180,7 +180,7 @@ workflows:
           browser: firefox
           filters:
             branches:
-              only: TS-1637-Housing-reg-view-only-ensure-dev-api-is-not-being-called-e2e
+              only: development
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ workflows:
           browser: chrome
           filters:
             branches:
-              only: development
+              only: TS-1637-Housing-reg-view-only-ensure-dev-api-is-not-being-called-e2e
       - run-cypress-e2e:
           name: E2E Tests - Firefox
           requires:
@@ -180,7 +180,7 @@ workflows:
           browser: firefox
           filters:
             branches:
-              only: development
+              only: TS-1637-Housing-reg-view-only-ensure-dev-api-is-not-being-called-e2e
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -46,21 +46,26 @@ export default defineConfig({
         },
       });
       on('task', {
-        nock: async ({ hostname, method, path, statusCode, body }) => {
+        nock: async ({ hostname, method, path, statusCode, body, persist }) => {
           if (!nock.isActive()) {
             nock.activate();
           }
+
           // leaving this here for debugging purposes.
           // console.log(
           //   'nock will: %s %s%s respond with %d %o',
           //   method,
           //   hostname,
           //   path,
+          //   persist,
           //   statusCode,
           //   body
           // );
           method = method.toLowerCase();
-          nock(hostname)[method](path).reply(statusCode, body);
+          nock(hostname)
+            [method](path)
+            .reply(statusCode, body)
+            .persist(!!persist);
 
           return null;
         },

--- a/cypress/e2e/searchForAnApplication.cy.ts
+++ b/cypress/e2e/searchForAnApplication.cy.ts
@@ -11,20 +11,22 @@ describe('User searches for an application', () => {
 
     cy.task('clearNock');
     cy.clearCookies();
-    cy.loginAsUser('readOnly');
-    ApplicationsPage.visit();
-    ApplicationsPage.getApplicationsPage().should('be.visible');
-    ApplicationsPage.getSearchInput().should('be.visible');
-    ApplicationsPage.getWorktray().should('not.exist');
-    ApplicationsPage.getWorktraySidebar().should('not.exist');
-    ApplicationsPage.getSearchInput().type(
-      application.mainApplicant.person.firstName
-    );
-    cy.mockHousingRegisterApiPostSearchResults(application);
+    cy.loginAsUser('readOnly').then((user) => {
+      cy.mockHousingRegisterApiGetApplicationsByStatusAndAssignedTo(user);
+      ApplicationsPage.visit();
+      ApplicationsPage.getApplicationsPage().should('be.visible');
+      ApplicationsPage.getSearchInput().should('be.visible');
+      ApplicationsPage.getWorktray().should('not.exist');
+      ApplicationsPage.getWorktraySidebar().should('not.exist');
+      ApplicationsPage.getSearchInput().type(
+        application.mainApplicant.person.firstName
+      );
+      cy.mockHousingRegisterApiPostSearchResults(application);
 
-    ApplicationsPage.getSearchSubmitButton().click();
-    ApplicationsPage.getSearchInputBox().should('be.visible');
-    ApplicationsPage.getWorktraySidebar().should('not.exist');
+      ApplicationsPage.getSearchSubmitButton().click();
+      ApplicationsPage.getSearchInputBox().should('be.visible');
+      ApplicationsPage.getWorktraySidebar().should('not.exist');
+    });
   });
 
   it(`as a user in the officer group I can engage with the worktray features`, () => {
@@ -33,19 +35,21 @@ describe('User searches for an application', () => {
     const application = generateApplication(applicationId, personId);
     cy.task('clearNock');
     cy.clearCookies();
-    cy.loginAsUser('officer');
+    cy.loginAsUser('officer').then((user) => {
+      cy.mockHousingRegisterApiGetApplicationsByStatusAndAssignedTo(user);
 
-    ApplicationsPage.visit();
-    ApplicationsPage.getApplicationsPage().should('be.visible');
-    ApplicationsPage.getSearchInput().should('be.visible');
-    ApplicationsPage.getWorktray().should('be.visible');
-    ApplicationsPage.getWorktraySidebar().should('be.visible');
-    ApplicationsPage.getSearchInput().type(
-      application.mainApplicant.person.firstName
-    );
-    cy.mockHousingRegisterApiPostSearchResults(application);
-    ApplicationsPage.getSearchSubmitButton().click();
-    ApplicationsPage.getSearchResultsBox().should('be.visible');
-    ApplicationsPage.getWorktraySidebar().should('be.visible');
+      ApplicationsPage.visit();
+      ApplicationsPage.getApplicationsPage().should('be.visible');
+      ApplicationsPage.getSearchInput().should('be.visible');
+      ApplicationsPage.getWorktray().should('be.visible');
+      ApplicationsPage.getWorktraySidebar().should('be.visible');
+      ApplicationsPage.getSearchInput().type(
+        application.mainApplicant.person.firstName
+      );
+      cy.mockHousingRegisterApiPostSearchResults(application);
+      ApplicationsPage.getSearchSubmitButton().click();
+      ApplicationsPage.getSearchResultsBox().should('be.visible');
+      ApplicationsPage.getWorktraySidebar().should('be.visible');
+    });
   });
 });

--- a/cypress/e2e/viewAnApplication.cy.ts
+++ b/cypress/e2e/viewAnApplication.cy.ts
@@ -11,37 +11,38 @@ describe('User views a resident application', () => {
 
     cy.task('clearNock');
     cy.clearCookies();
-    cy.loginAsUser('readOnly');
 
-    ApplicationsPage.visit();
-    ApplicationsPage.getSearchInput().should('be.visible');
+    cy.loginAsUser('readOnly').then((user) => {
+      cy.mockHousingRegisterApiGetApplicationsByStatusAndAssignedTo(user);
+      ApplicationsPage.visit();
+      ApplicationsPage.getSearchInput().should('be.visible');
 
-    ApplicationsPage.getSearchInput().type(
-      application.mainApplicant.person.firstName
-    );
+      ApplicationsPage.getSearchInput().type(
+        application.mainApplicant.person.firstName
+      );
+      cy.mockHousingRegisterApiPostSearchResults(application);
 
-    cy.mockHousingRegisterApiPostSearchResults(application);
+      ApplicationsPage.getSearchSubmitButton().click();
+      ApplicationsPage.getSearchResultsBox().should('be.visible');
+      ApplicationsPage.getViewApplicationLink()
+        .first()
+        .invoke('attr', 'href')
+        .then((href) => {
+          const targetId = href.split('/').pop();
+          cy.mockActivityHistoryApiEmptyResponse(targetId);
+          ApplicationsPage.getViewApplicationLink().first().click();
+        });
 
-    ApplicationsPage.getSearchSubmitButton().click();
-    ApplicationsPage.getSearchResultsBox().should('be.visible');
-    ApplicationsPage.getViewApplicationLink()
-      .first()
-      .invoke('attr', 'href')
-      .then((href) => {
-        const targetId = href.split('/').pop();
-        cy.mockActivityHistoryApiEmptyResponse(targetId);
-        ApplicationsPage.getViewApplicationLink().first().click();
-      });
+      cy.mockHousingRegisterApiGetApplications(applicationId, application);
 
-    cy.mockHousingRegisterApiGetApplications(applicationId, application);
-
-    ApplicationsPage.getViewApplicationPage().should('be.visible');
-    ApplicationsPage.getEditApplicantButton().should('not.exist');
-    ApplicationsPage.getEditHouseholdMemberButton().should('not.exist');
-    ApplicationsPage.getSensitiveDataButton().should('not.exist');
-    ApplicationsPage.getChangeApplicationDateButton().should('not.exist');
-    ApplicationsPage.getChangeApplicationStatusButton().should('not.exist');
-    ApplicationsPage.getAddHouseholdMemberButton().should('not.exist');
+      ApplicationsPage.getViewApplicationPage().should('be.visible');
+      ApplicationsPage.getEditApplicantButton().should('not.exist');
+      ApplicationsPage.getEditHouseholdMemberButton().should('not.exist');
+      ApplicationsPage.getSensitiveDataButton().should('not.exist');
+      ApplicationsPage.getChangeApplicationDateButton().should('not.exist');
+      ApplicationsPage.getChangeApplicationStatusButton().should('not.exist');
+      ApplicationsPage.getAddHouseholdMemberButton().should('not.exist');
+    });
   });
 
   it('as a manager group user I can edit all application details', () => {
@@ -51,36 +52,38 @@ describe('User views a resident application', () => {
 
     cy.task('clearNock');
     cy.clearCookies();
-    cy.loginAsUser('manager');
 
-    ApplicationsPage.visit();
-    ApplicationsPage.getSearchInput().should('be.visible');
-    ApplicationsPage.getSearchInput().type(
-      application.mainApplicant.person.firstName
-    );
+    cy.loginAsUser('manager').then((user) => {
+      cy.mockHousingRegisterApiGetApplicationsByStatusAndAssignedTo(user);
+      ApplicationsPage.visit();
+      ApplicationsPage.getSearchInput().should('be.visible');
+      ApplicationsPage.getSearchInput().type(
+        application.mainApplicant.person.firstName
+      );
 
-    cy.mockHousingRegisterApiPostSearchResults(application);
+      cy.mockHousingRegisterApiPostSearchResults(application);
 
-    ApplicationsPage.getSearchSubmitButton().click();
-    ApplicationsPage.getSearchResultsBox().should('be.visible');
+      ApplicationsPage.getSearchSubmitButton().click();
+      ApplicationsPage.getSearchResultsBox().should('be.visible');
 
-    ApplicationsPage.getViewApplicationLink()
-      .first()
-      .invoke('attr', 'href')
-      .then((href) => {
-        const targetId = href.split('/').pop();
-        cy.mockActivityHistoryApiEmptyResponse(targetId);
-        ApplicationsPage.getViewApplicationLink().first().click();
-      });
+      ApplicationsPage.getViewApplicationLink()
+        .first()
+        .invoke('attr', 'href')
+        .then((href) => {
+          const targetId = href.split('/').pop();
+          cy.mockActivityHistoryApiEmptyResponse(targetId);
+          ApplicationsPage.getViewApplicationLink().first().click();
+        });
 
-    cy.mockHousingRegisterApiGetApplications(applicationId, application);
+      cy.mockHousingRegisterApiGetApplications(applicationId, application);
 
-    ApplicationsPage.getViewApplicationPage().should('be.visible');
-    ApplicationsPage.getEditApplicantButton().should('be.visible');
-    ApplicationsPage.getSensitiveDataButton().should('be.visible');
-    ApplicationsPage.getChangeApplicationDateButton().should('be.visible');
-    ApplicationsPage.getChangeApplicationStatusButton().should('be.visible');
-    ApplicationsPage.getEditHouseholdMemberButton().should('be.visible');
-    ApplicationsPage.getAddHouseholdMemberButton().should('be.visible');
+      ApplicationsPage.getViewApplicationPage().should('be.visible');
+      ApplicationsPage.getEditApplicantButton().should('be.visible');
+      ApplicationsPage.getSensitiveDataButton().should('be.visible');
+      ApplicationsPage.getChangeApplicationDateButton().should('be.visible');
+      ApplicationsPage.getChangeApplicationStatusButton().should('be.visible');
+      ApplicationsPage.getEditHouseholdMemberButton().should('be.visible');
+      ApplicationsPage.getAddHouseholdMemberButton().should('be.visible');
+    });
   });
 });

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -4,7 +4,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       generateEmptyApplication(): Chainable<void>;
-      loginAsUser(groups: string): Chainable<void>;
+      loginAsUser(userType: string): Chainable<void>;
       mockHousingRegisterApiGetApplicationsByStatusAndAssignedTo(
         user: HackneyGoogleUserWithPermissions
       ): Chainable<void>;

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -1,8 +1,13 @@
+import { HackneyGoogleUserWithPermissions } from 'lib/utils/googleAuth';
+
 declare global {
   namespace Cypress {
     interface Chainable {
       generateEmptyApplication(): Chainable<void>;
-      loginAsUser(userType: string): Chainable<void>;
+      loginAsUser(groups: string): Chainable<void>;
+      mockHousingRegisterApiGetApplicationsByStatusAndAssignedTo(
+        user: HackneyGoogleUserWithPermissions
+      ): Chainable<void>;
       mockActivityHistoryApiEmptyResponse(targetId: string): Chainable<void>;
       mockHousingRegisterApiPostSearchResults(
         application: Application


### PR DESCRIPTION
https://hackney.atlassian.net/browse/TS-1637?atlOrigin=eyJpIjoiN2Y5YTY2MmU4ODQ1NDI3NGFmZjRkN2RlNzFmMmM3MzMiLCJwIjoiaiJ9

**What**
- Intercepts the HR API so that when test run, the dev API is no longer being called,
- Note on the pipeline the dev api env var is removed and is passing.

**Why**
- We don't want to engage with any 'real' APIs during the e2e testing process.

**How**
- We intercept the /applications/ListApplicationsByAssignedTo path on the /applications page using Nock and mock the response object, 
- By using cy.wrap in the login command, we can access the user object to pass to the new nock intercept (which requires user in the path and response),
- After some investigation, we also add the .persist method to the nock request ([see this](https://www.npmjs.com/package/nock/v/11.0.0-beta.13#specifying-hostname)). With nock, after the path is hit, the intercept no longer works. While hard to trace, in this page it was failing to match the correct path so it seems it is making more than one request. By persisting, this issue is resolved. This will default to false. 

**Future**
- Need to resolve the pipeline intermittent timeouts.