### PR TITLE
TS-1703 Improve data and error handling on edit person page

### DIFF
--- a/components/admin/MainApplicantForm.tsx
+++ b/components/admin/MainApplicantForm.tsx
@@ -1,4 +1,4 @@
-import { Form, Formik, FormikValues, FormikErrors } from 'formik';
+import { Form, Formik, FormikValues } from 'formik';
 import { UserContext } from '../../lib/contexts/user-context';
 import Button from '../../components/button';
 import ErrorSummary from '../../components/errors/error-summary';
@@ -17,6 +17,7 @@ import AddCaseAddress from '../../components/admin/AddCaseAddress';
 import AddCaseEthnicity from '../../components/admin/AddCaseEthnicity';
 import Layout from '../../components/layout/staff-layout';
 import { HeadingOne } from '../../components/content/headings';
+import Loading from 'components/loading';
 
 const keysToOmit = [
   'AGREEMENT',
@@ -84,12 +85,15 @@ interface PageProps {
   user: HackneyGoogleUser;
   onSubmit: (values: FormikValues) => void;
   isSubmitted: boolean;
-  addressHistory: any;
-  setAddressHistory: (addresses: any) => void;
-  handleSaveApplication: (isValid: boolean, touched: {}) => void;
+  addressHistory: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  setAddressHistory: (addresses: any) => void; // eslint-disable-line @typescript-eslint/no-explicit-any
+  handleSaveApplication: (isValid: boolean, touched: {}) => void; // eslint-disable-line @typescript-eslint/ban-types
   ethnicity: string;
   setEthnicity: (ethnicity: string) => void;
   data?: Application;
+  dataTestId?: string;
+  isSaving?: boolean;
+  userError?: string | null;
 }
 
 export default function MainApplicantForm({
@@ -103,6 +107,9 @@ export default function MainApplicantForm({
   ethnicity,
   setEthnicity,
   data,
+  dataTestId,
+  isSaving,
+  userError,
 }: PageProps) {
   const initialValues = isEditing
     ? generateEditInitialValues(data, true)
@@ -111,117 +118,129 @@ export default function MainApplicantForm({
   const isEditingCopy = isEditing ? 'Edit' : 'Add new';
   return (
     <UserContext.Provider value={{ user }}>
-      <Layout pageName={`${isEditingCopy} case`}>
+      <Layout pageName={`${isEditingCopy} case`} dataTestId={dataTestId}>
         <HeadingOne content={`${isEditingCopy} case`} />
         <h2 className="lbh-caption-xl lbh-caption govuk-!-margin-top-1">
           Main applicant details
         </h2>
-        <Formik
-          initialValues={initialValues}
-          onSubmit={onSubmit}
-          validationSchema={mainApplicantSchema}
-        >
-          {({ touched, isSubmitting, errors, isValid }) => {
-            const isTouched = Object.keys(touched).length !== 0;
-            return (
-              <>
-                {!isValid && isTouched && isSubmitted ? (
-                  <ErrorSummary title="There is a problem">
-                    <ul className="govuk-list govuk-error-summary__list">
-                      {Object.entries(errors).map(([inputName, errorTitle]) => (
-                        <li key={inputName}>
-                          <a href={`#${inputName}`}>{errorTitle}</a>
-                        </li>
-                      ))}
-                    </ul>
-                  </ErrorSummary>
-                ) : null}
-                <Form>
-                  {/* Identity */}
-                  <AddCaseSection section={personalDetailsSection} />
-                  <AddCaseSection section={immigrationStatusSection} />
-
-                  {/* Health */}
-                  <AddCaseSection section={medicalNeedsSection} />
-
-                  {/* Living situation */}
-                  <AddCaseSection section={residentialStatusSection} />
-                  <AddCaseAddress
-                    addresses={addressHistory}
-                    setAddresses={setAddressHistory}
-                  />
-
-                  {/* Current accommodation */}
-                  <AddCaseSection section={currentAccommodationSection} />
-                  <AddCaseSection section={currentAccommodationHostSection} />
-                  <AddCaseSection
-                    section={currentAccommodationLandlordSection}
-                  />
-
-                  {/* Your situation */}
-                  <AddCaseSection section={armedForcesSection} />
-                  <AddCaseSection section={courtOrderSection} />
-                  <AddCaseSection section={accomodationTypeSection} />
-                  <AddCaseSection section={sublettingSection} />
-                  <AddCaseSection section={domesticViolenceSection} />
-                  <AddCaseSection section={homelessnessSection} />
-                  <AddCaseSection section={propertyOwnwershipSection} />
-                  <AddCaseSection section={soldPropertySection} />
-                  <AddCaseSection section={medicalNeedSection} />
-                  <AddCaseSection section={purchasingPropertySection} />
-                  <AddCaseSection section={arrearsSection} />
-                  <AddCaseSection section={underOccupyingSection} />
-                  <AddCaseSection section={otherHousingRegisterSection} />
-                  <AddCaseSection section={breachOfTenancySection} />
-                  <AddCaseSection section={legalRestrictionsSection} />
-                  <AddCaseSection section={unspentConvictionsSection} />
-                  <AddCaseSection section={employmentSection} />
-                  <AddCaseSection section={incomeSavingsSection} />
-                  <AddCaseSection section={additionalQuestionsSection} />
-
-                  {/* Ethnicity */}
-                  {/* <AddCaseSection section={ethnicitySection} /> */}
-                  <AddCaseEthnicity
-                    section={ethnicitySection}
-                    ethnicity={ethnicity}
-                    setEthnicity={setEthnicity}
-                  />
-
-                  {ethnicity === 'asian-asian-british' ? (
-                    <AddCaseSection section={ethnicityAsianSection} />
+        {userError && (
+          <ErrorSummary dataTestId="test-agree-terms-error-summary">
+            {userError}
+          </ErrorSummary>
+        )}
+        {isSaving ? (
+          <Loading text="Saving..." />
+        ) : (
+          <Formik
+            initialValues={initialValues}
+            onSubmit={onSubmit}
+            validationSchema={mainApplicantSchema}
+          >
+            {({ touched, isSubmitting, errors, isValid }) => {
+              const isTouched = Object.keys(touched).length !== 0;
+              return (
+                <>
+                  {!isValid && isTouched && isSubmitted ? (
+                    <ErrorSummary title="There is a problem">
+                      <ul className="govuk-list govuk-error-summary__list">
+                        {Object.entries(errors).map(
+                          ([inputName, errorTitle]) => (
+                            <li key={inputName}>
+                              <a href={`#${inputName}`}>{errorTitle}</a>
+                            </li>
+                          )
+                        )}
+                      </ul>
+                    </ErrorSummary>
                   ) : null}
+                  <Form>
+                    {/* Identity */}
+                    <AddCaseSection section={personalDetailsSection} />
+                    <AddCaseSection section={immigrationStatusSection} />
 
-                  {ethnicity === 'black-black-british' ? (
-                    <AddCaseSection section={ethnicityBlackSection} />
-                  ) : null}
-                  {ethnicity === 'mixed-or-multiple-background' ? (
-                    <AddCaseSection section={ethnicityMixedSection} />
-                  ) : null}
+                    {/* Health */}
+                    <AddCaseSection section={medicalNeedsSection} />
 
-                  {ethnicity === 'white' ? (
-                    <AddCaseSection section={ethnicityWhiteSection} />
-                  ) : null}
+                    {/* Living situation */}
+                    <AddCaseSection section={residentialStatusSection} />
+                    <AddCaseAddress
+                      addresses={addressHistory}
+                      setAddresses={setAddressHistory}
+                    />
 
-                  {ethnicity === 'other-ethnic-group' ? (
-                    <AddCaseSection section={ethnicityOtherSection} />
-                  ) : null}
+                    {/* Current accommodation */}
+                    <AddCaseSection section={currentAccommodationSection} />
+                    <AddCaseSection section={currentAccommodationHostSection} />
+                    <AddCaseSection
+                      section={currentAccommodationLandlordSection}
+                    />
 
-                  <div className="c-flex__1 text-right">
-                    <Button
-                      onClick={() => handleSaveApplication(isValid, touched)}
-                      disabled={isSubmitting}
-                      type="submit"
-                    >
-                      {isEditing
-                        ? 'Update application'
-                        : 'Save new application'}
-                    </Button>
-                  </div>
-                </Form>
-              </>
-            );
-          }}
-        </Formik>
+                    {/* Your situation */}
+                    <AddCaseSection section={armedForcesSection} />
+                    <AddCaseSection section={courtOrderSection} />
+                    <AddCaseSection section={accomodationTypeSection} />
+                    <AddCaseSection section={sublettingSection} />
+                    <AddCaseSection section={domesticViolenceSection} />
+                    <AddCaseSection section={homelessnessSection} />
+                    <AddCaseSection section={propertyOwnwershipSection} />
+                    <AddCaseSection section={soldPropertySection} />
+                    <AddCaseSection section={medicalNeedSection} />
+                    <AddCaseSection section={purchasingPropertySection} />
+                    <AddCaseSection section={arrearsSection} />
+                    <AddCaseSection section={underOccupyingSection} />
+                    <AddCaseSection section={otherHousingRegisterSection} />
+                    <AddCaseSection section={breachOfTenancySection} />
+                    <AddCaseSection section={legalRestrictionsSection} />
+                    <AddCaseSection section={unspentConvictionsSection} />
+                    <AddCaseSection section={employmentSection} />
+                    <AddCaseSection section={incomeSavingsSection} />
+                    <AddCaseSection section={additionalQuestionsSection} />
+
+                    {/* Ethnicity */}
+                    {/* <AddCaseSection section={ethnicitySection} /> */}
+                    <AddCaseEthnicity
+                      section={ethnicitySection}
+                      ethnicity={ethnicity}
+                      setEthnicity={setEthnicity}
+                    />
+
+                    {ethnicity === 'asian-asian-british' ? (
+                      <AddCaseSection section={ethnicityAsianSection} />
+                    ) : null}
+
+                    {ethnicity === 'black-black-british' ? (
+                      <AddCaseSection section={ethnicityBlackSection} />
+                    ) : null}
+                    {ethnicity === 'mixed-or-multiple-background' ? (
+                      <AddCaseSection section={ethnicityMixedSection} />
+                    ) : null}
+
+                    {ethnicity === 'white' ? (
+                      <AddCaseSection section={ethnicityWhiteSection} />
+                    ) : null}
+
+                    {ethnicity === 'other-ethnic-group' ? (
+                      <AddCaseSection section={ethnicityOtherSection} />
+                    ) : null}
+
+                    <div className="c-flex__1 text-right">
+                      <Button
+                        onClick={() => handleSaveApplication(isValid, touched)}
+                        disabled={isSubmitting}
+                        type="submit"
+                        dataTestId="test-submit-main-applicant-button"
+                      >
+                        {isEditing
+                          ? 'Update application'
+                          : 'Save new application'}
+                      </Button>
+                    </div>
+                  </Form>
+                </>
+              );
+            }}
+          </Formik>
+        )}
       </Layout>
     </UserContext.Provider>
   );

--- a/cypress/e2e/pages/applications/edit/[id]/person/index.cy.ts
+++ b/cypress/e2e/pages/applications/edit/[id]/person/index.cy.ts
@@ -1,0 +1,75 @@
+import { faker } from '@faker-js/faker';
+import ApplicationEditPersonPage from '../../../../../../pages/applications/edit/[id]/person';
+import { generateApplication } from '../../../../../../../testUtils/applicationHelper';
+import ViewApplicationPage from '../../../../../../pages/viewApplication';
+import { StatusCodes } from 'http-status-codes';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+const submittedAt = faker.date.recent().toISOString();
+const application = generateApplication(
+  applicationId,
+  personId,
+  true,
+  false,
+  false,
+  submittedAt
+);
+
+describe('Edit person in application', () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.loginAsUser('manager');
+    cy.task('clearNock');
+  });
+
+  it('shows a saving message while application is updating', () => {
+    cy.mockHousingRegisterApiGetApplications(applicationId, application, true);
+    cy.mockHousingRegisterApiPatchApplication(applicationId, application, 1000);
+    cy.mockActivityHistoryApiEmptyResponse(applicationId);
+
+    ApplicationEditPersonPage.visit(applicationId, personId);
+    ApplicationEditPersonPage.getApplicationEditPersonPage().should(
+      'be.visible'
+    );
+
+    //update living situation
+    ApplicationEditPersonPage.getLivingSituationDropdown().select(
+      'private-rental'
+    );
+
+    //update citizenship status
+    ApplicationEditPersonPage.getCitizenshipDropdown().select('british');
+
+    ApplicationEditPersonPage.getSubmitMainApplicantDetailsButton().click();
+    cy.contains('Saving...');
+
+    //user pushed to view application page
+    ViewApplicationPage.getViewApplicationPage().should('be.visible');
+  });
+
+  it('shows an error message when application update fails', () => {
+    const errorCode = StatusCodes.INTERNAL_SERVER_ERROR;
+    cy.mockHousingRegisterApiGetApplications(applicationId, application, true);
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      0,
+      errorCode
+    );
+    cy.mockActivityHistoryApiEmptyResponse(applicationId);
+    ApplicationEditPersonPage.visit(applicationId, personId);
+    ApplicationEditPersonPage.getApplicationEditPersonPage().should(
+      'be.visible'
+    );
+    ApplicationEditPersonPage.getLivingSituationDropdown().select(
+      'private-rental'
+    );
+    ApplicationEditPersonPage.getCitizenshipDropdown().select('british');
+    ApplicationEditPersonPage.getSubmitMainApplicantDetailsButton().click();
+    cy.contains(`Unable to update application (${errorCode})`);
+
+    //user not pushed to view application page
+    ViewApplicationPage.getViewApplicationPage().should('not.exist');
+  });
+});

--- a/cypress/pages/applications/edit/[id]/person/index.ts
+++ b/cypress/pages/applications/edit/[id]/person/index.ts
@@ -1,0 +1,31 @@
+class ApplicationEditPersonPage {
+  static getApplicationEditPersonPage() {
+    const testId = 'test-application-edit-person-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static visit(applicationId: string, personId: string) {
+    cy.visit(`/applications/edit/${applicationId}/${personId}`);
+  }
+
+  static getSubmitMainApplicantDetailsButton() {
+    const testId = 'test-submit-main-applicant-button';
+    return this.getApplicationEditPersonPage().find(
+      `[data-testid="${testId}"]`
+    );
+  }
+
+  static getLivingSituationDropdown() {
+    return this.getApplicationEditPersonPage().find(
+      '#currentAccommodation_livingSituation'
+    );
+  }
+
+  static getCitizenshipDropdown() {
+    return this.getApplicationEditPersonPage().find(
+      '#immigrationStatus_citizenship'
+    );
+  }
+}
+
+export default ApplicationEditPersonPage;

--- a/cypress/pages/viewApplication.ts
+++ b/cypress/pages/viewApplication.ts
@@ -10,6 +10,11 @@ class ViewApplicationPage {
     return cy.get(`[data-testid="${testId}"]`);
   }
 
+  static getViewApplicationPage() {
+    const testId = 'test-view-application-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
   static mockHousingRegisterApiGetApplications(
     applicationId: string,
     application: Application

--- a/lib/gateways/internal-api.ts
+++ b/lib/gateways/internal-api.ts
@@ -14,10 +14,12 @@ export const updateApplication = async (application: Application) => {
     method: 'PATCH',
     body: JSON.stringify(application),
   });
-  if (res.status == 400) {
-    throw (await res.json()).message;
+
+  if (res.ok) {
+    return (await res.json()) as Application;
+  } else {
+    throw Error(`Unable to update application (${res.status})`);
   }
-  return (await res.json()) as Application;
 };
 
 export const createApplication = async (application: Application) => {

--- a/pages/applications/edit/[id]/[person]/index.tsx
+++ b/pages/applications/edit/[id]/[person]/index.tsx
@@ -18,10 +18,9 @@ import {
   generateQuestionArray,
 } from '../../../../../lib/utils/adminHelpers';
 import { getRedirect, getSession } from '../../../../../lib/utils/googleAuth';
-import { scrollToTop } from '../../../../../lib/utils/scroll';
+import { scrollToError, scrollToTop } from '../../../../../lib/utils/scroll';
 import Custom404 from '../../../../404';
 
-/* eslint-disable react/no-unused-prop-types */
 interface PageProps {
   user: HackneyGoogleUser;
   data: Application;
@@ -48,6 +47,9 @@ export default function EditApplicant({ user, data }: PageProps): JSX.Element {
     JSON.parse(savedAddresses) as Address[]
   );
   const [ethnicity, setEthnicity] = useState(JSON.parse(savedEthnicity));
+
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [userError, setUserError] = useState<string | null>(null);
 
   const onSubmit = (values: FormikValues) => {
     const questionValues = generateQuestionArray(
@@ -83,11 +85,26 @@ export default function EditApplicant({ user, data }: PageProps): JSX.Element {
       },
     };
 
-    updateApplication(request).then(() => {
-      router.push({
-        pathname: `/applications/view/${data.id}`,
+    setIsSaving(true);
+
+    updateApplication(request)
+      .then(() => {
+        setIsSaving(false);
+        router.push({
+          pathname: `/applications/view/${data.id}`,
+        });
+      })
+      .catch((err) => {
+        setIsSaving(false);
+
+        if (err instanceof Error) {
+          setUserError(err.message);
+        } else {
+          setUserError('Unable to update application');
+        }
+
+        scrollToError();
       });
-    });
   };
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const handleSaveApplication = (isValid: any, touched: any) => {
@@ -98,7 +115,6 @@ export default function EditApplicant({ user, data }: PageProps): JSX.Element {
 
     setIsSubmitted(true);
   };
-  /* eslint-disable react/jsx-no-useless-fragment */
   return (
     <>
       {data.id ? (
@@ -113,6 +129,9 @@ export default function EditApplicant({ user, data }: PageProps): JSX.Element {
           ethnicity={ethnicity}
           setEthnicity={setEthnicity}
           data={data}
+          dataTestId="test-application-edit-person-page"
+          isSaving={isSaving}
+          userError={userError}
         />
       ) : (
         <Custom404 />


### PR DESCRIPTION
## WHAT
`/applications/edit/[id]/[person]/index.tsx ` page is not currently displaying and handling HR API errors correctly. This update adds better saving and error handling messages, so user is aware what's happening.

## WHY
User don't currently get enough feedback on what's happening on the page when data is saved.

## HOW
1. Show saving... message to user when applications is saved 
2. Show error message when HR API call fails. This had to be added to the `MainApplicantForm` component too due to way the page is currently structured
3. Update the gateway method by removing the current status === 400 check and use generic error instead. Object returned by the API layer when status is 400 does not include message property, so that will always return undefined message. It's better to just show generic error and status code for now. 

## FUTURE
Build proper error handling for 400 errors happening at the backend, so that they can be shown to users in a friendly format. Right now we rely on the front end validation and if user gets passed that we have to look at the errors in the conesole. This is internal page only, so we can update this later.