### PR TITLE
TS-1707 Improve error handling on view application page

### DIFF
--- a/components/admin/other-members.tsx
+++ b/components/admin/other-members.tsx
@@ -15,6 +15,7 @@ interface SummaryProps {
   applicationId: string;
   canEdit: boolean;
   handleDelete: (applicant: Applicant) => void;
+  userError?: string;
 }
 
 export default function OtherMembers({
@@ -23,6 +24,7 @@ export default function OtherMembers({
   applicationId,
   canEdit,
   handleDelete,
+  userError,
 }: SummaryProps): JSX.Element {
   const [showDeleteWarningDialog, setShowDeleteWarningDialog] = useState(false);
   const [applicantToDelete, setApplicantToDelete] = useState({} as Applicant);
@@ -70,16 +72,18 @@ export default function OtherMembers({
                   <button
                     onClick={() => handleDeleteDialog(applicant)}
                     className="lbh-body-s lbh-link lbh-link--no-visited-state lbh-delete-link"
+                    data-testid={`test-remove-household-member-button-${applicant.person?.id}`}
                   >
                     Remove household member
                   </button>
                 )}
 
                 <Dialog
-                  isOpen={showDeleteWarningDialog}
+                  isOpen={showDeleteWarningDialog && !userError}
                   title="Confirm delete"
                   onConfirmation={() => handleDelete(applicantToDelete)}
                   onCancel={() => setShowDeleteWarningDialog(false)}
+                  confirmationButtonTestId={`test-remove-household-member-confirmation-button-${applicant.person?.id}`}
                 >
                   <Paragraph>
                     Are you sure you want to remove{' '}

--- a/components/dialog.tsx
+++ b/components/dialog.tsx
@@ -12,6 +12,7 @@ interface DialogProps {
   onConfirmationText?: string;
   onCancel?: () => void;
   onConfirmation?: () => void;
+  confirmationButtonTestId?: string;
 }
 
 export default function Dialog({
@@ -22,6 +23,7 @@ export default function Dialog({
   onConfirmationText,
   onCancel,
   onConfirmation,
+  confirmationButtonTestId,
 }: DialogProps) {
   return (
     <ReachDialog
@@ -35,7 +37,10 @@ export default function Dialog({
 
       <div className="lbh-dialog__actions">
         {onConfirmation && (
-          <Button onClick={onConfirmation}>
+          <Button
+            onClick={onConfirmation}
+            dataTestId={confirmationButtonTestId}
+          >
             {onConfirmationText === undefined ? 'Yes' : onConfirmationText}
           </Button>
         )}

--- a/cypress/e2e/pages/viewApplication.cy.ts
+++ b/cypress/e2e/pages/viewApplication.cy.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker';
 import { ApplicationStatus } from '../../../lib/types/application-status';
 import { generateApplication } from '../../../testUtils/applicationHelper';
 import ViewApplicationPage from '../../pages/viewApplication';
+import { StatusCodes } from 'http-status-codes';
 
 describe('View a resident application', () => {
   it('does not show the assessment area for read only users', () => {
@@ -17,12 +18,55 @@ describe('View a resident application', () => {
     cy.loginAsUser('readOnly');
 
     cy.mockActivityHistoryApiEmptyResponse(applicationId);
-    ViewApplicationPage.mockHousingRegisterApiGetApplications(
-      applicationId,
-      application
-    );
+    cy.mockHousingRegisterApiGetApplications(applicationId, application);
 
     ViewApplicationPage.visit(applicationId);
     ViewApplicationPage.getAssessmentNavLink().should('not.exist');
+  });
+
+  it('shows an error message when deleting household member fails', () => {
+    const applicationId = faker.string.uuid();
+    const personId = faker.string.uuid();
+    const submittedAt = faker.date.recent().toISOString();
+    const errorCode = StatusCodes.CONFLICT;
+
+    const application = generateApplication(
+      applicationId,
+      personId,
+      true,
+      true,
+      true,
+      submittedAt
+    );
+
+    cy.task('clearNock');
+    cy.loginAsUser('manager');
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      application,
+      true,
+      0,
+      StatusCodes.OK
+    );
+    cy.mockActivityHistoryApiEmptyResponse(applicationId, true);
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      0,
+      errorCode
+    );
+
+    ViewApplicationPage.visit(applicationId);
+
+    ViewApplicationPage.getRemoveHouseHoldMemberButton(personId + 1).click();
+    cy.contains('Confirm delete');
+    ViewApplicationPage.getRemoveHouseHoldMemberConfirmationButton(
+      personId + 1
+    ).should('be.visible');
+    ViewApplicationPage.getRemoveHouseHoldMemberConfirmationButton(
+      personId + 1
+    ).click();
+    ViewApplicationPage.getErrorSummary().should('be.visible');
+    cy.contains(`Unable to delete household member`);
   });
 });

--- a/cypress/e2e/pages/viewApplication.cy.ts
+++ b/cypress/e2e/pages/viewApplication.cy.ts
@@ -5,18 +5,21 @@ import { generateApplication } from '../../../testUtils/applicationHelper';
 import ViewApplicationPage from '../../pages/viewApplication';
 import { StatusCodes } from 'http-status-codes';
 
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+
 describe('View a resident application', () => {
+  beforeEach(() => {
+    cy.task('clearNock');
+    cy.clearAllCookies();
+  });
+
   it('does not show the assessment area for read only users', () => {
-    const applicationId = faker.string.uuid();
-    const personId = faker.string.uuid();
     const application = generateApplication(applicationId, personId);
     //ensure application requires assessment
     application.status = ApplicationStatus.SUBMITTED;
 
-    cy.task('clearNock');
-    cy.clearAllCookies();
     cy.loginAsUser('readOnly');
-
     cy.mockActivityHistoryApiEmptyResponse(applicationId);
     cy.mockHousingRegisterApiGetApplications(applicationId, application);
 
@@ -25,8 +28,6 @@ describe('View a resident application', () => {
   });
 
   it('shows an error message when deleting household member fails', () => {
-    const applicationId = faker.string.uuid();
-    const personId = faker.string.uuid();
     const submittedAt = faker.date.recent().toISOString();
     const errorCode = StatusCodes.CONFLICT;
 
@@ -39,7 +40,6 @@ describe('View a resident application', () => {
       submittedAt
     );
 
-    cy.task('clearNock');
     cy.loginAsUser('manager');
     cy.mockHousingRegisterApiGetApplications(
       applicationId,

--- a/cypress/pages/viewApplication.ts
+++ b/cypress/pages/viewApplication.ts
@@ -1,5 +1,3 @@
-import { Application } from '../../domain/HousingApi';
-
 class ViewApplicationPage {
   static visit(applicationId: string) {
     cy.visit(`/applications/view/${applicationId}`);
@@ -10,22 +8,19 @@ class ViewApplicationPage {
     return cy.get(`[data-testid="${testId}"]`);
   }
 
-  static mockHousingRegisterApiGetApplications(
-    applicationId: string,
-    application: Application
-  );
+  static getRemoveHouseHoldMemberButton(personId: string) {
+    const testId = `test-remove-household-member-button-${personId}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
 
-  static mockHousingRegisterApiGetApplications(
-    applicationId: string,
-    application: Application
-  ) {
-    cy.task('nock', {
-      hostname: `${Cypress.env('HOUSING_REGISTER_API')}`,
-      method: 'GET',
-      path: `/applications/${applicationId}`,
-      status: 200,
-      body: application,
-    });
+  static getRemoveHouseHoldMemberConfirmationButton(personId: string) {
+    const testId = `test-remove-household-member-confirmation-button-${personId}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getErrorSummary() {
+    const testId = 'test-view-application-page-error-summary';
+    return cy.get(`[data-testid="${testId}"]`);
   }
 }
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -66,7 +66,7 @@ Cypress.Commands.add('generateEmptyApplication', () => {
 
 Cypress.Commands.add(
   'mockActivityHistoryApiEmptyResponse',
-  (targetId: string) => {
+  (targetId: string, persist?: boolean) => {
     cy.task('nock', {
       hostname: Cypress.env('ACTIVITY_HISTORY_API'),
       method: 'GET',
@@ -76,6 +76,7 @@ Cypress.Commands.add(
         results: [{}],
         paginationDetails: { nextToken: null },
       },
+      persist,
     });
   }
 );

--- a/lib/gateways/internal-api.ts
+++ b/lib/gateways/internal-api.ts
@@ -14,10 +14,12 @@ export const updateApplication = async (application: Application) => {
     method: 'PATCH',
     body: JSON.stringify(application),
   });
-  if (res.status == 400) {
-    throw (await res.json()).message;
+
+  if (res.ok) {
+    return (await res.json()) as Application;
+  } else {
+    throw Error(`Unable to update application (${res.status})`);
   }
-  return (await res.json()) as Application;
 };
 
 export const createApplication = async (application: Application) => {

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -13,7 +13,10 @@ declare global {
       mockHousingRegisterApiGetApplicationsByStatusAndAssignedTo(
         user: HackneyGoogleUserWithPermissions
       ): Chainable<void>;
-      mockActivityHistoryApiEmptyResponse(targetId: string): Chainable<void>;
+      mockActivityHistoryApiEmptyResponse(
+        targetId: string,
+        persist?: boolean
+      ): Chainable<void>;
       mockHousingRegisterApiPostSearchResults(
         application: Application
       ): Chainable<void>;


### PR DESCRIPTION
## WHAT
Currently when household member is deleted from the application any API call failures happen silently, so user is not aware that something went wrong. This update improves the error handling to make the errors visible.

## WHY
User should be notified when the delete household member operation fails.

## HOW
Update the `handleDelete` function to show error message when the API call fails. This page has a deletion confirmation dialog, so this update closes the dialog on error and then displays the error message on the page, so it's constintent with other error messages. 

Cypress test setup has also been updated to remove page level API mocks, so they are now using the Cypress commands which is how other tests currently work.

`updateApplication` function in `internal-api` has been updated to throw an error when the API call fails. There's another PR (#402) open currently that further tests this function change, so any additional testing has been omitted from this PR.

## FUTURE
Implement user firendly saving status message to the dialog for better feedback to the user.