### PR TITLE
Add CloudFront Distribution logging

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -55,6 +55,10 @@ functions:
 
 resources:
   Resources:
+    CloudFrontDistributionLogsS3Bucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: ${self:service}-${self:provider.stage}-cfd-logs
     CloudFrontDistribution:
       Type: AWS::CloudFront::Distribution
       Properties:
@@ -93,6 +97,10 @@ resources:
                 HTTPPort: 80
                 HTTPSPort: 443
                 OriginProtocolPolicy: https-only
+          Logging:
+            Bucket: !Ref CloudFrontDistributionLogsS3Bucket
+            IncludeCookies: false
+            Prefix:
 
 custom:
   domain-name:


### PR DESCRIPTION
Temporarily enable CloudFront Distribution logs on development to help us troubleshoot an issue.