### PR TITLE
TS-1702: adds error handling on apply pages

### DIFF
--- a/components/form/CheckboxesConditional.tsx
+++ b/components/form/CheckboxesConditional.tsx
@@ -22,29 +22,26 @@ export function ConditionalInput({
   display,
 }: ConditionalFormFieldOptionInput) {
   return (
-    <>
-      <div
-        className={
-          'govuk-checkboxes__conditional' + (display ? '' : '--hidden')
-        }
-        id={containerId}
-      >
-        {as === 'textarea' ? (
-          <Textarea as="textarea" name={fieldName!} label={label!} />
-        ) : (
-          <>
-            <Label content={label} htmlFor={fieldId} />
-            <Field
-              className="govuk-input govuk-!-width-one-third"
-              type={as}
-              id={fieldId}
-              name={fieldName}
-              data-aria-controls={containerId}
-            />
-          </>
-        )}
-      </div>
-    </>
+    <div
+      className={'govuk-checkboxes__conditional' + (display ? '' : '--hidden')}
+      data-testid={`test-checkbox-conditional-container-${containerId}`}
+      id={containerId}
+    >
+      {as === 'textarea' ? (
+        <Textarea as="textarea" name={fieldName!} label={label!} />
+      ) : (
+        <>
+          <Label content={label} htmlFor={fieldId} />
+          <Field
+            className="govuk-input govuk-!-width-one-third"
+            type={as}
+            id={fieldId}
+            name={fieldName}
+            data-aria-controls={containerId}
+          />
+        </>
+      )}
+    </div>
   );
 }
 
@@ -69,7 +66,10 @@ export function Checkbox({
   }
 
   return (
-    <div className="govuk-checkboxes__item">
+    <div
+      className="govuk-checkboxes__item"
+      data-testid={`test-checkbox-conditional-${id}`}
+    >
       <Field
         className="govuk-checkboxes__input"
         type="checkbox"

--- a/components/form/radioconditional.tsx
+++ b/components/form/radioconditional.tsx
@@ -60,7 +60,10 @@ export function Radio({
   }
 
   return (
-    <div className="govuk-radios__item">
+    <div
+      className="govuk-radios__item"
+      data-testid={`test-radio-conditional-${name}-${index}`}
+    >
       <Field
         className="govuk-radios__input"
         type="radio"

--- a/components/form/radios.tsx
+++ b/components/form/radios.tsx
@@ -33,6 +33,7 @@ export function Radio({
         id={id}
         name={name}
         value={value}
+        data-testid={`test-radio-${id}`}
       />
       <Label
         className="govuk-radios__label"

--- a/components/loading/index.tsx
+++ b/components/loading/index.tsx
@@ -4,7 +4,10 @@ import Paragraph from '../content/paragraph';
 export default function Loading({ text = 'Loading…' }): ReactElement {
   return (
     <div className="lbh-loading">
-      <div className="lbh-loading__spinner"></div>
+      <div
+        className="lbh-loading__spinner"
+        data-testid="test-loading-spinner"
+      ></div>
       <Paragraph>{text}</Paragraph>
     </div>
   );

--- a/cypress/e2e/pages/agreeTerms.cy.ts
+++ b/cypress/e2e/pages/agreeTerms.cy.ts
@@ -1,4 +1,3 @@
-// import StartPage from '../../pages/start';
 import { generateApplication } from '../../../testUtils/applicationHelper';
 import { generatePerson } from '../../../testUtils/personHelper';
 import { faker } from '@faker-js/faker/locale/en_GB';
@@ -39,7 +38,7 @@ const applicationWithMainApplicantAndAgreedTerms = {
   },
 };
 
-describe('Application', () => {
+describe('Agree terms', () => {
   beforeEach(() => {
     cy.clearAllCookies();
     cy.task('clearNock');
@@ -60,24 +59,20 @@ describe('Application', () => {
     cy.contains('Checking information…');
   });
 
-  it('lets user fill in and submit their personal details when logged in', () => {
-    //login with claims to specific application id
+  it('lets user agree to terms when logged in', () => {
     cy.loginAsResident(applicationId, true);
 
-    //initial GET request for agree-terms page
     cy.mockHousingRegisterApiGetApplications(
       applicationId,
       applicationWithMainApplicant
     );
 
-    //PATCH request to update the application with agreed terms
     cy.mockHousingRegisterApiPatchApplication(
       applicationId,
       applicationWithMainApplicantAndAgreedTerms,
       apiResponseDelay
     );
 
-    //second GET request for household page after the application has been patched
     cy.mockHousingRegisterApiGetApplications(
       applicationId,
       applicationWithMainApplicantAndAgreedTerms
@@ -85,14 +80,11 @@ describe('Application', () => {
 
     AgreeTermsPage.visit();
 
-    // Agree to terms and submit
     AgreeTermsPage.getAgreeCheckbox().click();
     AgreeTermsPage.getAgreeButton().click();
 
-    //check that message is shown until (delayed) PATCH call has finished
     cy.contains('Saving...');
 
-    //check that user is now on the household member page
     HouseholdPage.getHouseholdPage().should('be.visible');
   });
 
@@ -106,7 +98,6 @@ describe('Application', () => {
 
     const errorStatusCode = StatusCodes.BAD_REQUEST;
 
-    //based on current API layer setup
     const expectedErrorMessage = `Unable to update application (${errorStatusCode})`;
 
     cy.mockHousingRegisterApiPatchApplication(

--- a/cypress/e2e/pages/apply/submit/additionalQuestions.cy.ts
+++ b/cypress/e2e/pages/apply/submit/additionalQuestions.cy.ts
@@ -1,0 +1,153 @@
+import { generateApplication } from '../../../../../testUtils/applicationHelper';
+import { generatePerson } from '../../../../../testUtils/personHelper';
+import { faker } from '@faker-js/faker/locale/en_GB';
+import { StatusCodes } from 'http-status-codes';
+import AdditionalQuestionsPage from '../../../../pages/additionalQuestions';
+
+import EthnicityPage from '../../../../pages/ethnicity';
+import { Errors } from '../../../../../lib/types/errors';
+import Components from '../../../../pages/components';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+const mainApplicant = generatePerson(personId);
+const apiResponseDelay = 1000;
+const application = generateApplication(applicationId, personId, false, false);
+const phoneNumber = faker.phone.number();
+
+const applicationWithMainApplicant = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    contactInformation: {
+      ...application.mainApplicant.contactInformation,
+      phoneNumber: phoneNumber,
+    },
+    person: mainApplicant,
+  },
+  calculatedBedroomNeed: 1,
+};
+
+describe('Additional questions', () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.task('clearNock');
+  });
+
+  it('shows the loading spinner while application data is being fetched on the background', () => {
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      application,
+      false,
+      apiResponseDelay
+    );
+
+    AdditionalQuestionsPage.visit();
+    AdditionalQuestionsPage.getAdditionalQuestionsPage().should('be.visible');
+
+    cy.contains('Checking information…');
+  });
+
+  it('lets user fill in and submit their personal details when logged in', () => {
+    cy.loginAsResident(applicationId, true);
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithMainApplicant,
+      apiResponseDelay
+    );
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    AdditionalQuestionsPage.visit();
+    AdditionalQuestionsPage.getAdditionalQuestionsPage().should('be.visible');
+
+    Components.getConditionalCheckboxes().first().click();
+    AdditionalQuestionsPage.getAdditionalQuestionsNotes()
+      .first()
+      .scrollIntoView()
+      .click()
+      .type(faker.lorem.sentence());
+
+    Components.getSaveButton().click();
+
+    cy.contains('Saving...');
+
+    Components.getLoadingSpinner().should('not.exist');
+    EthnicityPage.getEthnicityPage().should('be.visible');
+  });
+
+  it('shows an error message when action fails', () => {
+    cy.loginAsResident(applicationId, true);
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    const errorStatusCode = StatusCodes.BAD_REQUEST;
+
+    const expectedErrorMessage = `Unable to update application (${errorStatusCode})`;
+
+    AdditionalQuestionsPage.visit();
+
+    AdditionalQuestionsPage.getErrorSummary().should('not.exist');
+
+    Components.getConditionalCheckboxes().first().click();
+    AdditionalQuestionsPage.getAdditionalQuestionsNotes()
+      .first()
+      .scrollIntoView()
+      .click()
+      .type(faker.lorem.sentence());
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithMainApplicant,
+      apiResponseDelay,
+      errorStatusCode
+    );
+
+    Components.getSaveButton().click();
+
+    AdditionalQuestionsPage.getErrorSummary().should('be.visible');
+    cy.contains(expectedErrorMessage);
+  });
+  it('shows an error message when dispatch fails', () => {
+    cy.loginAsResident(applicationId, true);
+
+    cy.mockHousingRegisterApiGetApplications(applicationId, application);
+
+    const expectedErrorMessage = Errors.GENERIC_ERROR;
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithMainApplicant,
+      apiResponseDelay
+    );
+
+    AdditionalQuestionsPage.visit();
+
+    AdditionalQuestionsPage.getErrorSummary().should('not.exist');
+
+    Components.getConditionalCheckboxes().first().click();
+    AdditionalQuestionsPage.getAdditionalQuestionsNotes()
+      .first()
+      .scrollIntoView()
+      .click()
+      .type(faker.lorem.sentence());
+
+    Components.getSaveButton().click();
+
+    AdditionalQuestionsPage.getErrorSummary().should('be.visible');
+    cy.contains(expectedErrorMessage);
+  });
+});

--- a/cypress/e2e/pages/apply/submit/declaration.cy.ts
+++ b/cypress/e2e/pages/apply/submit/declaration.cy.ts
@@ -48,6 +48,7 @@ describe('Declaration', () => {
   beforeEach(() => {
     cy.clearAllCookies();
     cy.task('clearNock');
+    cy.mockNotifyEmailResponse(200);
   });
 
   it('shows the loading spinner while application data is being fetched on the background', () => {

--- a/cypress/e2e/pages/apply/submit/declaration.cy.ts
+++ b/cypress/e2e/pages/apply/submit/declaration.cy.ts
@@ -1,0 +1,222 @@
+import { generateApplication } from '../../../../../testUtils/applicationHelper';
+import { generatePerson } from '../../../../../testUtils/personHelper';
+import { faker } from '@faker-js/faker/locale/en_GB';
+import { StatusCodes } from 'http-status-codes';
+
+import DeclarationPage from '../../../../pages/declaration';
+import Components from '../../../../pages/components';
+import ConfirmationPage from '../../../../pages/confirmation';
+import RejectionPage from '../../../../pages/rejection';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+const mainApplicant = generatePerson(personId);
+const apiResponseDelay = 1000;
+const application = generateApplication(applicationId, personId, false, false);
+const phoneNumber = faker.phone.number();
+
+const applicationWithMainApplicant = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    contactInformation: {
+      ...application.mainApplicant.contactInformation,
+      phoneNumber: phoneNumber,
+    },
+    person: mainApplicant,
+  },
+  calculatedBedroomNeed: 1,
+};
+
+const dateOfBirth = new Date();
+dateOfBirth.setFullYear(dateOfBirth.getFullYear() - 7);
+const underEighteenDateOfBirth = dateOfBirth.toISOString();
+
+const applicationWithNoNeed = {
+  ...applicationWithMainApplicant,
+  mainApplicant: {
+    ...applicationWithMainApplicant.mainApplicant,
+    person: {
+      ...applicationWithMainApplicant.mainApplicant.person,
+      dateOfBirth: underEighteenDateOfBirth,
+    },
+  },
+  calculatedBedroomNeed: 0,
+};
+
+describe('Declaration', () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.task('clearNock');
+  });
+
+  it('shows the loading spinner while application data is being fetched on the background', () => {
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      application,
+      false,
+      apiResponseDelay
+    );
+
+    DeclarationPage.visit();
+    DeclarationPage.getDeclarationPage().should('be.visible');
+
+    cy.contains('Checking information…');
+  });
+
+  it('lets user accept declaration when signed in', () => {
+    cy.loginAsResident(applicationId, true);
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithMainApplicant,
+      apiResponseDelay
+    );
+
+    cy.mockHousingRegisterApiPostEvidenceRequest(
+      applicationId,
+      apiResponseDelay
+    );
+
+    cy.mockHousingRegisterApiPatchCompleteApplication(
+      applicationId,
+      apiResponseDelay
+    );
+
+    DeclarationPage.visit();
+    DeclarationPage.getDeclarationPage().should('be.visible');
+
+    Components.getCheckboxes().first().click();
+
+    Components.getSaveButton().click();
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    cy.contains('Saving...');
+
+    ConfirmationPage.getConfirmationPage().should('be.visible');
+    Components.getLoadingSpinner().should('not.exist');
+  });
+
+  it('shows user rejected declaration when signed in', () => {
+    cy.loginAsResident(applicationId, true);
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithNoNeed
+    );
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithNoNeed
+    );
+
+    DeclarationPage.visit();
+    DeclarationPage.getDeclarationPage().should('be.visible');
+
+    Components.getCheckboxes().first().click();
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithNoNeed
+    );
+
+    Components.getSaveButton().click();
+    Components.getLoadingSpinner().should('be.visible');
+
+    RejectionPage.getRejectionPage().should('be.visible');
+    Components.getLoadingSpinner().should('be.visible');
+  });
+
+  it('shows an error message when cannot complete successful application', () => {
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    const errorStatusCode = StatusCodes.INTERNAL_SERVER_ERROR;
+
+    const expectedErrorMessage = `Unable to complete application (${errorStatusCode})`;
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithMainApplicant,
+      apiResponseDelay
+    );
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    cy.mockHousingRegisterApiPostEvidenceRequest(
+      applicationId,
+      apiResponseDelay,
+      errorStatusCode
+    );
+
+    cy.mockHousingRegisterApiPatchCompleteApplication(
+      applicationId,
+      apiResponseDelay,
+      errorStatusCode
+    );
+
+    DeclarationPage.visit();
+    DeclarationPage.getDeclarationPage().should('be.visible');
+
+    Components.getCheckboxes().first().click();
+
+    Components.getSaveButton().click();
+
+    DeclarationPage.getErrorSummary().should('be.visible');
+    cy.contains(expectedErrorMessage);
+  });
+  it('shows an error message when cannot complete rejected application', () => {
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithNoNeed
+    );
+
+    const errorStatusCode = StatusCodes.INTERNAL_SERVER_ERROR;
+
+    const expectedErrorMessage = `Unable to complete application (${errorStatusCode})`;
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithNoNeed
+    );
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithNoNeed,
+      apiResponseDelay,
+      errorStatusCode
+    );
+
+    DeclarationPage.visit();
+    DeclarationPage.getDeclarationPage().should('be.visible');
+
+    Components.getCheckboxes().first().click();
+
+    Components.getSaveButton().click();
+
+    DeclarationPage.getErrorSummary().should('be.visible');
+    cy.contains(expectedErrorMessage);
+  });
+});

--- a/cypress/e2e/pages/apply/submit/ethnicityQuestions.cy.ts
+++ b/cypress/e2e/pages/apply/submit/ethnicityQuestions.cy.ts
@@ -1,0 +1,139 @@
+import { generateApplication } from '../../../../../testUtils/applicationHelper';
+import { generatePerson } from '../../../../../testUtils/personHelper';
+import { faker } from '@faker-js/faker/locale/en_GB';
+import { StatusCodes } from 'http-status-codes';
+
+import EthnicityPage from '../../../../pages/ethnicity';
+import { Errors } from '../../../../../lib/types/errors';
+import DeclarationPage from '../../../../pages/declaration';
+import Components from '../../../../pages/components';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+const mainApplicant = generatePerson(personId);
+const apiResponseDelay = 1000;
+const application = generateApplication(applicationId, personId, false, false);
+const phoneNumber = faker.phone.number();
+
+const applicationWithMainApplicant = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    contactInformation: {
+      ...application.mainApplicant.contactInformation,
+      phoneNumber: phoneNumber,
+    },
+    person: mainApplicant,
+  },
+  calculatedBedroomNeed: 1,
+};
+
+describe('Ethnicity questions', () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.task('clearNock');
+  });
+
+  it('shows the loading spinner while application data is being fetched on the background', () => {
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      application,
+      false,
+      apiResponseDelay
+    );
+
+    EthnicityPage.visit();
+    EthnicityPage.getEthnicityPage().should('be.visible');
+
+    cy.contains('Checking information…');
+  });
+
+  it('lets user fill in and submit their personal details when logged in', () => {
+    cy.loginAsResident(applicationId, true);
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithMainApplicant,
+      apiResponseDelay
+    );
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    EthnicityPage.visit();
+    EthnicityPage.getEthnicityPage().should('be.visible');
+
+    Components.getRadioButtons().first().click();
+
+    Components.getSaveButton().click();
+
+    cy.contains('Saving...');
+
+    Components.getLoadingSpinner().should('not.exist');
+    DeclarationPage.getDeclarationPage().should('be.visible');
+  });
+
+  it('shows an error message when patch is not fulfilled', () => {
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant
+    );
+
+    const errorStatusCode = StatusCodes.BAD_REQUEST;
+
+    const expectedErrorMessage = `Unable to update application (${errorStatusCode})`;
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithMainApplicant,
+      apiResponseDelay,
+      errorStatusCode
+    );
+
+    EthnicityPage.visit();
+
+    EthnicityPage.getErrorSummary().should('not.exist');
+
+    Components.getRadioButtons().first().click();
+
+    Components.getSaveButton().click();
+
+    EthnicityPage.getErrorSummary().should('be.visible');
+    cy.contains(expectedErrorMessage);
+  });
+  it('shows an error message when dispatch fails', () => {
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(applicationId, application);
+
+    const errorStatusCode = StatusCodes.BAD_REQUEST;
+
+    const expectedErrorMessage = Errors.GENERIC_ERROR;
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithMainApplicant,
+      apiResponseDelay,
+      errorStatusCode
+    );
+
+    EthnicityPage.visit();
+
+    EthnicityPage.getErrorSummary().should('not.exist');
+
+    Components.getRadioButtons().first().click();
+
+    Components.getSaveButton().click();
+
+    EthnicityPage.getErrorSummary().should('be.visible');
+    cy.contains(expectedErrorMessage);
+  });
+});

--- a/cypress/pages/additionalQuestions.ts
+++ b/cypress/pages/additionalQuestions.ts
@@ -1,0 +1,19 @@
+class AdditionalQuestionsPage {
+  static getAdditionalQuestionsPage() {
+    const testId = 'test-additional-questions-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+  static visit() {
+    cy.visit(`/apply/submit/additional-questions`);
+  }
+  static getAdditionalQuestionsNotes() {
+    const testId = 'test-checkbox-conditional-container';
+    return cy.get(`[data-testid*="${testId}"]`);
+  }
+  static getErrorSummary() {
+    const testId = 'test-additional-questions-error-summary';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+}
+
+export default AdditionalQuestionsPage;

--- a/cypress/pages/components.ts
+++ b/cypress/pages/components.ts
@@ -1,0 +1,24 @@
+class Components {
+  static getLoadingSpinner() {
+    const testId = 'test-loading-spinner';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+  static getSaveButton() {
+    const testId = 'test-submit-form-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+  static getRadioButtons() {
+    const testId = 'test-radio-';
+    return cy.get(`[data-testid*="${testId}"]`);
+  }
+  static getCheckboxes() {
+    const testId = 'test-checkbox-';
+    return cy.get(`[data-testid*="${testId}"]`);
+  }
+  static getConditionalCheckboxes() {
+    const testId = 'test-checkbox-conditional-';
+    return cy.get(`[data-testid*="${testId}"]`);
+  }
+}
+
+export default Components;

--- a/cypress/pages/confirmation.ts
+++ b/cypress/pages/confirmation.ts
@@ -1,0 +1,11 @@
+class ConfirmationPage {
+  static getConfirmationPage() {
+    const testId = 'test-apply-confirmation-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+  static visit() {
+    cy.visit(`/apply/confirmation`);
+  }
+}
+
+export default ConfirmationPage;

--- a/cypress/pages/declaration.ts
+++ b/cypress/pages/declaration.ts
@@ -1,0 +1,15 @@
+class DeclarationPage {
+  static getDeclarationPage() {
+    const testId = 'test-declaration-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+  static visit() {
+    cy.visit(`/apply/submit/declaration`);
+  }
+  static getErrorSummary() {
+    const testId = 'test-declaration-error-summary';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+}
+
+export default DeclarationPage;

--- a/cypress/pages/ethnicity.ts
+++ b/cypress/pages/ethnicity.ts
@@ -1,0 +1,27 @@
+class EthnicityPage {
+  static getEthnicityPage() {
+    const testId = 'test-ethnicity-questions-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+  static visit() {
+    cy.visit(`/apply/submit/ethnicity-questions`);
+  }
+  // static getEthnicityRadios() {
+  //   const testId = 'test-radio-';
+  //   return cy.get(`[data-testid*="${testId}"]`);
+  // }
+  // static getSaveButton() {
+  //   const testId = 'test-submit-form-button';
+  //   return cy.get(`[data-testid="${testId}"]`);
+  // }
+  static getErrorSummary() {
+    const testId = 'test-ethnicity-questions-error-summary';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+  // static getLoadingSpinner() {
+  //   const testId = 'test-loading-spinner';
+  //   return cy.get(`[data-testid="${testId}"]`);
+  // }
+}
+
+export default EthnicityPage;

--- a/cypress/pages/ethnicity.ts
+++ b/cypress/pages/ethnicity.ts
@@ -6,22 +6,11 @@ class EthnicityPage {
   static visit() {
     cy.visit(`/apply/submit/ethnicity-questions`);
   }
-  // static getEthnicityRadios() {
-  //   const testId = 'test-radio-';
-  //   return cy.get(`[data-testid*="${testId}"]`);
-  // }
-  // static getSaveButton() {
-  //   const testId = 'test-submit-form-button';
-  //   return cy.get(`[data-testid="${testId}"]`);
-  // }
+
   static getErrorSummary() {
     const testId = 'test-ethnicity-questions-error-summary';
     return cy.get(`[data-testid="${testId}"]`);
   }
-  // static getLoadingSpinner() {
-  //   const testId = 'test-loading-spinner';
-  //   return cy.get(`[data-testid="${testId}"]`);
-  // }
 }
 
 export default EthnicityPage;

--- a/cypress/pages/rejection.ts
+++ b/cypress/pages/rejection.ts
@@ -1,0 +1,11 @@
+class RejectionPage {
+  static getRejectionPage() {
+    const testId = 'test-apply-rejection-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+  static visit() {
+    cy.visit(`/apply/not-eligible`);
+  }
+}
+
+export default RejectionPage;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -321,3 +321,15 @@ Cypress.Commands.add(
     });
   }
 );
+Cypress.Commands.add(
+  'mockNotifyEmailResponse',
+  (statusCode: number = StatusCodes.OK) => {
+    cy.task('nock', {
+      hostname: 'https://api.notifications.service.gov.uk',
+      method: 'POST',
+      path: '/v2/notifications/email',
+      statusCode,
+      persist: true,
+    });
+  }
+);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -288,3 +288,36 @@ Cypress.Commands.add(
     });
   }
 );
+
+Cypress.Commands.add(
+  'mockHousingRegisterApiPostEvidenceRequest',
+  (
+    applicationId: string,
+    delay: number = 0,
+    statusCode: number = StatusCodes.OK
+  ) => {
+    cy.task('nock', {
+      hostname: Cypress.env('HOUSING_REGISTER_API'),
+      method: 'POST',
+      path: `/applications/${applicationId}/evidence`,
+      statusCode,
+      delay,
+    });
+  }
+);
+Cypress.Commands.add(
+  'mockHousingRegisterApiPatchCompleteApplication',
+  (
+    applicationId: string,
+    delay: number = 0,
+    statusCode: number = StatusCodes.OK
+  ) => {
+    cy.task('nock', {
+      hostname: Cypress.env('HOUSING_REGISTER_API'),
+      method: 'PATCH',
+      path: `/applications/${applicationId}/complete`,
+      statusCode,
+      delay,
+    });
+  }
+);

--- a/lib/hooks/useApiCallStatus.tsx
+++ b/lib/hooks/useApiCallStatus.tsx
@@ -5,7 +5,7 @@ import { ParsedUrlQueryInput } from 'querystring';
 
 // custom hook to manage the application status and ensure promises are fulfilled before moving to the next page.
 
-interface UseApplicationUpdateStatusProps {
+interface UseApiCallStatusProps {
   selector: ApiCallStatus | undefined;
   userActionCompleted: boolean;
   pathToPush: string;
@@ -21,7 +21,7 @@ const useApiCallStatus = ({
   scrollToError,
   pathToPush,
   query,
-}: UseApplicationUpdateStatusProps) => {
+}: UseApiCallStatusProps) => {
   const router = useRouter();
 
   useEffect(() => {

--- a/lib/store/application.ts
+++ b/lib/store/application.ts
@@ -51,30 +51,42 @@ export const updateApplication = createAsyncThunk(
 
 export const disqualifyApplication = createAsyncThunk(
   'application/disqualify',
-  async (id: string) => {
+  async (id: string, { rejectWithValue }) => {
     const request: Application = {
       id: id,
       status: ApplicationStatus.DISQUALIFIED,
     };
-    await fetch(`/api/applications/${id}`, {
+    const res = await fetch(`/api/applications/${id}`, {
       method: 'PATCH',
       body: JSON.stringify(request),
     });
+    if (res.ok) {
+      return (await res.json()) as EvidenceRequestResponse;
+    } else {
+      return rejectWithValue(`Unable to complete application (${res.status})`);
+    }
   }
 );
 
-export const completeApplication = createAsyncThunk(
+export const completeApplication = createAsyncThunk<
+  void,
+  Application,
+  { rejectValue: string }
+>(
   'application/complete',
-  async (application: Application) => {
-    await fetch(`/api/applications/${application.id}/complete`, {
+  async (application: Application, { rejectWithValue }) => {
+    const res = await fetch(`/api/applications/${application.id}/complete`, {
       method: 'PATCH',
     });
+    if (!res.ok) {
+      return rejectWithValue(`Unable to complete application (${res.status})`);
+    }
   }
 );
 
 export const createEvidenceRequest = createAsyncThunk(
   'application/evidence',
-  async (application: Application) => {
+  async (application: Application, { rejectWithValue }) => {
     const request: CreateEvidenceRequest = {
       documentTypes: getRequiredDocumentsForApplication(
         application.mainApplicant!
@@ -84,7 +96,11 @@ export const createEvidenceRequest = createAsyncThunk(
       method: 'POST',
       body: JSON.stringify(request),
     });
-    return (await res.json()) as EvidenceRequestResponse;
+    if (res.ok) {
+      return (await res.json()) as EvidenceRequestResponse;
+    } else {
+      return rejectWithValue(`Unable to complete application (${res.status})`);
+    }
   }
 );
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest && tsc --noEmit",
     "test:watch": "jest --watch",
     "prepare": "husky",
-    "cypress:open": "cypress open --browser electron",
+    "cypress:open": "cypress open --browser chrome",
     "e2e:run": "cypress run --e2e --browser electron",
     "component:run": "cypress run --component --browser electron"
   },

--- a/pages/apply/confirmation.tsx
+++ b/pages/apply/confirmation.tsx
@@ -24,7 +24,7 @@ const ApplicationConfirmation = (): JSX.Element => {
   };
 
   return (
-    <Layout pageName="Confirmation">
+    <Layout pageName="Confirmation" dataTestId="test-apply-confirmation-page">
       <Panel heading="Application complete">
         <>
           {`Your reference number: ${application.reference?.toUpperCase()}`}

--- a/pages/apply/not-eligible.tsx
+++ b/pages/apply/not-eligible.tsx
@@ -40,7 +40,7 @@ const NotEligible = (): JSX.Element => {
   };
 
   return (
-    <Layout>
+    <Layout dataTestId="test-apply-rejection-page">
       <Panel heading="You don't qualify to join the housing register">
         Your reference number: {application.reference?.toUpperCase()}
       </Panel>

--- a/pages/apply/submit/declaration.tsx
+++ b/pages/apply/submit/declaration.tsx
@@ -19,6 +19,10 @@ import Paragraph from '../../../components/content/paragraph';
 import { getDisqualificationReasonOption } from '../../../lib/utils/disqualificationReasonOptions';
 import Custom404 from '../../404';
 import Link from 'next/link';
+import { useState } from 'react';
+import ErrorSummary from 'components/errors/error-summary';
+import Loading from 'components/loading';
+import { scrollToError } from 'lib/utils/scroll';
 
 const Declaration = (): JSX.Element => {
   const router = useRouter();
@@ -27,72 +31,108 @@ const Declaration = (): JSX.Element => {
   const mainResident = useAppSelector((s) => s.application.mainApplicant);
   const application = useAppSelector((store) => store.application);
 
+  const [loading, setLoading] = useState<boolean>(false);
+  const [userError, setUserError] = useState<string | null>(null);
+
   const submitApplication = async () => {
     const [isEligible, reasons] = checkEligible(application);
+    setUserError(null);
+    setLoading(true);
     if (!isEligible) {
       const reasonStrings = reasons.map((reason) =>
         getDisqualificationReasonOption(reason)
       );
       const reason = reasonStrings.join(',');
+      // this is just a notification, so for now we don't need to handle errors
       dispatch(sendDisqualifyEmail({ application, reason }));
-      dispatch(disqualifyApplication(application.id!));
-      router.push('/apply/not-eligible');
+
+      try {
+        console.log('hello');
+        await dispatch(disqualifyApplication(application.id!)).unwrap();
+        router.push('/apply/not-eligible');
+      } catch (error) {
+        setUserError(error as string);
+        console.error('Error completing the application:', error);
+        scrollToError();
+      } finally {
+        setLoading(false);
+      }
     } else {
+      // these are just notifications, so we don't need to handle errors yet
       dispatch(sendConfirmation(application));
 
       const medicalNeeds = applicantsWithMedicalNeed(application);
       if (medicalNeeds > 0) {
+        // these are just notifications, so we don't need to handle errors yet
         dispatch(sendMedicalNeed({ application, medicalNeeds }));
       }
-
-      dispatch(completeApplication(application));
-      dispatch(createEvidenceRequest(application));
-      router.push('/apply/confirmation');
+      try {
+        await dispatch(completeApplication(application)).unwrap();
+        await dispatch(createEvidenceRequest(application)).unwrap();
+        router.push('/apply/confirmation');
+      } catch (error) {
+        console.log('Error completing the application:', error);
+        setUserError(error as string);
+        console.error('Error completing the application:', error);
+        scrollToError;
+      } finally {
+        setLoading(false);
+      }
     }
   };
 
+  if (!mainResident) {
+    return <Custom404 />;
+  }
+
   return (
-    <>
-      {mainResident ? (
-        <Layout pageName="Declaration">
-          <HeadingOne content="Declaration" />
+    <Layout pageName="Declaration" dataTestId="test-declaration-page">
+      <HeadingOne content="Declaration" />
+      {userError && (
+        <ErrorSummary dataTestId="test-declaration-error-summary">
+          {userError}
+        </ErrorSummary>
+      )}
 
-          <Paragraph>
-            <strong>Please read and confirm the following statement</strong>
-          </Paragraph>
+      <Paragraph>
+        <strong>Please read and confirm the following statement</strong>
+      </Paragraph>
 
-          <Paragraph>
-            I understand and agree that the information I have provided on this
-            form may be shared with another local authority, another social
-            landlord or a tenant management organisation, if they are
-            considering my application.
-          </Paragraph>
+      <Paragraph>
+        I understand and agree that the information I have provided on this form
+        may be shared with another local authority, another social landlord or a
+        tenant management organisation, if they are considering my application.
+      </Paragraph>
 
-          <Paragraph>
-            I declare that the information in this form is true and complete and
-            I give consent to Hackney Council making such enquiries as may be
-            necessary to confirm the information I have given.
-          </Paragraph>
+      <Paragraph>
+        I declare that the information in this form is true and complete and I
+        give consent to Hackney Council making such enquiries as may be
+        necessary to confirm the information I have given.
+      </Paragraph>
 
-          <Paragraph>
-            I understand that it is a criminal offence to provide false or
-            misleading information, or to withhold relevant information which
-            Hackney Council have reasonably required me to give.
-          </Paragraph>
+      <Paragraph>
+        I understand that it is a criminal offence to provide false or
+        misleading information, or to withhold relevant information which
+        Hackney Council have reasonably required me to give.
+      </Paragraph>
 
-          <Paragraph>
-            I understand that if information is found to be false, I may be
-            prosecuted and you may repossess my home if a tenancy arises from
-            it; or cancel my housing application or an offer of a property and I
-            will not be able to re-apply to go on the Council’s housing register
-            for at least 5 years.
-          </Paragraph>
+      <Paragraph>
+        I understand that if information is found to be false, I may be
+        prosecuted and you may repossess my home if a tenancy arises from it; or
+        cancel my housing application or an offer of a property and I will not
+        be able to re-apply to go on the Council’s housing register for at least
+        5 years.
+      </Paragraph>
 
-          <Paragraph>
-            If I am prosecuted by you and found guilty, I understand that I
-            could be ordered to pay a fine of up to £5,000.
-          </Paragraph>
+      <Paragraph>
+        If I am prosecuted by you and found guilty, I understand that I could be
+        ordered to pay a fine of up to £5,000.
+      </Paragraph>
 
+      {loading ? (
+        <Loading text="Saving..." />
+      ) : (
+        <>
           <Form
             buttonText="Submit application"
             formData={getFormData(FormID.DECLARATION)}
@@ -106,11 +146,9 @@ const Declaration = (): JSX.Element => {
               </a>
             </Link>
           </div>
-        </Layout>
-      ) : (
-        <Custom404 />
+        </>
       )}
-    </>
+    </Layout>
   );
 };
 

--- a/pages/apply/submit/declaration.tsx
+++ b/pages/apply/submit/declaration.tsx
@@ -43,11 +43,9 @@ const Declaration = (): JSX.Element => {
         getDisqualificationReasonOption(reason)
       );
       const reason = reasonStrings.join(',');
-      // this is just a notification, so for now we don't need to handle errors
       dispatch(sendDisqualifyEmail({ application, reason }));
 
       try {
-        console.log('hello');
         await dispatch(disqualifyApplication(application.id!)).unwrap();
         router.push('/apply/not-eligible');
       } catch (error) {
@@ -58,12 +56,10 @@ const Declaration = (): JSX.Element => {
         setLoading(false);
       }
     } else {
-      // these are just notifications, so we don't need to handle errors yet
       dispatch(sendConfirmation(application));
 
       const medicalNeeds = applicantsWithMedicalNeed(application);
       if (medicalNeeds > 0) {
-        // these are just notifications, so we don't need to handle errors yet
         dispatch(sendMedicalNeed({ application, medicalNeeds }));
       }
       try {
@@ -71,7 +67,6 @@ const Declaration = (): JSX.Element => {
         await dispatch(createEvidenceRequest(application)).unwrap();
         router.push('/apply/confirmation');
       } catch (error) {
-        console.log('Error completing the application:', error);
         setUserError(error as string);
         console.error('Error completing the application:', error);
         scrollToError();

--- a/pages/apply/submit/declaration.tsx
+++ b/pages/apply/submit/declaration.tsx
@@ -74,7 +74,7 @@ const Declaration = (): JSX.Element => {
         console.log('Error completing the application:', error);
         setUserError(error as string);
         console.error('Error completing the application:', error);
-        scrollToError;
+        scrollToError();
       } finally {
         setLoading(false);
       }

--- a/pages/apply/submit/declaration.tsx
+++ b/pages/apply/submit/declaration.tsx
@@ -37,15 +37,16 @@ const Declaration = (): JSX.Element => {
   const submitApplication = async () => {
     const [isEligible, reasons] = checkEligible(application);
     setUserError(null);
-    setLoading(true);
+
     if (!isEligible) {
       const reasonStrings = reasons.map((reason) =>
         getDisqualificationReasonOption(reason)
       );
       const reason = reasonStrings.join(',');
-      dispatch(sendDisqualifyEmail({ application, reason }));
+      await dispatch(sendDisqualifyEmail({ application, reason }));
 
       try {
+        setLoading(true);
         await dispatch(disqualifyApplication(application.id!)).unwrap();
         router.push('/apply/not-eligible');
       } catch (error) {
@@ -56,13 +57,14 @@ const Declaration = (): JSX.Element => {
         setLoading(false);
       }
     } else {
-      dispatch(sendConfirmation(application));
+      await dispatch(sendConfirmation(application));
 
       const medicalNeeds = applicantsWithMedicalNeed(application);
       if (medicalNeeds > 0) {
-        dispatch(sendMedicalNeed({ application, medicalNeeds }));
+        await dispatch(sendMedicalNeed({ application, medicalNeeds }));
       }
       try {
+        setLoading(true);
         await dispatch(completeApplication(application)).unwrap();
         await dispatch(createEvidenceRequest(application)).unwrap();
         router.push('/apply/confirmation');

--- a/pages/apply/submit/ethnicity-questions.tsx
+++ b/pages/apply/submit/ethnicity-questions.tsx
@@ -1,5 +1,4 @@
 import { FormikValues, getIn } from 'formik';
-// import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { HeadingOne } from '../../../components/content/headings';
 import Form from '../../../components/form/form';

--- a/pages/apply/submit/ethnicity-questions.tsx
+++ b/pages/apply/submit/ethnicity-questions.tsx
@@ -1,5 +1,5 @@
 import { FormikValues, getIn } from 'formik';
-import { useRouter } from 'next/router';
+// import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { HeadingOne } from '../../../components/content/headings';
 import Form from '../../../components/form/form';
@@ -10,15 +10,26 @@ import { useAppDispatch, useAppSelector } from '../../../lib/store/hooks';
 import { updateWithFormValues } from '../../../lib/store/applicant';
 import withApplication from '../../../lib/hoc/withApplication';
 import { Applicant } from '../../../domain/HousingApi';
+import Loading from 'components/loading';
+import { scrollToError } from '../../../lib/utils/scroll';
+import {
+  selectSaveApplicationStatus,
+  ApiCallStatusCode,
+} from 'lib/store/apiCallsStatus';
+import useApiCallStatus from 'lib/hooks/useApiCallStatus';
+import ErrorSummary from 'components/errors/error-summary';
+import { Errors } from 'lib/types/errors';
 
 const EthnicityQuestions = (): JSX.Element => {
-  const router = useRouter();
   const dispatch = useAppDispatch();
   const applicant = useAppSelector(
     (store) => store.application.mainApplicant
   ) as Applicant;
 
   const [formId, setFormId] = useState('ethnicity-questions');
+  const [hasSaved, setHasSaved] = useState<boolean>(false);
+  const [userError, setUserError] = useState<string | null>(null);
+  const saveApplicationStatus = useAppSelector(selectSaveApplicationStatus);
   const [activeStepID, setActiveStepId] = useState(() => {
     switch (formId) {
       case 'ethnicity-extended-category-asian-asian-british':
@@ -40,12 +51,19 @@ const EthnicityQuestions = (): JSX.Element => {
         return FormID.ETHNICITY_QUESTIONS;
     }
   });
+  const formData = getFormData(activeStepID);
+
+  useApiCallStatus({
+    selector: saveApplicationStatus,
+    userActionCompleted: hasSaved,
+    setUserError,
+    pathToPush: '/apply/submit/declaration',
+    scrollToError,
+  });
 
   if (!applicant) {
     return <Custom404 />;
   }
-
-  const formData = getFormData(activeStepID);
 
   const nextStep = (values: FormikValues) => {
     const { nextFormId } = formData.conditionals?.find(
@@ -53,15 +71,21 @@ const EthnicityQuestions = (): JSX.Element => {
     ) ?? { nextFormId: 'exit' };
 
     if (nextFormId === 'exit') {
-      dispatch(
-        updateWithFormValues({
-          formID: activeStepID,
-          personID: applicant.person!.id!,
-          values,
-          markAsComplete: true,
-        })
-      );
-      router.push('/apply/submit/declaration');
+      try {
+        dispatch(
+          updateWithFormValues({
+            formID: activeStepID,
+            personID: applicant.person!.id!,
+            values,
+            markAsComplete: true,
+          })
+        );
+        setHasSaved(true);
+      } catch (error) {
+        console.error('Error saving agreement:', error);
+        setUserError(Errors.GENERIC_ERROR);
+        scrollToError();
+      }
       return;
     }
 
@@ -70,26 +94,45 @@ const EthnicityQuestions = (): JSX.Element => {
   };
 
   const onSave = (values: FormikValues) => {
-    dispatch(
-      updateWithFormValues({
-        formID: activeStepID,
-        personID: applicant.person!.id!,
-        values,
-        markAsComplete: true,
-      })
-    );
+    try {
+      dispatch(
+        updateWithFormValues({
+          formID: activeStepID,
+          personID: applicant.person!.id!,
+          values,
+          markAsComplete: true,
+        })
+      );
+      setHasSaved(true);
+    } catch (error) {
+      console.error('Error saving agreement:', error);
+      setUserError(Errors.GENERIC_ERROR);
+      scrollToError();
+    }
   };
 
   return (
-    <Layout pageName="Before you submit">
+    <Layout
+      pageName="Before you submit"
+      dataTestId="test-ethnicity-questions-page"
+    >
       <HeadingOne content="Before you submit" />
-      <Form
-        key={activeStepID}
-        buttonText="Save and continue"
-        formData={formData}
-        onSave={onSave}
-        onSubmit={nextStep}
-      />
+      {userError && (
+        <ErrorSummary dataTestId="test-ethnicity-questions-error-summary">
+          {userError}
+        </ErrorSummary>
+      )}
+      {saveApplicationStatus?.callStatus === ApiCallStatusCode.PENDING ? (
+        <Loading text="Saving..." />
+      ) : (
+        <Form
+          key={activeStepID}
+          buttonText="Save and continue"
+          formData={formData}
+          onSave={onSave}
+          onSubmit={nextStep}
+        />
+      )}
     </Layout>
   );
 };

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -41,6 +41,16 @@ declare global {
         delay?: number,
         statusCode?: number
       ): Chainable<void>;
+      mockHousingRegisterApiPostEvidenceRequest(
+        applicationId: string,
+        delay?: number,
+        statusCode?: number
+      ): Chainable<void>;
+      mockHousingRegisterApiPatchCompleteApplication(
+        applicationId: string,
+        delay?: number,
+        statusCode?: number
+      ): Chainable<void>;
     }
   }
 }

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -51,6 +51,7 @@ declare global {
         delay?: number,
         statusCode?: number
       ): Chainable<void>;
+      mockNotifyEmailResponse(statusCode?: number): Chainable<void>;
     }
   }
 }


### PR DESCRIPTION
https://hackney.atlassian.net/browse/TS-1702?atlOrigin=eyJpIjoiNWU5OGVmZDE4YzM4NGYwN2IyZjQ0OWQyODJmYjU5ZGUiLCJwIjoiaiJ9

**What**
Ensure that promises are fulfilled before progressing on the apply/ pages

**Why**
This is an implementation of the original issue detailed https://github.com/LBHackney-IT/lbh-housing-register/pull/421

**How**
Where the action triggers middleware to save, the custom hook is implemented to keep track of the promise state.

Where the action triggers a thunk directly, error handling is added to the page and the thunk is adapted to return an error on unfulfilled promise. 

