### PR TITLE
TS-1659 fix person details null overwrite bug

### DIFF
--- a/components/errors/error-summary.tsx
+++ b/components/errors/error-summary.tsx
@@ -3,11 +3,13 @@ import { ReactNode } from 'react';
 interface ErrorSummaryProps {
   title?: string;
   children: ReactNode;
+  dataTestId?: string;
 }
 
 export default function ErrorSummary({
   title,
   children,
+  dataTestId,
 }: ErrorSummaryProps): JSX.Element {
   return (
     <div
@@ -16,6 +18,7 @@ export default function ErrorSummary({
       role="alert"
       tabIndex={-1}
       data-module="govuk-error-summary"
+      data-testid={dataTestId}
     >
       {title && (
         <h2 className="govuk-error-summary__title" id="error-summary-title">

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -46,7 +46,15 @@ export default defineConfig({
         },
       });
       on('task', {
-        nock: async ({ hostname, method, path, statusCode, body, persist }) => {
+        nock: async ({
+          hostname,
+          method,
+          path,
+          statusCode,
+          body,
+          persist,
+          delay,
+        }) => {
           if (!nock.isActive()) {
             nock.activate();
           }
@@ -59,11 +67,14 @@ export default defineConfig({
           //   path,
           //   persist,
           //   statusCode,
-          //   body
+          //   body,
+          //   delay
           // );
           method = method.toLowerCase();
+
           nock(hostname)
             [method](path)
+            .delay(delay ?? 0)
             .reply(statusCode, body)
             .persist(!!persist);
 

--- a/cypress/e2e/pages/startApplicationLoggedIn.cy.ts
+++ b/cypress/e2e/pages/startApplicationLoggedIn.cy.ts
@@ -31,7 +31,7 @@ const applicationWithMainApplicant = {
   calculatedBedroomNeed: 1,
 };
 
-const fillInTheForm = () => {
+const fillInTheSignUpForm = () => {
   StartPage.getTitleDropdown().select(title);
   StartPage.getFirstNameInput().type(faker.person.firstName());
   StartPage.getLastNameInput().type(faker.person.lastName());
@@ -89,7 +89,7 @@ describe('Application', () => {
     StartPage.visit();
 
     //fill in the personal details form and submit
-    fillInTheForm();
+    fillInTheSignUpForm();
     StartPage.getSubmitButton().click();
 
     //check that message is shown until (delayed) PATCH call has finished
@@ -123,7 +123,7 @@ describe('Application', () => {
     StartPage.visit();
     StartPage.getErrorSummary().should('not.exist');
 
-    fillInTheForm();
+    fillInTheSignUpForm();
     StartPage.getSubmitButton().click();
 
     StartPage.getErrorSummary().should('be.visible');

--- a/cypress/e2e/pages/startApplicationLoggedIn.cy.ts
+++ b/cypress/e2e/pages/startApplicationLoggedIn.cy.ts
@@ -1,0 +1,132 @@
+import StartPage from '../../pages/start';
+import { generateApplication } from '../../../testUtils/applicationHelper';
+import {
+  generatePerson,
+  getRandomGender,
+  TitleEnum,
+} from '../../../testUtils/personHelper';
+import { faker } from '@faker-js/faker/locale/en_GB';
+import AgreeTermsPage from '../../pages/agreeTerms';
+import { StatusCodes } from 'http-status-codes';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+const title = faker.helpers.enumValue(TitleEnum);
+const birthDate = faker.date.birthdate({ mode: 'age', min: 18, max: 70 });
+const mainApplicant = generatePerson(personId);
+const apiResponseDelay = 1000;
+const application = generateApplication(applicationId, personId, false, false);
+const phoneNumber = faker.phone.number();
+
+const applicationWithMainApplicant = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    contactInformation: {
+      ...application.mainApplicant.contactInformation,
+      phoneNumber: phoneNumber,
+    },
+    person: mainApplicant,
+  },
+  calculatedBedroomNeed: 1,
+};
+
+const fillInTheForm = () => {
+  StartPage.getTitleDropdown().select(title);
+  StartPage.getFirstNameInput().type(faker.person.firstName());
+  StartPage.getLastNameInput().type(faker.person.lastName());
+  StartPage.getDoBDayInput().type(birthDate.getDate().toString());
+  StartPage.getDoBMonthInput().type((birthDate.getMonth() + 1).toString());
+  StartPage.getDoBYearInput().type(birthDate.getFullYear().toString());
+  StartPage.getGenderOptions().check(getRandomGender());
+  StartPage.getNationalInsuranceNumberInput().type(
+    faker.string.alphanumeric(9)
+  );
+  StartPage.getPhoneNumberInput().type(phoneNumber);
+};
+
+describe('Application', () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.task('clearNock');
+  });
+
+  it('shows the loading spinner while application data is being fetched on the background', () => {
+    console.dir(application);
+    console.dir(applicationWithMainApplicant);
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      application,
+      false,
+      apiResponseDelay
+    );
+
+    StartPage.visit();
+    cy.contains('Checking information…');
+  });
+
+  it('lets user fill in and submit their personal details when logged in', () => {
+    //login with claims to specific application id
+    cy.loginAsResident(applicationId, true);
+
+    //initial GET request for start page
+    cy.mockHousingRegisterApiGetApplications(applicationId, application);
+
+    //PATCH request to update the application
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithMainApplicant,
+      apiResponseDelay
+    );
+
+    //second GET request for agree-terms page after the application has been patched
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    StartPage.visit();
+
+    //fill in the personal details form and submit
+    fillInTheForm();
+    StartPage.getSubmitButton().click();
+
+    //check that message is shown until (delayed) PATCH call has finished
+    cy.contains('Saving...');
+
+    //check that user is now on the agree-terms page
+    AgreeTermsPage.getAgreeTermsPage().should('be.visible');
+  });
+
+  it('shows an error message when application update fails', () => {
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(applicationId, application);
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    const errorStatus = 'Bad Request';
+    const errorStatusCode = StatusCodes.BAD_REQUEST;
+
+    //based on current API layer setup
+    const expectedErrorMessage = `Unable to update application: ${errorStatus} (${errorStatusCode})`;
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      null,
+      apiResponseDelay,
+      errorStatusCode
+    );
+
+    StartPage.visit();
+    StartPage.getErrorSummary().should('not.exist');
+
+    fillInTheForm();
+    StartPage.getSubmitButton().click();
+
+    StartPage.getErrorSummary().should('be.visible');
+    cy.contains(expectedErrorMessage);
+  });
+});

--- a/cypress/e2e/pages/startApplicationLoggedIn.cy.ts
+++ b/cypress/e2e/pages/startApplicationLoggedIn.cy.ts
@@ -52,8 +52,6 @@ describe('Application', () => {
   });
 
   it('shows the loading spinner while application data is being fetched on the background', () => {
-    console.dir(application);
-    console.dir(applicationWithMainApplicant);
     cy.loginAsResident(applicationId, true);
     cy.mockHousingRegisterApiGetApplications(
       applicationId,

--- a/cypress/e2e/viewAnApplication.cy.ts
+++ b/cypress/e2e/viewAnApplication.cy.ts
@@ -48,7 +48,14 @@ describe('User views a resident application', () => {
   it('as a manager group user I can edit all application details', () => {
     const personId = faker.string.uuid();
     const applicationId = faker.string.uuid();
-    const application = generateApplication(applicationId, personId);
+    const application = generateApplication(
+      applicationId,
+      personId,
+      true,
+      true,
+      true,
+      faker.date.recent().toString()
+    );
 
     cy.task('clearNock');
     cy.clearCookies();

--- a/cypress/pages/agreeTerms.ts
+++ b/cypress/pages/agreeTerms.ts
@@ -1,0 +1,8 @@
+class AgreeTermsPage {
+  static getAgreeTermsPage() {
+    const testId = 'agree-terms-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+}
+
+export default AgreeTermsPage;

--- a/cypress/pages/start.ts
+++ b/cypress/pages/start.ts
@@ -3,5 +3,54 @@ class StartPage {
     const testId = 'test-start-application-page';
     return cy.get(`[data-testid="${testId}"]`);
   }
+
+  static visit() {
+    cy.visit(`/apply/start`);
+  }
+
+  static getTitleDropdown() {
+    return this.getStartApplicationPage().find('select');
+  }
+
+  static getFirstNameInput() {
+    return this.getStartApplicationPage().find('#firstName');
+  }
+
+  static getLastNameInput() {
+    return this.getStartApplicationPage().find('#surname');
+  }
+
+  static getDoBDayInput() {
+    return this.getStartApplicationPage().find('#dateOfBirth-day');
+  }
+
+  static getDoBMonthInput() {
+    return this.getStartApplicationPage().find('#dateOfBirth-month');
+  }
+
+  static getDoBYearInput() {
+    return this.getStartApplicationPage().find('#dateOfBirth-year');
+  }
+
+  static getGenderOptions() {
+    return this.getStartApplicationPage().find('[type=radio]');
+  }
+
+  static getNationalInsuranceNumberInput() {
+    return this.getStartApplicationPage().find('#nationalInsuranceNumber');
+  }
+
+  static getPhoneNumberInput() {
+    return this.getStartApplicationPage().find('#phoneNumber');
+  }
+
+  static getSubmitButton() {
+    return this.getStartApplicationPage().find('button[type="submit"]');
+  }
+
+  static getErrorSummary() {
+    const testId = 'start-page-error-summary';
+    return this.getStartApplicationPage().find(`[data-testid="${testId}"]`);
+  }
 }
 export default StartPage;

--- a/lib/store/apiCallsStatus.ts
+++ b/lib/store/apiCallsStatus.ts
@@ -1,0 +1,64 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from '.';
+import { updateApplication } from './application';
+
+export enum ApiCallStatusCode {
+  'IDLE',
+  'PENDING',
+  'FULFILLED',
+  'REJECTED',
+}
+
+export interface ApiCallStatus {
+  callStatus: ApiCallStatusCode;
+  error?: string | null;
+}
+
+export interface HRApiCallsStatusState {
+  patchApplication: ApiCallStatus;
+}
+
+const initialState: HRApiCallsStatusState = {
+  patchApplication: {
+    callStatus: ApiCallStatusCode.IDLE,
+    error: null,
+  },
+};
+
+export const selectPatchApplicationStatus = (
+  state: RootState
+): ApiCallStatus | undefined => state.hrApiCallsStatus.patchApplication;
+
+export const hrApiCallsStatus = createSlice({
+  name: 'hrApiCallsStatus',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(updateApplication.pending, (state) => {
+        state.patchApplication = {
+          callStatus: ApiCallStatusCode.PENDING,
+          error: null,
+        };
+      })
+      .addCase(updateApplication.fulfilled, (state) => {
+        state.patchApplication = {
+          callStatus: ApiCallStatusCode.FULFILLED,
+          error: null,
+        };
+      })
+      .addCase(updateApplication.rejected, (state, action) => {
+        console.dir(action.payload);
+        state.patchApplication = {
+          callStatus: ApiCallStatusCode.REJECTED,
+          error: action.payload as string,
+        };
+      })
+      .addDefaultCase((state) => {
+        state.patchApplication = {
+          callStatus: ApiCallStatusCode.IDLE,
+          error: null,
+        };
+      });
+  },
+});

--- a/lib/store/apiCallsStatus.ts
+++ b/lib/store/apiCallsStatus.ts
@@ -48,7 +48,6 @@ export const hrApiCallsStatus = createSlice({
         };
       })
       .addCase(updateApplication.rejected, (state, action) => {
-        console.dir(action.payload);
         state.patchApplication = {
           callStatus: ApiCallStatusCode.REJECTED,
           error: action.payload as string,

--- a/lib/store/index.ts
+++ b/lib/store/index.ts
@@ -3,13 +3,16 @@ import { createWrapper } from 'next-redux-wrapper';
 import { combineReducers } from 'redux';
 import { Application } from '../../domain/HousingApi';
 import application, { autoSaveMiddleware } from './application';
+import { hrApiCallsStatus, HRApiCallsStatusState } from './apiCallsStatus';
 
 export interface Store {
   application: Application;
+  hrApiCallsStatus: HRApiCallsStatusState;
 }
 
 const reducer = combineReducers<Store>({
   application: application.reducer,
+  hrApiCallsStatus: hrApiCallsStatus.reducer,
 });
 
 const makeStore = () =>

--- a/pages/apply/agree-terms.tsx
+++ b/pages/apply/agree-terms.tsx
@@ -24,7 +24,7 @@ const ApplicationTermsPage = (): JSX.Element => {
   };
 
   return (
-    <Layout pageName="Agreement">
+    <Layout pageName="Agreement" dataTestId="agree-terms-page">
       <HeadingOne content="Confidentiality and data protection" />
 
       <Paragraph>

--- a/pages/apply/agree-terms.tsx
+++ b/pages/apply/agree-terms.tsx
@@ -24,7 +24,7 @@ const ApplicationTermsPage = (): JSX.Element => {
   };
 
   return (
-    <Layout pageName="Agreement" dataTestId="agree-terms-page">
+    <Layout pageName="Agreement" dataTestId="test-agree-terms-page">
       <HeadingOne content="Confidentiality and data protection" />
 
       <Paragraph>

--- a/pages/apply/start.tsx
+++ b/pages/apply/start.tsx
@@ -35,7 +35,7 @@ const ApplicationStartPage = (): JSX.Element => {
       router.push('/apply/agree-terms');
     }
 
-    if (patchApplicationStatus?.callStatus == ApiCallStatusCode.REJECTED) {
+    if (patchApplicationStatus?.callStatus === ApiCallStatusCode.REJECTED) {
       setUserError(
         patchApplicationStatus.error ?? 'Error patching the application'
       );

--- a/testUtils/applicationHelper.ts
+++ b/testUtils/applicationHelper.ts
@@ -6,7 +6,11 @@ import { generatePerson } from './personHelper';
 
 export const generateApplication = (
   applicationId: string,
-  personId: string
+  personId: string,
+  addMainApplicant: boolean = true,
+  addOtherMembers: boolean = true,
+  addAssessment?: boolean,
+  submittedAt?: string
 ): Application => {
   return {
     id: applicationId,
@@ -15,26 +19,37 @@ export const generateApplication = (
     sensitiveData: false,
     assignedTo: 'unassigned',
     createdAt: faker.date.recent().toISOString(),
-    submittedAt: faker.date.recent().toString(),
+    submittedAt,
     mainApplicant: {
-      person: generatePerson(personId),
+      person: addMainApplicant ? generatePerson(personId) : undefined,
+      address: undefined,
       contactInformation: {
         emailAddress: faker.internet.email({ provider: 'hackneyTEST.gov.uk' }),
+        phoneNumber: undefined,
+        preferredMethodOfContact: undefined,
       },
+      questions: undefined,
+      requiresMedical: false,
+      medicalNeed: undefined,
     },
-    otherMembers: [
-      {
-        person: generatePerson(personId + 1),
-        contactInformation: {
-          emailAddress: faker.internet.email({
-            provider: 'hackneyTEST.gov.uk',
-          }),
-        },
-      },
-    ],
-    assessment: {
-      effectiveDate: faker.date.recent().toISOString(),
-    },
+    calculatedBedroomNeed: undefined,
+    otherMembers: addOtherMembers
+      ? [
+          {
+            person: generatePerson(personId + 1),
+            contactInformation: {
+              emailAddress: faker.internet.email({
+                provider: 'hackneyTEST.gov.uk',
+              }),
+            },
+          },
+        ]
+      : [],
+    assessment: addAssessment
+      ? {
+          effectiveDate: faker.date.recent().toISOString(),
+        }
+      : undefined,
     importedFromLegacyDatabase: false,
   };
 };

--- a/testUtils/personHelper.ts
+++ b/testUtils/personHelper.ts
@@ -6,6 +6,16 @@ import { Person } from '../domain/HousingApi';
 const dateOfBirth = faker.date.birthdate();
 const personRelationshipOptions = relationshipOptions.map(({ value }) => value);
 
+//matches the values in data/sign-up-details.json
+export enum TitleEnum {
+  Mrs = 'Mrs',
+  Mr = 'Mr',
+  Miss = 'Miss',
+  Mx = 'Mx',
+  Other = 'Other',
+  Ms = 'Ms',
+}
+
 //Logic from the HR API
 export const calculateAge = (birthDate: Date): number => {
   const now = new Date();
@@ -36,4 +46,10 @@ export const generatePerson = (personId: string): Person => {
     nationalInsuranceNumber: faker.string.alphanumeric(9),
     age: calculateAge(dateOfBirth),
   };
+};
+
+export const getRandomGender = (): string => {
+  //values match the current form
+  const genderOptions = ['M', 'F', 'self'];
+  return genderOptions[Math.floor(Math.random() * genderOptions.length)];
 };

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -5,6 +5,10 @@ declare global {
     interface Chainable {
       generateEmptyApplication(): Chainable<void>;
       loginAsUser(userType: string): Chainable<void>;
+      loginAsResident(
+        applicationId: string,
+        setSeenCookieMessage?: boolean
+      ): Chainable<void>;
       mockHousingRegisterApiGetApplicationsByStatusAndAssignedTo(
         user: HackneyGoogleUserWithPermissions
       ): Chainable<void>;
@@ -14,9 +18,17 @@ declare global {
       ): Chainable<void>;
       mockHousingRegisterApiGetApplications(
         applicationId: string,
-        application: Application
+        application: Application,
+        persist?: boolean,
+        delay?: number
       ): Chainable<void>;
       mount: typeof mount;
+      mockHousingRegisterApiPatchApplication(
+        applicationId: string,
+        body?: Application,
+        delay?: number,
+        statusCode?: number
+      ): Chainable<void>;
     }
   }
 }


### PR DESCRIPTION
## WHAT
Current Lambda function on production is running on Node v14 runtime. That version of Node is now out of support and we cannot deploy changes using that runtime anymore. As part of the read only access feature development work we have updated the project to use the latest LTS Node version, 20.17. However that introduced some critical bugs that will stop us from deploying to production until they are fixed.

We noticed an issue where sometimes initial signup details where lost when user progressed from the login stage to the household members view. After troubleshooting the issue locally it appeared that the application does not handle delayed API calls properly which is causing the database and the application local state (using Redux) to get out of sync.

When the issue occurs the flow of events are as follows:
1. User fills in their personal details on the start page
2. User submits the details which causes API PATCH endpoint to be called while at the same time router push is used to move the user to the next page in the sign up flow i.e. agree-terms
3. When user agree the terms they are then "pushed" to the /apply/household page
4. When user gets to the household page they see undefined undefined in the main applicant section rather than their first and last name 

This behaviour was successfully created locally by delaying the API PATCH call, so it wasn't complete before the next page (agree-terms) was loaded.

The way the pages are designed to work is that start page updates the application details in the database on submit and then when user is pushed to the agree-terms page it loads the data from the database and uses that to update the local Redux store with the application details. This state is then used in turn in the switch from agree-terms to apply/household page to patch the application in the database again. In the above scenario the first patch that adds the person details to the application is not complete before the next get request occurs which means that the person is null in the local state and later calls.

This update addresses the issue by updating the start page to ensure the application has been updated in the database before pushing the user to the agree-terms page. This has been successfully tested locally and the person details now persists regardles of the delay in the application patch. 

## WHY
When the bug happens user ends up in unrecoverable situation where they cannot continue with the application.

## HOW
The following updates have been made to the application to resolve this issue:

1. Add new `hrApiCallsStatus` slice to the store, so we can track the status of various API calls. This slice only has extra reducers that update the new slice based on the `patchApplication` async thunk events
2. Update the `patchApplication` thunk to better handle the API call states and add support for handling failures
3. Update the start page to wait for the PATCH call to complete before pushing user to the next page
4. Update the error summary component for better testing support
5. Update Cypress config with new patch end point mock. Also minor tweaks to the get mock
6. Add test coverage for the store and page changes. The approach taken on testing is based on the recommendations from the Redux team i.e. majority of the tests should be integration tests where the whole application and components are tested together. For that reason the `patchApplication` and the slice & extra reducers are not tested individually, but as part of Cypress e2e test where the pages operate as they normally would. API calls are mocked at network level using nock which is also the recommended way to mock APIs when Redux is used


## FUTURE
1. Go through the rest of the pages to ensure they handle delayed API calls the same way to avoid any data loss 
2. Tidy up the API mock setups now that we are passing more and more props