### PR TITLE
Fixes the missing value prop

### DIFF
--- a/components/form/input.tsx
+++ b/components/form/input.tsx
@@ -24,6 +24,12 @@ export default function Input({
   hideLabel,
   ...additionalInputProps
 }: InputProps): JSX.Element {
+  const { conditionalDisplay, ...otherValues } = additionalInputProps;
+  const additionalInputPropsWithConditionalDisplay = {
+    ...otherValues,
+    conditionaldisplay: conditionalDisplay,
+  };
+
   return (
     <div>
       <Field name={name}>
@@ -54,7 +60,7 @@ export default function Input({
             )}
             <input
               // Lowest priority to prevent accidental override of component defined props
-              {...additionalInputProps}
+              {...additionalInputPropsWithConditionalDisplay}
               className={`govuk-input lbh-input ${className ? className : ''} ${
                 meta.touched && meta.error ? 'govuk-input--error' : ''
               }`}
@@ -64,6 +70,7 @@ export default function Input({
               {...field}
               maxLength={500}
               data-testid={`test-input-${name}`}
+              value={field.value ?? ''}
             />
           </FormGroup>
         )}


### PR DESCRIPTION
https://hackney.atlassian.net/browse/TS-1736?atlOrigin=eyJpIjoiNGM2ZmMyNmU0Y2FhNDY3N2JkNTNlMjdhNDkwNzY4YjQiLCJwIjoiaiJ9

**What**
The input field was being passed a conditionalDisplay prop and throwing a warning. This PR cleans the prop to eliminate the warning. 

<img width="1493" alt="Screenshot 2024-10-23 at 09 16 56" src="https://github.com/user-attachments/assets/8d5d32c9-891e-45e4-95dc-9b10ba490c5f">
