### PR TITLE
TS-1712 Improve error handling on add-case page

### DIFF
--- a/components/admin/AddCaseAddress.tsx
+++ b/components/admin/AddCaseAddress.tsx
@@ -218,6 +218,7 @@ export default function AddCaseAddress({
                     : 'govuk-secondary lbh-button--secondary'
                 }`}
                 onClick={addNewAddress}
+                data-testid="test-add-case-address-button"
               >
                 Add address
               </button>
@@ -373,7 +374,12 @@ export default function AddCaseAddress({
             />
           </div>
 
-          <Button onClick={saveAddress}>Save address</Button>
+          <Button
+            dataTestId="test-save-case-address-button"
+            onClick={saveAddress}
+          >
+            Save address
+          </Button>
         </>
       </Dialog>
     </>

--- a/cypress/e2e/addCase.cy.ts
+++ b/cypress/e2e/addCase.cy.ts
@@ -1,8 +1,0 @@
-describe('Add case', () => {
-  it('shows access denied page for user with read only permissions', () => {
-    cy.clearAllCookies();
-    cy.loginAsUser('readOnly');
-    cy.visit('applications/add-case');
-    cy.contains('Access denied');
-  });
-});

--- a/cypress/e2e/pages/applications/add-case.cy.ts
+++ b/cypress/e2e/pages/applications/add-case.cy.ts
@@ -1,0 +1,109 @@
+import { faker } from '@faker-js/faker';
+import AddCasePage from '../../../pages/applications/add-case';
+import { generatePerson, TitleEnum } from '../../../../testUtils/personHelper';
+import { generateApplication } from '../../../../testUtils/applicationHelper';
+import { StatusCodes } from 'http-status-codes';
+
+const title = faker.helpers.enumValue(TitleEnum);
+const birthDate = faker.date.birthdate({ mode: 'age', min: 18, max: 70 });
+const personId = faker.string.uuid();
+const person = generatePerson(personId);
+const applicationId = faker.string.uuid();
+const application = generateApplication(applicationId, personId, true, false);
+
+//generic error code returned by the current API layer on failure for affected endpoints
+const errorCode = StatusCodes.INTERNAL_SERVER_ERROR;
+
+const fillInTheCaseForm = () => {
+  AddCasePage.getTitleDropdown().select(title);
+  AddCasePage.getFirstNameInput().type(person.firstName);
+  AddCasePage.getLastNameInput().type(person.surname);
+  AddCasePage.getDoBDayInput().type(birthDate.getDate().toString());
+  AddCasePage.getDoBMonthInput().type((birthDate.getMonth() + 1).toString());
+  AddCasePage.getDoBYearInput().type(birthDate.getFullYear().toString());
+  AddCasePage.getGenderDropdown().select(person.gender);
+  AddCasePage.getLivingSituationDropdown().select('private-rental');
+  AddCasePage.getCitizenshipDropdown().select('british');
+  AddCasePage.getAddAddressButton().click();
+  AddCasePage.getAddressLine1Input().type('line 1');
+  AddCasePage.getSaveAddressButton().scrollIntoView().click();
+};
+
+describe('Add case', () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.task('clearNock');
+    cy.loginAsUser('manager');
+    cy.mockActivityHistoryApiEmptyResponse(applicationId);
+    cy.mockHousingRegisterApiGetApplications(applicationId, application);
+  });
+
+  it('shows access denied page for user with read only permissions', () => {
+    cy.clearAllCookies();
+    cy.loginAsUser('readOnly');
+    AddCasePage.visit();
+    cy.contains('Access denied');
+  });
+
+  it('shows saving message while application is created', () => {
+    //mock object does not follow the real shape changes between actions.
+    // These are just for getting the UI to run for this particular test
+    cy.mockHousingRegisterApiPostApplication(application, 1000);
+    cy.mockHousingRegisterApiCompleteApplication(
+      applicationId,
+      application,
+      1000
+    );
+    cy.mockHousingRegisterApiPatchApplication(applicationId, application, 1000);
+
+    AddCasePage.visit();
+    fillInTheCaseForm();
+    AddCasePage.getSubmitButton().click();
+
+    cy.contains('Saving...');
+  });
+
+  it('shows an error when application creation fails', () => {
+    cy.mockHousingRegisterApiPostApplication(application, 0, errorCode);
+
+    AddCasePage.visit();
+    fillInTheCaseForm();
+    AddCasePage.getSubmitButton().click();
+
+    cy.contains(`Unable to create application (${errorCode})`);
+  });
+
+  it('shows an error when application completion fails', () => {
+    cy.mockHousingRegisterApiPostApplication(application, 0);
+    cy.mockHousingRegisterApiCompleteApplication(
+      applicationId,
+      application,
+      0,
+      errorCode
+    );
+
+    AddCasePage.visit();
+    fillInTheCaseForm();
+    AddCasePage.getSubmitButton().click();
+
+    cy.contains(`Unable to complete application (${errorCode})`);
+  });
+
+  it('shows an error when application update to manual draft status fails', () => {
+    cy.mockHousingRegisterApiPostApplication(application, 0);
+    cy.mockHousingRegisterApiCompleteApplication(applicationId, application, 0);
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      0,
+      errorCode
+    );
+
+    AddCasePage.visit();
+    fillInTheCaseForm();
+
+    AddCasePage.getSubmitButton().click();
+
+    cy.contains(`Unable to update application (${errorCode})`);
+  });
+});

--- a/cypress/pages/applications/add-case.ts
+++ b/cypress/pages/applications/add-case.ts
@@ -1,0 +1,66 @@
+class AddCasePage {
+  static getAddCasePage() {
+    const testId = 'test-add-case-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static visit() {
+    cy.visit('applications/add-case');
+  }
+
+  static getSubmitButton() {
+    return this.getAddCasePage().find('button[type=submit]');
+  }
+
+  static getTitleDropdown() {
+    return this.getAddCasePage().find('#personalDetails_title');
+  }
+
+  static getFirstNameInput() {
+    return this.getAddCasePage().find('#personalDetails_firstName');
+  }
+
+  static getLastNameInput() {
+    return this.getAddCasePage().find('#personalDetails_surname');
+  }
+
+  static getDoBDayInput() {
+    return this.getAddCasePage().find('#personalDetails_dateOfBirth-day');
+  }
+
+  static getDoBMonthInput() {
+    return this.getAddCasePage().find('#personalDetails_dateOfBirth-month');
+  }
+
+  static getDoBYearInput() {
+    return this.getAddCasePage().find('#personalDetails_dateOfBirth-year');
+  }
+
+  static getGenderDropdown() {
+    return this.getAddCasePage().find('#personalDetails_gender');
+  }
+
+  static getLivingSituationDropdown() {
+    return this.getAddCasePage().find('#currentAccommodation_livingSituation');
+  }
+
+  static getCitizenshipDropdown() {
+    return this.getAddCasePage().find('#immigrationStatus_citizenship');
+  }
+
+  static getAddAddressButton() {
+    const testId = 'test-add-case-address-button';
+    return this.getAddCasePage().find(`[data-testId="${testId}"]`);
+  }
+
+  static getAddressLine1Input() {
+    return cy.get('input[name="line1"]');
+  }
+
+  static getSaveAddressButton() {
+    const testId = 'test-save-case-address-button';
+    return cy.get(`[data-testId="${testId}"]`);
+  }
+}
+
+export default AddCasePage;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -136,6 +136,43 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add(
+  'mockHousingRegisterApiCompleteApplication',
+  (
+    applicationId: string,
+    body?: Application,
+    delay: number = 0,
+    statusCode: number = StatusCodes.OK
+  ) => {
+    cy.task('nock', {
+      hostname: Cypress.env('HOUSING_REGISTER_API'),
+      method: 'PATCH',
+      path: `/applications/${applicationId}/complete`,
+      statusCode,
+      body,
+      delay,
+    });
+  }
+);
+
+Cypress.Commands.add(
+  'mockHousingRegisterApiPostApplication',
+  (
+    body?: Application,
+    delay: number = 0,
+    statusCode: number = StatusCodes.OK
+  ) => {
+    cy.task('nock', {
+      hostname: Cypress.env('HOUSING_REGISTER_API'),
+      method: 'POST',
+      path: `/applications`,
+      statusCode,
+      body,
+      delay,
+    });
+  }
+);
+
+Cypress.Commands.add(
   'mockHousingRegisterApiPostSearchResults',
   (application: Application) => {
     cy.task('nock', {

--- a/lib/gateways/internal-api.ts
+++ b/lib/gateways/internal-api.ts
@@ -27,7 +27,12 @@ export const createApplication = async (application: Application) => {
     method: 'POST',
     body: JSON.stringify(application),
   });
-  return (await res.json()) as Application;
+
+  if (res.ok) {
+    return (await res.json()) as Application;
+  } else {
+    throw Error(`Unable to create application (${res.status})`);
+  }
 };
 
 export const completeApplication = async (application: Application) => {
@@ -35,7 +40,11 @@ export const completeApplication = async (application: Application) => {
     method: 'PATCH',
     body: JSON.stringify(application),
   });
-  return (await res.json()) as Application;
+  if (res.ok) {
+    return (await res.json()) as Application;
+  } else {
+    throw Error(`Unable to complete application (${res.status})`);
+  }
 };
 
 export const generateNovaletExport = async () => {

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -27,9 +27,19 @@ declare global {
         delay?: number,
         statusCode?: number
       ): Chainable<void>;
-      mount: typeof mount;
       mockHousingRegisterApiPatchApplication(
         applicationId: string,
+        body?: Application,
+        delay?: number,
+        statusCode?: number
+      ): Chainable<void>;
+      mockHousingRegisterApiCompleteApplication(
+        applicationId: string,
+        body?: Application,
+        delay?: number,
+        statusCode?: number
+      ): Chainable<void>;
+      mockHousingRegisterApiPostApplication(
         body?: Application,
         delay?: number,
         statusCode?: number
@@ -44,6 +54,8 @@ declare global {
         delay?: number,
         statusCode?: number
       ): Chainable<void>;
+
+      mount: typeof mount;
     }
   }
 }


### PR DESCRIPTION
## WHAT
Currently users are not notified of any backend errors on `/applications/add-case` page. This is the page where officers can create new cases directly from the app without resident having to create one of their own first. This update improves the error handling by showing an error message if any of the API calls made during the process fail. Saving message has also been added to indicate that the application creation process is in progress after form submission. The process includes the following steps in the backend:
1. Create the application
2. Complete the application
3. Update the application status to `MANUAL_DRAFT` 

## WHY
Users should get better feedback what's happening during the process. By adding error handling and saving status it's clear at all times what's happening in the backend.

## HOW
1. Update the affected end points to return error status code on API call failure
2. Update the `add-case` page to show those errors to the user
3. Add saving message to indicate that the  application creation process is currently running

## FUTURE