### PR TITLE
Remove temporary cfd logs S3 bucket

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -55,13 +55,6 @@ functions:
 
 resources:
   Resources:
-    CloudFrontDistributionLogsS3Bucket:
-      Type: AWS::S3::Bucket
-      Properties:
-        BucketName: ${self:service}-${self:provider.stage}-cfd-logs
-        OwnershipControls:
-          Rules:
-            - ObjectOwnership: BucketOwnerPreferred
     CloudFrontDistribution:
       Type: AWS::CloudFront::Distribution
       Properties:


### PR DESCRIPTION
The logs bucket is no longer needed, so this update removes it from the config.