### PR TITLE
Remove cloudfront distribution logging

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -100,10 +100,6 @@ resources:
                 HTTPPort: 80
                 HTTPSPort: 443
                 OriginProtocolPolicy: https-only
-          Logging:
-            Bucket: !GetAtt CloudFrontDistributionLogsS3Bucket.DomainName
-            IncludeCookies: false
-            Prefix:
 
 custom:
   domain-name:


### PR DESCRIPTION
Remove the temporary CloudFront Distribution loggin that was enabled for troubleshooting purposes.