### PR TITLE
TS-1720 improve error handling on apply/resident pages

### DIFF
--- a/components/application/ApplicantStep.tsx
+++ b/components/application/ApplicantStep.tsx
@@ -10,11 +10,13 @@ function ApplicantStep({
   formID,
   applicant,
   stepName,
+  dataTestId,
 }: {
   children: ReactNode;
   formID: FormID;
   stepName: string;
   applicant: Applicant;
+  dataTestId?: string;
 }): ReactElement {
   const formData = getFormData(formID);
   const breadcrumbs = [
@@ -33,7 +35,11 @@ function ApplicantStep({
   ];
 
   return (
-    <Layout pageName={stepName} breadcrumbs={breadcrumbs}>
+    <Layout
+      pageName={stepName}
+      breadcrumbs={breadcrumbs}
+      dataTestId={dataTestId}
+    >
       {formData.heading && <HeadingOne content={formData.heading} />}
       {formData.copy && (
         <Paragraph>

--- a/components/application/ApplicantSummary.tsx
+++ b/components/application/ApplicantSummary.tsx
@@ -6,6 +6,7 @@ interface ApplicantSummaryProps {
   mainApplicantCompleted: boolean;
   applicantNumber: number;
   tasks: { total: number; remaining: number };
+  applicantLinkTestId?: string;
 }
 
 export default function ApplicantSummary({
@@ -14,6 +15,7 @@ export default function ApplicantSummary({
   mainApplicantCompleted,
   applicantNumber,
   tasks,
+  applicantLinkTestId,
 }: ApplicantSummaryProps): JSX.Element {
   return (
     <>
@@ -28,7 +30,10 @@ export default function ApplicantSummary({
           </div>
           <span className="lbh-!-margin-top-0">
             <Link href={`/apply/${applicant.person?.id}`}>
-              <a className="lbh-applicant-summary__name lbh-link lbh-link--no-visited-state lbh-body-l lbh-!-font-weight-bold lbh-!-margin-top-0">
+              <a
+                data-testid={`test-application-applicant-summary-section-button-${applicantLinkTestId}`}
+                className="lbh-applicant-summary__name lbh-link lbh-link--no-visited-state lbh-body-l lbh-!-font-weight-bold lbh-!-margin-top-0"
+              >
                 {`${applicant.person?.firstName} ${applicant.person?.surname}`}
                 {tasks.remaining !== 0 ? (
                   <div className="lbh-applicant-summary__action">

--- a/components/delete-link.tsx
+++ b/components/delete-link.tsx
@@ -6,12 +6,16 @@ interface DeleteLinkProps {
   content: string;
   details?: string;
   onDelete: () => void;
+  mainButtonTestId?: string;
+  dialogConfirmButtonTestId?: string;
 }
 
 export default function DeleteLink({
   content,
   details,
   onDelete,
+  mainButtonTestId: mainButtonDataTestId,
+  dialogConfirmButtonTestId: dialogConfirmButtonDataTestId,
 }: DeleteLinkProps) {
   const [open, setOpen] = useState(false);
 
@@ -21,6 +25,7 @@ export default function DeleteLink({
         <button
           onClick={() => setOpen(true)}
           className="lbh-link lbh-link--no-visited-state lbh-delete-link"
+          data-testid={mainButtonDataTestId}
         >
           {content}
         </button>
@@ -31,6 +36,7 @@ export default function DeleteLink({
         title="Are you sure?"
         onConfirmation={onDelete}
         onCancel={() => setOpen(false)}
+        confirmationButtonTestId={dialogConfirmButtonDataTestId}
       >
         <Paragraph>{details}</Paragraph>
       </Dialog>

--- a/components/form/form.tsx
+++ b/components/form/form.tsx
@@ -13,6 +13,7 @@ import Button from '../button';
 import { HeadingTwo } from '../content/headings';
 import Paragraph from '../content/paragraph';
 import DynamicField from './dynamic-field';
+import Loading from 'components/loading';
 interface FormProps {
   buttonText?: string;
   formData: MultiStepForm;
@@ -20,6 +21,7 @@ interface FormProps {
   onSubmit?: (values: FormData, bag: FormikHelpers<FormData>) => void;
   initialValues?: FormikValues;
   activeStep?: string;
+  isSavingToDatabase?: boolean;
 }
 
 export default function Form({
@@ -28,6 +30,7 @@ export default function Form({
   onSave,
   onSubmit,
   initialValues,
+  isSavingToDatabase = false,
 }: FormProps): JSX.Element {
   const [stepNumber, setStepNumber] = useState(0);
 
@@ -94,38 +97,44 @@ export default function Form({
       >
         {({ isSubmitting, values }) => (
           <FormikForm>
-            {step.heading && <HeadingTwo content={step.heading} />}
-            {step.copy && <Paragraph>{step.copy}</Paragraph>}
-            {step.fields.map(
-              (field, index) =>
-                getDisplayStateOfField(field, values) && (
-                  <DynamicField key={index} field={field} />
-                )
-            )}
+            {isSavingToDatabase ? (
+              <Loading text="Saving..." />
+            ) : (
+              <>
+                {step.heading && <HeadingTwo content={step.heading} />}
+                {step.copy && <Paragraph>{step.copy}</Paragraph>}
+                {step.fields.map(
+                  (field, index) =>
+                    getDisplayStateOfField(field, values) && (
+                      <DynamicField key={index} field={field} />
+                    )
+                )}
 
-            <div className="c-flex lbh-simple-pagination">
-              {stepNumber > 0 && (
-                <div className="c-flex__1">
-                  <Button
-                    onClick={() => previous()}
-                    secondary={true}
-                    type="button"
-                  >
-                    Previous step
-                  </Button>
+                <div className="c-flex lbh-simple-pagination">
+                  {stepNumber > 0 && (
+                    <div className="c-flex__1">
+                      <Button
+                        onClick={() => previous()}
+                        secondary={true}
+                        type="button"
+                      >
+                        Previous step
+                      </Button>
+                    </div>
+                  )}
+
+                  <div className="c-flex__1 text-right">
+                    <Button
+                      disabled={isSubmitting}
+                      type="submit"
+                      dataTestId={`test-submit-form-button`}
+                    >
+                      {buttonText ? buttonText : 'Save'}
+                    </Button>
+                  </div>
                 </div>
-              )}
-
-              <div className="c-flex__1 text-right">
-                <Button
-                  disabled={isSubmitting}
-                  type="submit"
-                  dataTestId={`test-submit-form-button`}
-                >
-                  {buttonText ? buttonText : 'Save'}
-                </Button>
-              </div>
-            </div>
+              </>
+            )}
           </FormikForm>
         )}
       </Formik>

--- a/cypress/e2e/pages/agreeTerms.cy.ts
+++ b/cypress/e2e/pages/agreeTerms.cy.ts
@@ -3,7 +3,7 @@ import { generateApplication } from '../../../testUtils/applicationHelper';
 import { generatePerson } from '../../../testUtils/personHelper';
 import { faker } from '@faker-js/faker/locale/en_GB';
 import AgreeTermsPage from '../../pages/agreeTerms';
-import HouseholdPage from '../../pages/household';
+import ApplyHouseholdPage from '../../pages/household';
 import { StatusCodes } from 'http-status-codes';
 
 const applicationId = faker.string.uuid();
@@ -93,7 +93,7 @@ describe('Application', () => {
     cy.contains('Saving...');
 
     //check that user is now on the household member page
-    HouseholdPage.getHouseholdPage().should('be.visible');
+    ApplyHouseholdPage.getHouseholdPage().should('be.visible');
   });
 
   it('shows an error message when application update fails', () => {

--- a/cypress/e2e/pages/apply/[resident]/[section].cy.ts
+++ b/cypress/e2e/pages/apply/[resident]/[section].cy.ts
@@ -1,0 +1,85 @@
+import { faker } from '@faker-js/faker';
+import { generateApplication } from '../../../../../testUtils/applicationHelper';
+import ApplyHouseholdPage from '../../../../pages/household';
+import ApplyExpectPage from '../../../../pages/apply/expect';
+import ApplyOverviewPage from '../../../../pages/apply/overview';
+import ApplyResidentIndexPage from '../../../../pages/apply/[resident]';
+import { StatusCodes } from 'http-status-codes';
+import ApplyResidentSectionPage from '../../../../pages/apply/[resident]/[section]';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+const application = generateApplication(applicationId, personId, true, false);
+
+//mark previous section as complete, so we can access one of the [section] page
+const completedSections = [
+  {
+    answer: 'true',
+    id: 'personal-details/sectionCompleted',
+  },
+];
+
+const applicationWithCompletedMainApplicantSections = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    questions: completedSections,
+  },
+};
+
+describe('Apply resident [section] page', () => {
+  beforeEach(() => {
+    cy.loginAsResident(applicationId, true);
+    cy.task('clearNock');
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithCompletedMainApplicantSections,
+      true
+    );
+  });
+
+  //applies to various section pages that share the same page
+  it('shows saving message when user submits immigration status details', () => {
+    //Application object does not reflect the correct state after patch, but it doesn't matter for this test
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      3000,
+      StatusCodes.OK,
+      false
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getImmigrationStatusSectionLink().click();
+    ApplyResidentSectionPage.getImmigrationStatusRadioButton(0).check();
+    ApplyResidentSectionPage.getSubmitButton().click();
+
+    cy.contains('Saving...');
+  });
+
+  it('shows error message when section data submit fails', () => {
+    //Application object does not reflect the correct state after patch, but it doesn't matter for this test
+    const errorCode = StatusCodes.CONFLICT;
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      0,
+      errorCode,
+      false
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getImmigrationStatusSectionLink().click();
+    ApplyResidentSectionPage.getImmigrationStatusRadioButton(0).check();
+    ApplyResidentSectionPage.getSubmitButton().click();
+
+    cy.contains(`Unable to update application (${errorCode})`);
+  });
+});

--- a/cypress/e2e/pages/apply/[resident]/address-history.cy.ts
+++ b/cypress/e2e/pages/apply/[resident]/address-history.cy.ts
@@ -1,0 +1,83 @@
+import { faker } from '@faker-js/faker';
+import ApplyResidentAddressHistoryPage from '../../../../pages/apply/[resident]/address-history';
+import ApplyHouseholdPage from '../../../../pages/household';
+import ApplyExpectPage from '../../../../pages/apply/expect';
+import ApplyOverviewPage from '../../../../pages/apply/overview';
+import ApplyResidentIndexPage from '../../../../pages/apply/[resident]';
+import {
+  completedApplicationFormSections,
+  generateApplication,
+} from '../../../../../testUtils/applicationHelper';
+import { StatusCodes } from 'http-status-codes';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+const application = generateApplication(applicationId, personId, true, false);
+const postcode = 'A1 1AB';
+
+//mark all sections as complete, so we can access them without filling them all in
+const applicationWithCompletedMainApplicantSections = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    questions: completedApplicationFormSections,
+  },
+};
+
+describe('Apply resident address history page', () => {
+  beforeEach(() => {
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithCompletedMainApplicantSections,
+      true
+    );
+    cy.mockAddressAPISearchByPostcode(postcode);
+  });
+
+  it('shows saving message when user submits the address history form', () => {
+    cy.mockHousingRegisterApiPatchApplication(applicationId, application, 1000);
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getAddressHistorySectionLink().click();
+
+    ApplyResidentAddressHistoryPage.getPostcodeInputField().type(postcode);
+    ApplyResidentAddressHistoryPage.getFindAddressButton().click();
+    ApplyResidentAddressHistoryPage.getMovingDateMonth().type('1');
+    ApplyResidentAddressHistoryPage.getMovingDateYear().type('2000');
+    ApplyResidentAddressHistoryPage.getGetSaveAndContinueButton().click();
+    //same button used to submit the details
+    ApplyResidentAddressHistoryPage.getGetSaveAndContinueButton().click();
+    cy.contains('Saving...');
+    //ensure we are back on the index page
+    ApplyResidentIndexPage.getApplyResidentIndexPage().should('be.visible');
+  });
+
+  it('shows error message when application update fails', () => {
+    const errorCode = StatusCodes.CONFLICT;
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      0,
+      errorCode
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getAddressHistorySectionLink().click();
+
+    ApplyResidentAddressHistoryPage.getPostcodeInputField().type(postcode);
+    ApplyResidentAddressHistoryPage.getFindAddressButton().click();
+    ApplyResidentAddressHistoryPage.getMovingDateMonth().type('1');
+    ApplyResidentAddressHistoryPage.getMovingDateYear().type('2000');
+    ApplyResidentAddressHistoryPage.getGetSaveAndContinueButton().click();
+    //same button used to submit the details
+    ApplyResidentAddressHistoryPage.getGetSaveAndContinueButton().click();
+    cy.contains('Unable to update application (409)');
+  });
+});

--- a/cypress/e2e/pages/apply/[resident]/current-accommodation.cy.ts
+++ b/cypress/e2e/pages/apply/[resident]/current-accommodation.cy.ts
@@ -1,0 +1,78 @@
+import { faker } from '@faker-js/faker';
+import { generateApplication } from '../../../../../testUtils/applicationHelper';
+import ApplyHouseholdPage from '../../../../pages/household';
+import ApplyExpectPage from '../../../../pages/apply/expect';
+import ApplyOverviewPage from '../../../../pages/apply/overview';
+import ApplyResidentIndexPage from '../../../../pages/apply/[resident]';
+import { StatusCodes } from 'http-status-codes';
+import ApplyResidentCurrentAccommodationPage from '../../../../pages/apply/[resident]/current-accommodation';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+const application = generateApplication(applicationId, personId, true, false);
+
+//mark previous sections as complete, so we can access the accommodation section
+const completedSections = [
+  {
+    answer: 'true',
+    id: 'personal-details/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'immigration-status/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'medical-needs/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'residential-status/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'address-history/sectionCompleted',
+  },
+];
+
+const applicationWithCompletedMainApplicantSections = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    questions: completedSections,
+  },
+};
+
+describe('Apply resident current accommodation page', () => {
+  beforeEach(() => {
+    cy.loginAsResident(applicationId, true);
+    cy.task('clearNock');
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithCompletedMainApplicantSections,
+      true
+    );
+  });
+
+  it('shows saving message when user submits accommodation details', () => {
+    //Application object does not reflect the correct state after patch, but it doesn't matter for this test
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      1000,
+      StatusCodes.OK,
+      false
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getCurrentAccommodationSectionLink().click();
+    ApplyResidentCurrentAccommodationPage.getRadioButton().check(
+      'private-rental'
+    );
+    ApplyResidentCurrentAccommodationPage.getSaveAndContinueButton().click();
+    cy.contains('Saving...');
+  });
+});

--- a/cypress/e2e/pages/apply/[resident]/current-accommodation.cy.ts
+++ b/cypress/e2e/pages/apply/[resident]/current-accommodation.cy.ts
@@ -54,14 +54,14 @@ describe('Apply resident current accommodation page', () => {
     );
   });
 
-  it('shows saving message when user submits accommodation details', () => {
+  it('shows saving message when user submits accommodation details section', () => {
     //Application object does not reflect the correct state after patch, but it doesn't matter for this test
     cy.mockHousingRegisterApiPatchApplication(
       applicationId,
       application,
       1000,
       StatusCodes.OK,
-      false
+      true
     );
 
     ApplyHouseholdPage.visit();
@@ -71,6 +71,48 @@ describe('Apply resident current accommodation page', () => {
     ApplyResidentIndexPage.getCurrentAccommodationSectionLink().click();
     ApplyResidentCurrentAccommodationPage.getRadioButton().check(
       'private-rental'
+    );
+    ApplyResidentCurrentAccommodationPage.getSaveAndContinueButton().click();
+    cy.contains('Saving...');
+  });
+
+  //different flow for last section, so need to be covered separately
+  it('shows saving message when user submits the last accommodation details section', () => {
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      1000,
+      StatusCodes.OK,
+      true
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getCurrentAccommodationSectionLink().click();
+    ApplyResidentCurrentAccommodationPage.getRadioButton().check(
+      'private-rental'
+    );
+
+    ApplyResidentCurrentAccommodationPage.getSaveAndContinueButton().click();
+    ApplyResidentCurrentAccommodationPage.getDescribeHomeRadioButton(0).check();
+    ApplyResidentCurrentAccommodationPage.getSaveAndContinueButton().click();
+    ApplyResidentCurrentAccommodationPage.getFloorInput().type('1');
+    ApplyResidentCurrentAccommodationPage.getShareInput().type('3');
+    ApplyResidentCurrentAccommodationPage.getBedroomsInput().type('1');
+    ApplyResidentCurrentAccommodationPage.getLivingRoomsInput().type('1');
+    ApplyResidentCurrentAccommodationPage.getDiningRoomsInput().type('0');
+    ApplyResidentCurrentAccommodationPage.getBathRoomsInput().type('1');
+    ApplyResidentCurrentAccommodationPage.getKitchensInput().type('1');
+    ApplyResidentCurrentAccommodationPage.getOtherRoomsInput().type('none');
+    ApplyResidentCurrentAccommodationPage.getSaveAndContinueButton().click();
+    ApplyResidentCurrentAccommodationPage.getUnsuitableHomeReasonInput().type(
+      faker.lorem.paragraph()
+    );
+    ApplyResidentCurrentAccommodationPage.getSaveAndContinueButton().click();
+    ApplyResidentCurrentAccommodationPage.getLandlordNameInput().type(
+      faker.person.fullName()
     );
     ApplyResidentCurrentAccommodationPage.getSaveAndContinueButton().click();
     cy.contains('Saving...');

--- a/cypress/e2e/pages/apply/[resident]/index.cy.ts
+++ b/cypress/e2e/pages/apply/[resident]/index.cy.ts
@@ -1,0 +1,99 @@
+/* eslint-disable */
+
+import { faker } from '@faker-js/faker';
+import HouseholdPage from '../../../../pages/household';
+import {
+  completedApplicationFormSections,
+  generateApplication,
+} from '../../../../../testUtils/applicationHelper';
+import { Application } from '../../../../../domain/HousingApi';
+
+const personId = faker.string.uuid();
+const applicationId = faker.string.uuid();
+const application = generateApplication(applicationId, personId, true, true);
+
+//mark main applicant sections complete, so household member can be accessed
+const applicationWithCompletedMainApplicantSections = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    questions: completedApplicationFormSections,
+  },
+};
+
+//mock the object with household member removed
+const applicationWithHouseholdMemberRemoved: Application = {
+  ...applicationWithCompletedMainApplicantSections,
+  otherMembers: [],
+};
+
+describe('Apply resident index page', () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.loginAsResident(applicationId, true);
+    cy.task('clearNock');
+  });
+
+  it('shows a saving message while application is being updated', () => {
+    //start from household overview page which loads the application from the database
+    // this way we get the correct store state without having to mock it (which we don't have a setup yet)
+
+    //cover the initial page load GET calls
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithCompletedMainApplicantSections,
+      false
+    );
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithCompletedMainApplicantSections,
+      false
+    );
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithCompletedMainApplicantSections,
+      false
+    );
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithCompletedMainApplicantSections,
+      false
+    );
+
+    //mock the patch after deletion
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithHouseholdMemberRemoved,
+      5000
+    );
+
+    //mock the GET after removing household member
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithHouseholdMemberRemoved,
+      false
+    );
+
+    HouseholdPage.visit();
+    //HouseholdPage.getContinueToNextStepLink().click();
+    cy.get('.lbh-button')
+      .contains('Continue to next step')
+      .scrollIntoView()
+      .click();
+    cy.get('.lbh-button')
+      .contains('Save and continue')
+      .scrollIntoView()
+      .click();
+
+    const householdMemberName = `${application.otherMembers[0].person.firstName} ${application.otherMembers[0].person.surname}`;
+    cy.get('.lbh-applicant-summary__name')
+      .contains(householdMemberName)
+      .click();
+    cy.get('button').contains('Delete this information').click();
+    cy.get('button').contains('Yes').click();
+
+    cy.contains('Saving...');
+  });
+});

--- a/cypress/e2e/pages/apply/[resident]/personal-details.cy.ts
+++ b/cypress/e2e/pages/apply/[resident]/personal-details.cy.ts
@@ -1,0 +1,66 @@
+import { faker } from '@faker-js/faker';
+import ApplyHouseholdPage from '../../../../pages/household';
+import { generateApplication } from '../../../../../testUtils/applicationHelper';
+import ApplyResidentIndexPage from '../../../../pages/apply/[resident]';
+import ApplyExpectPage from '../../../../pages/apply/expect';
+import ApplyOverviewPage from '../../../../pages/apply/overview';
+import ApplyResidentPersonalDetailsPage from '../../../../pages/apply/[resident]/personal-details';
+import { StatusCodes } from 'http-status-codes';
+
+const personId = faker.string.uuid();
+const applicationId = faker.string.uuid();
+const application = generateApplication(applicationId, personId, true, true);
+const phoneNumber = faker.phone.number();
+
+describe('Apply resident section page', () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.loginAsResident(applicationId, true);
+    cy.task('clearNock');
+  });
+
+  it('shows saving message when user submits the section', () => {
+    cy.mockHousingRegisterApiGetApplications(applicationId, application, true);
+    cy.mockHousingRegisterApiPatchApplication(applicationId, application, 1000);
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getPersonalDetailsSectionLink().click();
+    ApplyResidentPersonalDetailsPage.getApplyResidentSectionPage().should(
+      'be.visible'
+    );
+    cy.contains('Personal details');
+
+    ApplyResidentPersonalDetailsPage.getPhoneNumberInput().type(phoneNumber);
+    ApplyResidentPersonalDetailsPage.getSubmitButton().scrollIntoView().click();
+    cy.contains('Saving...');
+  });
+
+  it('shows an error messages when the section save fails', () => {
+    const errorCode = StatusCodes.CONFLICT;
+    cy.mockHousingRegisterApiGetApplications(applicationId, application, true);
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      0,
+      errorCode
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getPersonalDetailsSectionLink().click();
+    ApplyResidentPersonalDetailsPage.getApplyResidentSectionPage().should(
+      'be.visible'
+    );
+    cy.contains('Personal details');
+
+    ApplyResidentPersonalDetailsPage.getPhoneNumberInput().type(phoneNumber);
+    ApplyResidentPersonalDetailsPage.getSubmitButton().scrollIntoView().click();
+    ApplyResidentPersonalDetailsPage.getErrorSummary().should('be.visible');
+    cy.contains(`Unable to update application (${errorCode})`);
+  });
+});

--- a/cypress/e2e/pages/apply/[resident]/summary.cy.ts
+++ b/cypress/e2e/pages/apply/[resident]/summary.cy.ts
@@ -1,0 +1,195 @@
+import { faker } from '@faker-js/faker';
+import {
+  completedApplicationFormSections,
+  generateApplication,
+} from '../../../../../testUtils/applicationHelper';
+import ApplyHouseholdPage from '../../../../pages/household';
+import ApplyExpectPage from '../../../../pages/apply/expect';
+import ApplyOverviewPage from '../../../../pages/apply/overview';
+import ApplyResidentIndexPage from '../../../../pages/apply/[resident]';
+import { StatusCodes } from 'http-status-codes';
+import ApplyResidentSummaryPage from '../../../../pages/apply/[resident]/summary';
+import { Application, Person } from '../../../../../domain/HousingApi';
+import { generatePerson } from '../../../../../testUtils/personHelper';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+const application = generateApplication(applicationId, personId, true, false);
+const birthDateUnder18 = faker.date.birthdate({ mode: 'age', min: 1, max: 17 });
+const birthDateOver55 = faker.date.birthdate({
+  mode: 'age',
+  min: 56,
+  max: 100,
+});
+
+const ineligibleApplicationWithCompletedMainApplicantSections: Application = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    person: {
+      ...application.mainApplicant.person,
+      dateOfBirth: birthDateUnder18,
+    },
+    questions: completedApplicationFormSections,
+  },
+};
+
+const eligibleApplicationWithCompletedMainApplicantSections: Application = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    person: {
+      ...application.mainApplicant.person,
+      dateOfBirth: birthDateOver55,
+    },
+    questions: completedApplicationFormSections,
+  },
+};
+
+describe('Apply resident summary page', () => {
+  beforeEach(() => {
+    cy.loginAsResident(applicationId, true);
+    cy.task('clearNock');
+    cy.mockNotifyEmailResponse();
+  });
+
+  it('shows saving message when user confirms the resident details and is not eligible to apply', () => {
+    //Application object does not reflect the correct state after patch, but it doesn't matter for this test
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      ineligibleApplicationWithCompletedMainApplicantSections,
+      1000,
+      StatusCodes.OK,
+      false
+    );
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      ineligibleApplicationWithCompletedMainApplicantSections,
+      true
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentSummaryPage.getConfirmDetailsButton().click();
+
+    cy.contains('Saving...');
+  });
+
+  it('shows an error message when application save fails and user is not eligible to apply', () => {
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      ineligibleApplicationWithCompletedMainApplicantSections,
+      0,
+      StatusCodes.CONFLICT,
+      false
+    );
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      ineligibleApplicationWithCompletedMainApplicantSections,
+      true
+    );
+
+    cy.mockNotifyEmailResponse();
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentSummaryPage.getConfirmDetailsButton().click();
+
+    cy.contains('Unable to update application');
+  });
+
+  it('redirects eligible user to person overview page after they confirm their details', () => {
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      eligibleApplicationWithCompletedMainApplicantSections,
+      0,
+      StatusCodes.OK,
+      false
+    );
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      eligibleApplicationWithCompletedMainApplicantSections,
+      true
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getCheckAnswersButton().click();
+    ApplyResidentSummaryPage.getConfirmDetailsButton().click();
+    ApplyOverviewPage.getApplyOverviewPage().should('be.visible');
+  });
+
+  it('shows saving message when user deletes a household member from the application', () => {
+    //complete household member sections, so summary page is available
+    const householdMember: Person = generatePerson(personId + 1);
+
+    const eligibleApplicationWithHouseholdMemberCompleted: Application = {
+      ...eligibleApplicationWithCompletedMainApplicantSections,
+      otherMembers: [
+        {
+          person: householdMember,
+          contactInformation: {
+            emailAddress: faker.internet.email({
+              provider: 'hackneyTEST.gov.uk',
+            }),
+          },
+          questions: [
+            {
+              answer: 'true',
+              id: 'personal-details/sectionCompleted',
+            },
+            {
+              answer: 'true',
+              id: 'immigration-status/sectionCompleted',
+            },
+            {
+              answer: 'true',
+              id: 'medical-needs/sectionCompleted',
+            },
+            {
+              answer: 'true',
+              id: 'address-history/sectionCompleted',
+            },
+            {
+              answer: 'true',
+              id: 'employment/sectionCompleted',
+            },
+          ],
+        },
+      ],
+    };
+
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      eligibleApplicationWithHouseholdMemberCompleted,
+      1000,
+      StatusCodes.OK,
+      false
+    );
+
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      eligibleApplicationWithHouseholdMemberCompleted,
+      true
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(householdMember.id).click();
+    ApplyResidentIndexPage.getCheckAnswersButton().click();
+    ApplyResidentSummaryPage.getDeleteThisInformationButton().click();
+    ApplyResidentSummaryPage.getYesDeleteInformationButton().click();
+
+    cy.contains('Saving...');
+  });
+});

--- a/cypress/e2e/pages/apply/[resident]/your-situation.cy.ts
+++ b/cypress/e2e/pages/apply/[resident]/your-situation.cy.ts
@@ -1,0 +1,124 @@
+import { faker } from '@faker-js/faker';
+import { StatusCodes } from 'http-status-codes';
+import { generateApplication } from '../../../../../testUtils/applicationHelper';
+import ApplyHouseholdPage from '../../../../pages/household';
+import ApplyExpectPage from '../../../../pages/apply/expect';
+import ApplyOverviewPage from '../../../../pages/apply/overview';
+import ApplyResidentIndexPage from '../../../../pages/apply/[resident]';
+import ApplyResidentYourSituationPage from '../../../../pages/apply/[resident]/your-situation';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+const application = generateApplication(applicationId, personId, true, false);
+
+//mark previous sections as complete, so we can access the your situation section
+const completedSections = [
+  {
+    answer: 'true',
+    id: 'personal-details/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'immigration-status/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'medical-needs/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'residential-status/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'address-history/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'current-accommodation/sectionCompleted',
+  },
+];
+
+const applicationWithCompletedMainApplicantSections = {
+  ...application,
+  mainApplicant: {
+    ...application.mainApplicant,
+    questions: completedSections,
+  },
+};
+
+describe('Apply resident your situation page', () => {
+  beforeEach(() => {
+    cy.loginAsResident(applicationId, true);
+    cy.task('clearNock');
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithCompletedMainApplicantSections,
+      true
+    );
+  });
+
+  it('shows saving message when user submits your situation details form', () => {
+    //Application object does not reflect the correct state after patch, but it doesn't matter for this test
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      1000,
+      StatusCodes.OK,
+      true
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getYourSituationSectionLink().click();
+    ApplyResidentYourSituationPage.getServedInArmedForcesRadioButton().check();
+    ApplyResidentYourSituationPage.getSubmitButton().click();
+    cy.contains('Saving...');
+  });
+
+  it('shows saving message when user submits the last section form', () => {
+    //Application object does not reflect the correct state after patch, but it doesn't matter for this test
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      application,
+      1000,
+      StatusCodes.OK,
+      true
+    );
+
+    ApplyHouseholdPage.visit();
+    ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
+    ApplyExpectPage.getContinueToNextStepButton().click();
+    ApplyOverviewPage.getApplicantButton(personId).click();
+    ApplyResidentIndexPage.getYourSituationSectionLink().click();
+
+    ApplyResidentYourSituationPage.getServedInArmedForcesRadioButton().check();
+    ApplyResidentYourSituationPage.getSubmitButton().click();
+    ApplyResidentYourSituationPage.getIntentionallyHomelessRadioButton(
+      1
+    ).check();
+    ApplyResidentYourSituationPage.getSubmitButton().click();
+    ApplyResidentYourSituationPage.getOwnPropertyRadioButton(1).check();
+    ApplyResidentYourSituationPage.getSubmitButton().click();
+    ApplyResidentYourSituationPage.getSoldPropertyRadioButton(1).check();
+    ApplyResidentYourSituationPage.getSubmitButton().click();
+    ApplyResidentYourSituationPage.getRentArrearsRadioButton(1).check();
+    ApplyResidentYourSituationPage.getSubmitButton().click();
+    ApplyResidentYourSituationPage.getBreachOfTenancyRadioButton(1).check();
+    ApplyResidentYourSituationPage.getSubmitButton().click();
+    ApplyResidentYourSituationPage.getSubmitButton().click();
+    ApplyResidentYourSituationPage.getLegalRestrictionsRadioButton(1).check();
+    ApplyResidentYourSituationPage.getSubmitButton().click();
+    ApplyResidentYourSituationPage.getUnspentConvictionsRadioButton(1).check();
+    //last form page, triggers exit flow
+    ApplyResidentYourSituationPage.getSubmitButton().click();
+    cy.contains('Saving...');
+  });
+
+  it('shows page not found when accessed directly', () => {
+    ApplyResidentYourSituationPage.visit(personId);
+    cy.contains('404 Page not found');
+  });
+});

--- a/cypress/pages/apply/[resident]/[section].ts
+++ b/cypress/pages/apply/[resident]/[section].ts
@@ -1,0 +1,14 @@
+//shared with all single step form sections
+class ApplyResidentSectionPage {
+  static getSubmitButton() {
+    const testId = 'test-submit-form-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getImmigrationStatusRadioButton(index: number) {
+    const testId = `test-radio-citizenship.${index}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+}
+
+export default ApplyResidentSectionPage;

--- a/cypress/pages/apply/[resident]/address-history.ts
+++ b/cypress/pages/apply/[resident]/address-history.ts
@@ -1,0 +1,26 @@
+class ApplyResidentAddressHistoryPage {
+  static getPostcodeInputField() {
+    return cy.get('#postcode');
+  }
+
+  static getFindAddressButton() {
+    const testId = 'test-apply-resident-address-history-find-address-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getGetSaveAndContinueButton() {
+    const testId =
+      'test-apply-resident-address-history-save-and-continue-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getMovingDateMonth() {
+    return cy.get('#date-month');
+  }
+
+  static getMovingDateYear() {
+    return cy.get('#date-year');
+  }
+}
+
+export default ApplyResidentAddressHistoryPage;

--- a/cypress/pages/apply/[resident]/current-accommodation.ts
+++ b/cypress/pages/apply/[resident]/current-accommodation.ts
@@ -1,0 +1,52 @@
+class ApplyResidentCurrentAccommodationPage {
+  static getRadioButton() {
+    return cy.get('[type="radio"]');
+  }
+
+  static getSaveAndContinueButton() {
+    const testId = 'test-submit-form-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getFloorInput() {
+    return cy.get('#home-floor');
+  }
+
+  static getShareInput() {
+    return cy.get('#home-how-many-people-share');
+  }
+
+  static getBedroomsInput() {
+    return cy.get('#home-how-many-bedrooms');
+  }
+
+  static getLivingRoomsInput() {
+    return cy.get('#home-how-many-livingrooms');
+  }
+
+  static getDiningRoomsInput() {
+    return cy.get('#home-how-many-diningrooms');
+  }
+
+  static getBathRoomsInput() {
+    return cy.get('#home-how-many-bathrooms');
+  }
+
+  static getKitchensInput() {
+    return cy.get('#home-how-many-kitchens');
+  }
+
+  static getOtherRoomsInput() {
+    return cy.get('#home-how-many-other-rooms');
+  }
+
+  static getUnsuitableHomeReasonInput() {
+    return cy.get('#why-home-unsuitable');
+  }
+
+  static getLandlordNameInput() {
+    return cy.get('#landlord-name');
+  }
+}
+
+export default ApplyResidentCurrentAccommodationPage;

--- a/cypress/pages/apply/[resident]/current-accommodation.ts
+++ b/cypress/pages/apply/[resident]/current-accommodation.ts
@@ -8,6 +8,11 @@ class ApplyResidentCurrentAccommodationPage {
     return cy.get(`[data-testid="${testId}"]`);
   }
 
+  static getDescribeHomeRadioButton(index: number) {
+    const testId = `test-radio-home.${index}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
   static getFloorInput() {
     return cy.get('#home-floor');
   }

--- a/cypress/pages/apply/[resident]/index.ts
+++ b/cypress/pages/apply/[resident]/index.ts
@@ -31,6 +31,10 @@ class ApplyResidentIndexPage {
     return cy.get('.lbh-link').contains('Current accommodation');
   }
 
+  static getImmigrationStatusSectionLink() {
+    return cy.get('.lbh-link').contains('Immigration status');
+  }
+
   static getYourSituationSectionLink() {
     return cy.get('.lbh-link').contains('Your situation');
   }

--- a/cypress/pages/apply/[resident]/index.ts
+++ b/cypress/pages/apply/[resident]/index.ts
@@ -3,6 +3,11 @@ class ApplyResidentIndexPage {
     cy.visit(`/apply/${personId}`);
   }
 
+  static getApplyResidentIndexPage() {
+    const testId = 'test-apply-resident-index-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
   static getDeleteThisInformationButton() {
     const testId = 'test-apply-resident-index-delete-this-information-button';
     return cy.get(`[data-testid="${testId}"]`);
@@ -16,6 +21,10 @@ class ApplyResidentIndexPage {
 
   static getPersonalDetailsSectionLink() {
     return cy.get('.lbh-link').contains('Personal details');
+  }
+
+  static getAddressHistorySectionLink() {
+    return cy.get('.lbh-link').contains('Address history');
   }
 }
 

--- a/cypress/pages/apply/[resident]/index.ts
+++ b/cypress/pages/apply/[resident]/index.ts
@@ -30,6 +30,11 @@ class ApplyResidentIndexPage {
   static getCurrentAccommodationSectionLink() {
     return cy.get('.lbh-link').contains('Current accommodation');
   }
+
+  static getCheckAnswersButton() {
+    const testId = 'test-apply-resident-index-check-answers-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
 }
 
 export default ApplyResidentIndexPage;

--- a/cypress/pages/apply/[resident]/index.ts
+++ b/cypress/pages/apply/[resident]/index.ts
@@ -26,6 +26,10 @@ class ApplyResidentIndexPage {
   static getAddressHistorySectionLink() {
     return cy.get('.lbh-link').contains('Address history');
   }
+
+  static getCurrentAccommodationSectionLink() {
+    return cy.get('.lbh-link').contains('Current accommodation');
+  }
 }
 
 export default ApplyResidentIndexPage;

--- a/cypress/pages/apply/[resident]/index.ts
+++ b/cypress/pages/apply/[resident]/index.ts
@@ -2,6 +2,17 @@ class ApplyResidentIndexPage {
   static visit(personId: string) {
     cy.visit(`/apply/${personId}`);
   }
+
+  static getDeleteThisInformationButton() {
+    const testId = 'test-apply-resident-index-delete-this-information-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getYesDeleteButton() {
+    const testId =
+      'test-apply-resident-index-delete-this-information-confirm-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
 }
 
 export default ApplyResidentIndexPage;

--- a/cypress/pages/apply/[resident]/index.ts
+++ b/cypress/pages/apply/[resident]/index.ts
@@ -1,0 +1,7 @@
+class ApplyResidentIndexPage {
+  static visit(personId: string) {
+    cy.visit(`/apply/${personId}`);
+  }
+}
+
+export default ApplyResidentIndexPage;

--- a/cypress/pages/apply/[resident]/index.ts
+++ b/cypress/pages/apply/[resident]/index.ts
@@ -31,6 +31,10 @@ class ApplyResidentIndexPage {
     return cy.get('.lbh-link').contains('Current accommodation');
   }
 
+  static getYourSituationSectionLink() {
+    return cy.get('.lbh-link').contains('Your situation');
+  }
+
   static getCheckAnswersButton() {
     const testId = 'test-apply-resident-index-check-answers-button';
     return cy.get(`[data-testid="${testId}"]`);

--- a/cypress/pages/apply/[resident]/index.ts
+++ b/cypress/pages/apply/[resident]/index.ts
@@ -13,6 +13,10 @@ class ApplyResidentIndexPage {
       'test-apply-resident-index-delete-this-information-confirm-button';
     return cy.get(`[data-testid="${testId}"]`);
   }
+
+  static getPersonalDetailsSectionLink() {
+    return cy.get('.lbh-link').contains('Personal details');
+  }
 }
 
 export default ApplyResidentIndexPage;

--- a/cypress/pages/apply/[resident]/personal-details.ts
+++ b/cypress/pages/apply/[resident]/personal-details.ts
@@ -1,0 +1,21 @@
+class ApplyResidentPersonalDetailsPage {
+  static getApplyResidentSectionPage() {
+    const testId = `test-apply-resident-personal-details-step`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getSubmitButton() {
+    return cy.get('button[type="submit"]');
+  }
+
+  static getPhoneNumberInput() {
+    return cy.get('#phoneNumber');
+  }
+
+  static getErrorSummary() {
+    const testId = 'test-apply-resident-personal-details-step-error-summary';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+}
+
+export default ApplyResidentPersonalDetailsPage;

--- a/cypress/pages/apply/[resident]/summary.ts
+++ b/cypress/pages/apply/[resident]/summary.ts
@@ -1,6 +1,26 @@
 class ApplyResidentSummaryPage {
+  static visit(personId: string) {
+    cy.visit(`/apply/$${personId}/summary`);
+  }
+
   static getApplyResidentSummaryPage() {
     const testId = 'test-apply-resident-summary-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getConfirmDetailsButton() {
+    const testId = 'test-apply-resident-summary-confirm-details-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getDeleteThisInformationButton() {
+    const testId = 'test-apply-resident-summary-delete-this-information-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getYesDeleteInformationButton() {
+    const testId =
+      'test-apply-resident-summary-yes-delete-this-information-button';
     return cy.get(`[data-testid="${testId}"]`);
   }
 }

--- a/cypress/pages/apply/[resident]/summary.ts
+++ b/cypress/pages/apply/[resident]/summary.ts
@@ -1,0 +1,8 @@
+class ApplyResidentSummaryPage {
+  static getApplyResidentSummaryPage() {
+    const testId = 'test-apply-resident-summary-page';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+}
+
+export default ApplyResidentSummaryPage;

--- a/cypress/pages/apply/[resident]/your-situation.ts
+++ b/cypress/pages/apply/[resident]/your-situation.ts
@@ -1,0 +1,52 @@
+class ApplyResidentYourSituationPage {
+  static visit(personId: string) {
+    cy.visit(`/apply/${personId}/your-situation`);
+  }
+
+  static getServedInArmedForcesRadioButton() {
+    const testId = 'test-radio-situation-armed-forces.1';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getIntentionallyHomelessRadioButton(index: number) {
+    const testId = `test-radio-homelessness.${index}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getOwnPropertyRadioButton(index: number) {
+    const testId = `test-radio-property-ownership.${index}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getSoldPropertyRadioButton(index: number) {
+    const testId = `test-radio-sold-property.${index}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getRentArrearsRadioButton(index: number) {
+    const testId = `test-radio-arrears.${index}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getBreachOfTenancyRadioButton(index: number) {
+    const testId = `test-radio-breach-of-tenancy.${index}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getLegalRestrictionsRadioButton(index: number) {
+    const testId = `test-radio-legal-restrictions.${index}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getUnspentConvictionsRadioButton(index: number) {
+    const testId = `test-radio-unspent-convictions.${index}`;
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+
+  static getSubmitButton() {
+    const testId = 'test-submit-form-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+}
+
+export default ApplyResidentYourSituationPage;

--- a/cypress/pages/apply/expect.ts
+++ b/cypress/pages/apply/expect.ts
@@ -1,0 +1,8 @@
+class ApplyExpectPage {
+  static getContinueToNextStepButton() {
+    const testId = 'test-apply-expect-save-and-continue-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
+}
+
+export default ApplyExpectPage;

--- a/cypress/pages/apply/overview.ts
+++ b/cypress/pages/apply/overview.ts
@@ -1,5 +1,5 @@
 class ApplyOverviewPage {
-  static getHouseHoldMemberButton(personId: string) {
+  static getApplicantButton(personId: string) {
     return cy.get(
       `[data-testid="test-application-applicant-summary-section-button-${personId}"]`
     );

--- a/cypress/pages/apply/overview.ts
+++ b/cypress/pages/apply/overview.ts
@@ -1,4 +1,8 @@
 class ApplyOverviewPage {
+  static getApplyOverviewPage() {
+    return cy.get(`[data-testid="test-apply-resident-overview-page"]`);
+  }
+
   static getApplicantButton(personId: string) {
     return cy.get(
       `[data-testid="test-application-applicant-summary-section-button-${personId}"]`

--- a/cypress/pages/apply/overview.ts
+++ b/cypress/pages/apply/overview.ts
@@ -1,0 +1,9 @@
+class ApplyOverviewPage {
+  static getHouseHoldMemberButton(personId: string) {
+    return cy.get(
+      `[data-testid="test-application-applicant-summary-section-button-${personId}"]`
+    );
+  }
+}
+
+export default ApplyOverviewPage;

--- a/cypress/pages/household.ts
+++ b/cypress/pages/household.ts
@@ -2,10 +2,15 @@ class HouseholdPage {
   static visit() {
     cy.visit(`/apply/household`);
   }
+
   static getHouseholdPage() {
     const testId = 'test-apply-household-page';
     return cy.get(`[data-testid="${testId}"]`);
   }
+
+  // static getContinueToNextStepLink() {
+  //   return cy.get('lbh-button').contains('Continue to next step');
+  // }
 }
 
 export default HouseholdPage;

--- a/cypress/pages/household.ts
+++ b/cypress/pages/household.ts
@@ -1,4 +1,4 @@
-class HouseholdPage {
+class ApplyHouseholdPage {
   static visit() {
     cy.visit(`/apply/household`);
   }
@@ -8,9 +8,10 @@ class HouseholdPage {
     return cy.get(`[data-testid="${testId}"]`);
   }
 
-  // static getContinueToNextStepLink() {
-  //   return cy.get('lbh-button').contains('Continue to next step');
-  // }
+  static getContinueToNextStepLink() {
+    const testId = 'test-apply-household-index-continue-to-next-step-button';
+    return cy.get(`[data-testid="${testId}"]`);
+  }
 }
 
-export default HouseholdPage;
+export default ApplyHouseholdPage;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -122,7 +122,8 @@ Cypress.Commands.add(
     applicationId: string,
     body?: Application,
     delay: number = 0,
-    statusCode: number = StatusCodes.OK
+    statusCode: number = StatusCodes.OK,
+    persist?: boolean
   ) => {
     cy.task('nock', {
       hostname: Cypress.env('HOUSING_REGISTER_API'),
@@ -130,6 +131,7 @@ Cypress.Commands.add(
       path: `/applications/${applicationId}`,
       statusCode,
       body,
+      persist,
       delay,
     });
   }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -326,3 +326,28 @@ Cypress.Commands.add(
     });
   }
 );
+
+Cypress.Commands.add('mockAddressAPISearchByPostcode', (postcode: string) => {
+  cy.task('nock', {
+    hostname: Cypress.env('LOOKUP_API_URL'),
+    method: 'GET',
+    path: `/?postcode=${postcode}`,
+    body: {
+      data: {
+        address: [
+          {
+            line1: 'Address Line 1',
+            line2: 'Address Line 2',
+            line3: 'Address Line 3',
+            line4: 'Address Line 4',
+            town: 'Test Town',
+            postcode,
+            UPRN: 12345678901,
+          },
+        ],
+        page_count: 1,
+        total_count: 1,
+      },
+    },
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest && tsc --noEmit",
     "test:watch": "jest --watch",
     "prepare": "husky",
-    "cypress:open": "cypress open --browser electron",
+    "cypress:open": "cypress open --browser chrome",
     "e2e:run": "cypress run --e2e --browser electron",
     "component:run": "cypress run --component --browser electron"
   },

--- a/pages/apply/[resident]/[section].tsx
+++ b/pages/apply/[resident]/[section].tsx
@@ -2,12 +2,18 @@ import { useRouter } from 'next/router';
 import ApplicationForms from '../../../components/application/application-forms';
 import Layout from '../../../components/layout/resident-layout';
 import withApplication from '../../../lib/hoc/withApplication';
-import { applicantHasId, selectApplicant } from '../../../lib/store/applicant';
+import { selectApplicant } from '../../../lib/store/applicant';
 import { Applicant } from '../../../domain/HousingApi';
 import { useAppSelector } from '../../../lib/store/hooks';
 import { getApplicationSectionFromId } from '../../../lib/utils/application-forms';
 import { isOver18 } from '../../../lib/utils/dateOfBirth';
 import { getApplicationSectionsForResident } from '../../../lib/utils/resident';
+import { useState } from 'react';
+import { selectSaveApplicationStatus } from 'lib/store/apiCallsStatus';
+import useApiCallStatus from 'lib/hooks/useApiCallStatus';
+import { scrollToError } from 'lib/utils/scroll';
+import Loading from 'components/loading';
+import ErrorSummary from 'components/errors/error-summary';
 
 const ApplicationSection = (): JSX.Element => {
   const router = useRouter();
@@ -21,6 +27,19 @@ const ApplicationSection = (): JSX.Element => {
 
   const baseHref = `/apply/${applicant?.person?.id}`;
   const returnHref = '/apply/overview';
+
+  const [isSavingToDatabase, setIsSavingToDatabase] = useState<boolean>(false);
+  const applicationSaveStatus = useAppSelector(selectSaveApplicationStatus);
+  const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
+  const [userError, setUserError] = useState<string | null>(null);
+
+  useApiCallStatus({
+    selector: applicationSaveStatus,
+    userActionCompleted: hasSubmitted,
+    setUserError,
+    scrollToError,
+    pathToPush: baseHref,
+  });
 
   const sectionGroups = applicant
     ? getApplicationSectionsForResident(
@@ -49,18 +68,28 @@ const ApplicationSection = (): JSX.Element => {
   ];
 
   const onSubmit = async () => {
-    router.push(baseHref);
+    setHasSubmitted(true);
+    setIsSavingToDatabase(true);
   };
 
   return (
     <>
       <Layout pageName={sectionName} breadcrumbs={breadcrumbs}>
-        <ApplicationForms
-          applicant={applicant}
-          sectionGroups={sectionGroups}
-          activeStep={section}
-          onSubmit={onSubmit}
-        />
+        {userError && (
+          <ErrorSummary dataTestId="test-agree-terms-error-summary">
+            {userError}
+          </ErrorSummary>
+        )}
+        {isSavingToDatabase && !userError ? (
+          <Loading text="Saving..." />
+        ) : (
+          <ApplicationForms
+            applicant={applicant}
+            sectionGroups={sectionGroups}
+            activeStep={section}
+            onSubmit={onSubmit}
+          />
+        )}
       </Layout>
     </>
   );

--- a/pages/apply/[resident]/address-history.tsx
+++ b/pages/apply/[resident]/address-history.tsx
@@ -32,6 +32,14 @@ import {
 } from '../../../lib/utils/addressHistory';
 import { FormID } from '../../../lib/utils/form-data';
 import Custom404 from '../../404';
+import useApiCallStatus from 'lib/hooks/useApiCallStatus';
+import {
+  ApiCallStatusCode,
+  selectSaveApplicationStatus,
+} from 'lib/store/apiCallsStatus';
+import { scrollToError } from 'lib/utils/scroll';
+import Loading from 'components/loading';
+import ErrorSummary from 'components/errors/error-summary';
 
 type State = 'postcode-entry' | 'manual-entry' | 'choose-address' | 'review';
 
@@ -215,6 +223,18 @@ const ApplicationStep = (): JSX.Element => {
     applicant === application.mainApplicant ||
     applicant?.person?.relationshipType === 'partner';
 
+  const [hasSaved, setHasSaved] = useState<boolean>(false);
+  const saveApplicationStatus = useAppSelector(selectSaveApplicationStatus);
+  const [userError, setUserError] = useState<string | null>(null);
+
+  useApiCallStatus({
+    selector: saveApplicationStatus,
+    userActionCompleted: hasSaved,
+    setUserError,
+    scrollToError,
+    pathToPush: `/apply/${resident}`,
+  });
+
   const requiredYears = isMainResidentOrPartner ? 5 : 0;
 
   const initialValues = {
@@ -312,6 +332,7 @@ const ApplicationStep = (): JSX.Element => {
 
       case 'review': {
         const [currentAddress] = addressHistory;
+        setHasSaved(true);
         dispatch(
           updateApplicant({
             person: { id: applicant.person?.id || '' },
@@ -334,7 +355,6 @@ const ApplicationStep = (): JSX.Element => {
             markAsComplete: true,
           })
         );
-        router.push(`/apply/${resident}`);
         break;
       }
     }
@@ -348,140 +368,164 @@ const ApplicationStep = (): JSX.Element => {
           stepName="Address History"
           formID={FormID.ADDRESS_HISTORY}
         >
-          {isMainResidentOrPartner ? (
-            <>
-              <HeadingOne content="Address history" />
-              <Paragraph>
-                <strong>
-                  Tell us where you have been living for the last five years.
-                </strong>
-              </Paragraph>
-            </>
-          ) : (
-            <HeadingOne content="Address" />
+          {userError && (
+            <ErrorSummary dataTestId="test-agree-terms-error-summary">
+              {userError}
+            </ErrorSummary>
           )}
-          <h2 className="lbh-heading-h2">Current address</h2>
-          <Details summary="Help with your address">
-            If you have no fixed abode or if you are sofa surfing, use the
-            address where you sleep for the majority of the week. If you are
-            living on the street, contact a{' '}
-            <a
-              className="lbh-link lbh-link--no-visited-state"
-              href="https://hackney.gov.uk/housing-options"
-            >
-              housing officer
-            </a>
-          </Details>
+          {saveApplicationStatus?.callStatus === ApiCallStatusCode.PENDING ? (
+            <Loading text="Saving..." />
+          ) : (
+            <>
+              {isMainResidentOrPartner ? (
+                <>
+                  <HeadingOne content="Address history" />
+                  <Paragraph>
+                    <strong>
+                      Tell us where you have been living for the last five
+                      years.
+                    </strong>
+                  </Paragraph>
+                </>
+              ) : (
+                <HeadingOne content="Address" />
+              )}
+              <h2 className="lbh-heading-h2">Current address</h2>
+              <Details summary="Help with your address">
+                If you have no fixed abode or if you are sofa surfing, use the
+                address where you sleep for the majority of the week. If you are
+                living on the street, contact a{' '}
+                <a
+                  className="lbh-link lbh-link--no-visited-state"
+                  href="https://hackney.gov.uk/housing-options"
+                >
+                  housing officer
+                </a>
+              </Details>
 
-          <Summary addressHistory={addressHistory} />
-          <Formik
-            initialValues={initialValues}
-            onSubmit={onSubmit}
-            validationSchema={generateValidationSchema(state, addressHistory)}
-          >
-            {({ isSubmitting, values }) => (
-              <Form>
-                {state === 'postcode-entry' && (
-                  <>
-                    {addressHistory.length > 0 && (
-                      <h2 className="lbh-heading-h2">Previous address</h2>
-                    )}
-                    <Input
-                      name="postcode"
-                      label="Postcode"
-                      autoComplete="postal-code"
-                    />
-                    <Button type="submit">Find address</Button>
-                  </>
+              <Summary addressHistory={addressHistory} />
+              <Formik
+                initialValues={initialValues}
+                onSubmit={onSubmit}
+                validationSchema={generateValidationSchema(
+                  state,
+                  addressHistory
                 )}
-
-                {state === 'manual-entry' && (
-                  <InsetText>
-                    <ManualEntry />
-                    <DateInput
-                      name={'date'}
-                      label={'When did you move to this address?'}
-                      showDay={false}
-                    />
-                    {addressHistory.length > 0 && (
-                      <DateInput
-                        name={'dateTo'}
-                        label={'When did you leave this address?'}
-                        showDay={false}
-                      />
+              >
+                {({ isSubmitting, values }) => (
+                  <Form>
+                    {state === 'postcode-entry' && (
+                      <>
+                        {addressHistory.length > 0 && (
+                          <h2 className="lbh-heading-h2">Previous address</h2>
+                        )}
+                        <Input
+                          name="postcode"
+                          label="Postcode"
+                          autoComplete="postal-code"
+                        />
+                        <Button
+                          type="submit"
+                          dataTestId="test-apply-resident-address-history-find-address-button"
+                        >
+                          Find address
+                        </Button>
+                      </>
                     )}
-                  </InsetText>
-                )}
 
-                {state === 'choose-address' && (
-                  <InsetText>
-                    <Label content={'Postcode'} strong />
+                    {state === 'manual-entry' && (
+                      <InsetText>
+                        <ManualEntry />
+                        <DateInput
+                          name={'date'}
+                          label={'When did you move to this address?'}
+                          showDay={false}
+                        />
+                        {addressHistory.length > 0 && (
+                          <DateInput
+                            name={'dateTo'}
+                            label={'When did you leave this address?'}
+                            showDay={false}
+                          />
+                        )}
+                      </InsetText>
+                    )}
 
-                    <div>
-                      {values.postcode}
-                      &nbsp;&nbsp;&nbsp;
-                      <a
-                        role="button"
-                        href="#"
-                        className="lbh-link lbh-link--no-visited-state"
-                        onClick={() => {
-                          setState('postcode-entry');
-                        }}
-                      >
-                        Change
-                      </a>
+                    {state === 'choose-address' && (
+                      <InsetText>
+                        <Label content={'Postcode'} strong />
+
+                        <div>
+                          {values.postcode}
+                          &nbsp;&nbsp;&nbsp;
+                          <a
+                            role="button"
+                            href="#"
+                            className="lbh-link lbh-link--no-visited-state"
+                            onClick={() => {
+                              setState('postcode-entry');
+                            }}
+                          >
+                            Change
+                          </a>
+                        </div>
+
+                        <Select
+                          label={'Select an address'}
+                          name={'uprn'}
+                          options={postcodeResults.map((address) => ({
+                            label: address.line1 + ', ' + address.town,
+                            value: address.UPRN.toString(),
+                          }))}
+                        />
+
+                        <a
+                          role="button"
+                          href="#"
+                          className="lbh-link lbh-link--no-visited-state"
+                          onClick={() => setState('manual-entry')}
+                        >
+                          I can't find my address in the list
+                        </a>
+                        <DateInput
+                          name={'date'}
+                          label={'When did you move to this address?'}
+                          showDay={false}
+                        />
+                        {addressHistory.length > 0 && (
+                          <DateInput
+                            name={'dateTo'}
+                            label={'When did you leave this address?'}
+                            showDay={false}
+                          />
+                        )}
+                      </InsetText>
+                    )}
+
+                    <div className="c-flex lbh-simple-pagination">
+                      {state === 'review' && (
+                        <div className="c-flex__1">
+                          <Button onClick={restart} secondary={true}>
+                            Update address
+                          </Button>
+                        </div>
+                      )}
+
+                      <div className="c-flex__1 text-right">
+                        <Button
+                          disabled={isSubmitting}
+                          type="submit"
+                          dataTestId="test-apply-resident-address-history-save-and-continue-button"
+                        >
+                          Save and continue
+                        </Button>
+                      </div>
                     </div>
-
-                    <Select
-                      label={'Select an address'}
-                      name={'uprn'}
-                      options={postcodeResults.map((address) => ({
-                        label: address.line1 + ', ' + address.town,
-                        value: address.UPRN.toString(),
-                      }))}
-                    />
-
-                    <a
-                      role="button"
-                      href="#"
-                      className="lbh-link lbh-link--no-visited-state"
-                      onClick={() => setState('manual-entry')}
-                    >
-                      I can't find my address in the list
-                    </a>
-                    <DateInput
-                      name={'date'}
-                      label={'When did you move to this address?'}
-                      showDay={false}
-                    />
-                    {addressHistory.length > 0 && (
-                      <DateInput
-                        name={'dateTo'}
-                        label={'When did you leave this address?'}
-                        showDay={false}
-                      />
-                    )}
-                  </InsetText>
+                  </Form>
                 )}
-
-                <div className="c-flex lbh-simple-pagination">
-                  {state === 'review' && (
-                    <div className="c-flex__1">
-                      <Button onClick={restart} secondary={true}>
-                        Update address
-                      </Button>
-                    </div>
-                  )}
-
-                  <div className="c-flex__1 text-right">
-                    <Button disabled={isSubmitting} type="submit">
-                      Save and continue
-                    </Button>
-                  </div>
-                </div>
-              </Form>
-            )}
-          </Formik>
+              </Formik>
+            </>
+          )}
         </ApplicantStep>
       ) : (
         <Custom404 />

--- a/pages/apply/[resident]/current-accommodation.tsx
+++ b/pages/apply/[resident]/current-accommodation.tsx
@@ -1,6 +1,6 @@
 import { FormikValues, getIn } from 'formik';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { HeadingOne } from '../../../components/content/headings';
 import Form from '../../../components/form/form';
 import Layout from '../../../components/layout/resident-layout';
@@ -15,6 +15,12 @@ import { useAppDispatch, useAppSelector } from '../../../lib/store/hooks';
 import { FormID, getFormData } from '../../../lib/utils/form-data';
 import Custom404 from '../../404';
 import { Applicant } from '../../../domain/HousingApi';
+import {
+  ApiCallStatusCode,
+  selectSaveApplicationStatus,
+} from 'lib/store/apiCallsStatus';
+import { scrollToError } from 'lib/utils/scroll';
+import ErrorSummary from 'components/errors/error-summary';
 
 const CurrentAccommodation = (): JSX.Element => {
   const router = useRouter();
@@ -22,10 +28,24 @@ const CurrentAccommodation = (): JSX.Element => {
   const { resident } = router.query as { resident: string };
 
   const applicant = useAppSelector(selectApplicant(resident)) as Applicant;
-
   const [activeStepID, setActiveStepId] = useState(
     FormID.CURRENT_ACCOMMODATION
   );
+
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [userError, setUserError] = useState<string | null>(null);
+  const saveApplicationStatus = useAppSelector(selectSaveApplicationStatus);
+
+  useEffect(() => {
+    if (saveApplicationStatus?.callStatus === ApiCallStatusCode.FULFILLED) {
+      setIsSaving(false);
+    }
+    if (saveApplicationStatus?.callStatus === ApiCallStatusCode.REJECTED) {
+      setIsSaving(false);
+      setUserError('Unable to save application');
+      scrollToError();
+    }
+  }, [saveApplicationStatus?.callStatus]);
 
   if (!applicantHasId(applicant)) {
     return <Custom404 />;
@@ -62,6 +82,7 @@ const CurrentAccommodation = (): JSX.Element => {
     ) ?? { nextFormId: 'exit' };
 
     if (nextFormId === 'exit') {
+      //Save status has been handled elsewhere before this triggers
       router.push(baseHref);
       return;
     }
@@ -70,6 +91,7 @@ const CurrentAccommodation = (): JSX.Element => {
   };
 
   const onSave = (values: FormikValues) => {
+    setIsSaving(true);
     dispatch(
       updateWithFormValues({
         formID: activeStepID,
@@ -83,6 +105,11 @@ const CurrentAccommodation = (): JSX.Element => {
   return (
     <Layout pageName="Current accommodation" breadcrumbs={breadcrumbs}>
       <HeadingOne content="Current accommodation" />
+      {userError && (
+        <ErrorSummary dataTestId="test-agree-terms-error-summary">
+          {userError}
+        </ErrorSummary>
+      )}
       <Form
         // Intentional key outside of an array. Force a fresh form component when we change steps to avoid values persisting between forms.
         initialValues={initialValues}
@@ -91,6 +118,7 @@ const CurrentAccommodation = (): JSX.Element => {
         formData={formData}
         onSave={onSave}
         onSubmit={nextStep}
+        isSavingToDatabase={isSaving}
       />
     </Layout>
   );

--- a/pages/apply/[resident]/current-accommodation.tsx
+++ b/pages/apply/[resident]/current-accommodation.tsx
@@ -35,10 +35,16 @@ const CurrentAccommodation = (): JSX.Element => {
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [userError, setUserError] = useState<string | null>(null);
   const saveApplicationStatus = useAppSelector(selectSaveApplicationStatus);
+  const [isLastFormPageSubmit, setIsLastFormPageSubmit] = useState<boolean>(
+    false
+  );
 
   useEffect(() => {
     if (saveApplicationStatus?.callStatus === ApiCallStatusCode.FULFILLED) {
       setIsSaving(false);
+      if (isLastFormPageSubmit) {
+        router.push(baseHref);
+      }
     }
     if (saveApplicationStatus?.callStatus === ApiCallStatusCode.REJECTED) {
       setIsSaving(false);
@@ -82,8 +88,7 @@ const CurrentAccommodation = (): JSX.Element => {
     ) ?? { nextFormId: 'exit' };
 
     if (nextFormId === 'exit') {
-      //Save status has been handled elsewhere before this triggers
-      router.push(baseHref);
+      setIsLastFormPageSubmit(true);
       return;
     }
 

--- a/pages/apply/[resident]/index.tsx
+++ b/pages/apply/[resident]/index.tsx
@@ -65,20 +65,22 @@ const ResidentIndex = (): JSX.Element => {
       setUserHasSaved(false);
     }
 
-    if (saveApplicationStatus?.callStatus === ApiCallStatusCode.FULFILLED) {
-      router.push(returnHref);
-    }
+    if (isSaving) {
+      if (saveApplicationStatus?.callStatus === ApiCallStatusCode.FULFILLED) {
+        router.push(returnHref);
+      }
 
-    if (saveApplicationStatus?.callStatus === ApiCallStatusCode.REJECTED) {
-      router.push(
-        {
-          pathname: returnHref,
-          query: {
-            error: 'Unable to delete household member. Please try again.',
+      if (saveApplicationStatus?.callStatus === ApiCallStatusCode.REJECTED) {
+        router.push(
+          {
+            pathname: returnHref,
+            query: {
+              error: 'Unable to delete household member. Please try again.',
+            },
           },
-        },
-        returnHref
-      );
+          returnHref
+        );
+      }
     }
   }, [saveApplicationStatus?.callStatus, userHasSaved]);
 
@@ -168,7 +170,11 @@ const ResidentIndex = (): JSX.Element => {
   };
 
   return (
-    <Layout pageName="Person overview" breadcrumbs={breadcrumbs}>
+    <Layout
+      pageName="Person overview"
+      breadcrumbs={breadcrumbs}
+      dataTestId="test-apply-resident-index-page"
+    >
       <h1 className="lbh-heading-h1" style={{ marginBottom: '40px' }}>
         <span className="govuk-hint lbh-hint">Complete information for:</span>
         {`${currentResident.person?.firstName} ${currentResident.person?.surname}`}

--- a/pages/apply/[resident]/index.tsx
+++ b/pages/apply/[resident]/index.tsx
@@ -49,6 +49,14 @@ const ResidentIndex = (): JSX.Element => {
   const [isSaving, setIsSaving] = useState<boolean>(false);
 
   const returnHref = '/apply/overview';
+  let isEligible = true;
+
+  //use effect to stop router.push firing multiple times
+  useEffect(() => {
+    if (!isEligible && currentResident === mainResident) {
+      router.push(checkAnswers);
+    }
+  }, [isEligible]);
 
   useEffect(() => {
     if (userHasSaved) {
@@ -88,7 +96,7 @@ const ResidentIndex = (): JSX.Element => {
     return <Custom404 />;
   }
 
-  const baseHref = !isSaving ? `/ apply / ${currentResident.person?.id} ` : '';
+  const baseHref = !isSaving ? `/apply/${currentResident.person?.id}` : '';
 
   const breadcrumbs = !isSaving
     ? [
@@ -105,11 +113,7 @@ const ResidentIndex = (): JSX.Element => {
 
   const checkAnswers = `${baseHref}/summary`;
 
-  const [isEligible] = checkEligible(application);
-
-  if (!isEligible && currentResident === mainResident) {
-    router.push(checkAnswers);
-  }
+  [isEligible] = checkEligible(application);
 
   const steps = getApplicationSectionsForResident(
     currentResident === mainResident,

--- a/pages/apply/[resident]/index.tsx
+++ b/pages/apply/[resident]/index.tsx
@@ -92,7 +92,6 @@ const ResidentIndex = (): JSX.Element => {
       </Layout>
     );
   }
-
   //redirect when applicant details missing and not saving
   if (!currentResident || !mainResident) {
     return <Custom404 />;

--- a/pages/apply/[resident]/index.tsx
+++ b/pages/apply/[resident]/index.tsx
@@ -211,7 +211,10 @@ const ResidentIndex = (): JSX.Element => {
         </div>
       ))}
       {tasks.remaining == 0 && (
-        <ButtonLink href={`/apply/${currentResident.person?.id}/summary/`}>
+        <ButtonLink
+          href={`/apply/${currentResident.person?.id}/summary/`}
+          dataTestId="test-apply-resident-index-check-answers-button"
+        >
           Check answers
         </ButtonLink>
       )}

--- a/pages/apply/[resident]/personal-details.tsx
+++ b/pages/apply/[resident]/personal-details.tsx
@@ -14,6 +14,14 @@ import { FormID } from '../../../lib/utils/form-data';
 import Custom404 from '../../404';
 import AddPersonForm from '../../../components/application/add-person-form';
 import { Applicant } from '../../../domain/HousingApi';
+import useApiCallSelectorStatus from '../../../lib/hooks/useApiCallStatus';
+import {
+  ApiCallStatusCode,
+  selectSaveApplicationStatus,
+} from 'lib/store/apiCallsStatus';
+import { scrollToError } from 'lib/utils/scroll';
+import Loading from 'components/loading';
+import ErrorSummary from 'components/errors/error-summary';
 
 const ApplicationStep = (): JSX.Element => {
   const router = useRouter();
@@ -24,7 +32,19 @@ const ApplicationStep = (): JSX.Element => {
 
   const applicant = useAppSelector(selectApplicant(resident)) as Applicant;
   const mainResident = useAppSelector((s) => s.application.mainApplicant);
+  const saveApplicationStatus = useAppSelector(selectSaveApplicationStatus);
+  const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
+  const [userError, setUserError] = useState<string | null>(null);
+
   const isMainApplicant = applicant == mainResident;
+
+  useApiCallSelectorStatus({
+    selector: saveApplicationStatus,
+    userActionCompleted: hasSubmitted,
+    setUserError,
+    scrollToError,
+    pathToPush: `/apply/${resident}`,
+  });
 
   const onSubmit = ({
     title,
@@ -47,6 +67,8 @@ const ApplicationStep = (): JSX.Element => {
       phoneNumber = '';
       emailAddress = '';
     }
+
+    setHasSubmitted(true);
 
     dispatch(
       updateApplicant({
@@ -75,8 +97,6 @@ const ApplicationStep = (): JSX.Element => {
         markAsComplete: true,
       })
     );
-
-    router.push(`/apply/${resident}`);
   };
 
   return (
@@ -86,15 +106,25 @@ const ApplicationStep = (): JSX.Element => {
           applicant={applicant}
           stepName="Personal details"
           formID={FormID.PERSONAL_DETAILS}
+          dataTestId="test-apply-resident-personal-details-step"
         >
-          <AddPersonForm
-            applicant={applicant}
-            onSubmit={onSubmit}
-            isMainApplicant={isMainApplicant}
-            buttonText="Save and continue"
-            isOver16={isOver16State}
-            setIsOver16State={setIsOver16State}
-          />
+          {userError && (
+            <ErrorSummary dataTestId="test-apply-resident-personal-details-step-error-summary">
+              {userError}
+            </ErrorSummary>
+          )}
+          {saveApplicationStatus?.callStatus === ApiCallStatusCode.PENDING ? (
+            <Loading text="Saving..." />
+          ) : (
+            <AddPersonForm
+              applicant={applicant}
+              onSubmit={onSubmit}
+              isMainApplicant={isMainApplicant}
+              buttonText="Save and continue"
+              isOver16={isOver16State}
+              setIsOver16State={setIsOver16State}
+            />
+          )}
         </ApplicantStep>
       ) : (
         <Custom404 />

--- a/pages/apply/[resident]/summary.tsx
+++ b/pages/apply/[resident]/summary.tsx
@@ -110,7 +110,11 @@ const UserSummary = (): JSX.Element => {
   const medicalNeedsCompleted = isSectionComplete(FormID.MEDICAL_NEEDS);
 
   return (
-    <Layout pageName="Application summary" breadcrumbs={breadcrumbs}>
+    <Layout
+      pageName="Application summary"
+      breadcrumbs={breadcrumbs}
+      dataTestId="test-apply-resident-summary-page"
+    >
       <h1 className="lbh-heading-h1">
         <span className="govuk-hint lbh-hint">Check answers for:</span>
         {currentResident.person?.firstName} {currentResident.person?.surname}

--- a/pages/apply/[resident]/summary.tsx
+++ b/pages/apply/[resident]/summary.tsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/router';
 import Custom404 from '../../404';
 import DeleteLink from '../../../components/delete-link';
 import PersonalDetailsSummary from '../../../components/summary/PersonalDetails';
-import React from 'react';
+import React, { useState } from 'react';
 import { AddressHistorySummary } from '../../../components/summary/AddressHistory';
 import { CurrentAccommodationSummary } from '../../../components/summary/CurrentAccommodation';
 import { EmploymentSummary } from '../../../components/summary/Employment';
@@ -30,6 +30,11 @@ import {
   sendDisqualifyEmail,
 } from '../../../lib/store/application';
 import { Applicant } from '../../../domain/HousingApi';
+import { scrollToError } from 'lib/utils/scroll';
+import Loading from 'components/loading';
+import ErrorSummary from 'components/errors/error-summary';
+import { selectSaveApplicationStatus } from 'lib/store/apiCallsStatus';
+import useApiCallStatus from 'lib/hooks/useApiCallStatus';
 
 const UserSummary = (): JSX.Element => {
   const router = useRouter();
@@ -46,12 +51,35 @@ const UserSummary = (): JSX.Element => {
 
   const application = useAppSelector((store) => store.application);
 
+  const [userError, setUserError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const saveApplicationStatus = useAppSelector(selectSaveApplicationStatus);
+  const [
+    hasDeletedHouseholdMember,
+    setHasDeletedHouseholdMember,
+  ] = useState<boolean>(false);
+
+  const returnHref = '/apply/overview';
+
+  useApiCallStatus({
+    selector: saveApplicationStatus,
+    userActionCompleted: hasDeletedHouseholdMember,
+    setUserError,
+    scrollToError,
+    pathToPush: returnHref,
+  });
+
+  if (isSaving) {
+    return (
+      <Layout pageName="Application summary" pageLoadsApplication={false}>
+        <Loading text="Saving..." />
+      </Layout>
+    );
+  }
+
   if (!currentResident || !mainResident) {
     return <Custom404 />;
   }
-
-  const baseHref = `/apply/${currentResident.person?.id}`;
-  const returnHref = '/apply/overview';
 
   const onConfirmData = () => {
     const [isEligible, reasons] = checkEligible(application);
@@ -60,18 +88,35 @@ const UserSummary = (): JSX.Element => {
         getDisqualificationReasonOption(reason)
       );
       const reason = reasonStrings.join(',');
+
+      //sends an email, no need to handle save. TODO: add error handling
       dispatch(sendDisqualifyEmail({ application, reason }));
-      dispatch(disqualifyApplication(application.id!));
-      router.push('/apply/not-eligible');
+
+      setIsSaving(true);
+
+      dispatch(disqualifyApplication(application.id!))
+        .unwrap()
+        .then(() => {
+          router.push('/apply/not-eligible');
+        })
+        .catch(() => {
+          setIsSaving(false);
+          setUserError('Unable to update application');
+          scrollToError();
+        });
     } else {
+      //not saving data, OK as is
       router.push('/apply/overview');
     }
   };
 
   const onDelete = () => {
+    setHasDeletedHouseholdMember(true);
+    setIsSaving(true);
     dispatch(removeApplicant(currentResident.person!.id!));
-    router.push(returnHref);
   };
+
+  const baseHref = `/apply/${currentResident.person?.id}`;
 
   const breadcrumbs = [
     {
@@ -119,57 +164,77 @@ const UserSummary = (): JSX.Element => {
         <span className="govuk-hint lbh-hint">Check answers for:</span>
         {currentResident.person?.firstName} {currentResident.person?.surname}
       </h1>
-      {pesonalDetailsCompleted && (
-        <PersonalDetailsSummary currentResident={currentResident} />
+      {userError && (
+        <ErrorSummary dataTestId="test-agree-terms-error-summary">
+          {userError}
+        </ErrorSummary>
       )}
-
-      {immigrationStatusCompleted && (
-        <ImmigrationStatusSummary currentResident={currentResident} />
-      )}
-
-      {isMainApplicant && (
+      {isSaving ? (
+        <Loading text="Saving..." />
+      ) : (
         <>
-          {residentialStatusCompleted && (
-            <ResidentialStatusSummary currentResident={currentResident} />
+          {pesonalDetailsCompleted && (
+            <PersonalDetailsSummary currentResident={currentResident} />
+          )}
+
+          {immigrationStatusCompleted && (
+            <ImmigrationStatusSummary currentResident={currentResident} />
+          )}
+
+          {isMainApplicant && (
+            <>
+              {residentialStatusCompleted && (
+                <ResidentialStatusSummary currentResident={currentResident} />
+              )}
+            </>
+          )}
+          {addressHistoryCompleted && (
+            <AddressHistorySummary currentResident={currentResident} />
+          )}
+
+          {isMainApplicant && (
+            <>
+              {currentAccommodationCompleted && (
+                <CurrentAccommodationSummary
+                  currentResident={currentResident}
+                />
+              )}
+              {yourSituationCompleted && (
+                <YourSituationSummary currentResident={currentResident} />
+              )}
+            </>
+          )}
+
+          {isOver18(currentResident) && (
+            <>
+              {incomeSavingsCompleted && (
+                <IncomeSavingsSummary currentResident={currentResident} />
+              )}
+              {employmentCompleted && (
+                <EmploymentSummary currentResident={currentResident} />
+              )}
+            </>
+          )}
+          {medicalNeedsCompleted && (
+            <MedicalNeedsSummary currentResident={currentResident} />
+          )}
+
+          <Button
+            onClick={onConfirmData}
+            dataTestId="test-apply-resident-summary-confirm-details-button"
+          >
+            I confirm this is correct
+          </Button>
+          {currentResident !== mainResident && (
+            <DeleteLink
+              content="Delete this information"
+              details="This information will be permanently deleted."
+              onDelete={onDelete}
+              mainButtonTestId="test-apply-resident-summary-delete-this-information-button"
+              dialogConfirmButtonTestId="test-apply-resident-summary-yes-delete-this-information-button"
+            />
           )}
         </>
-      )}
-      {addressHistoryCompleted && (
-        <AddressHistorySummary currentResident={currentResident} />
-      )}
-
-      {isMainApplicant && (
-        <>
-          {currentAccommodationCompleted && (
-            <CurrentAccommodationSummary currentResident={currentResident} />
-          )}
-          {yourSituationCompleted && (
-            <YourSituationSummary currentResident={currentResident} />
-          )}
-        </>
-      )}
-
-      {isOver18(currentResident) && (
-        <>
-          {incomeSavingsCompleted && (
-            <IncomeSavingsSummary currentResident={currentResident} />
-          )}
-          {employmentCompleted && (
-            <EmploymentSummary currentResident={currentResident} />
-          )}
-        </>
-      )}
-      {medicalNeedsCompleted && (
-        <MedicalNeedsSummary currentResident={currentResident} />
-      )}
-
-      <Button onClick={onConfirmData}>I confirm this is correct</Button>
-      {currentResident !== mainResident && (
-        <DeleteLink
-          content="Delete this information"
-          details="This information will be permanently deleted."
-          onDelete={onDelete}
-        />
       )}
     </Layout>
   );

--- a/pages/apply/[resident]/your-situation.tsx
+++ b/pages/apply/[resident]/your-situation.tsx
@@ -1,6 +1,6 @@
 import { FormikValues, getIn } from 'formik';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { HeadingOne } from '../../../components/content/headings';
 import Form from '../../../components/form/form';
 import Layout from '../../../components/layout/resident-layout';
@@ -14,6 +14,12 @@ import { useAppDispatch, useAppSelector } from '../../../lib/store/hooks';
 import { FormID, getFormData } from '../../../lib/utils/form-data';
 import { Applicant } from '../../../domain/HousingApi';
 import Custom404 from '../../404';
+import {
+  ApiCallStatusCode,
+  selectSaveApplicationStatus,
+} from 'lib/store/apiCallsStatus';
+import { scrollToError } from 'lib/utils/scroll';
+import ErrorSummary from 'components/errors/error-summary';
 
 const YourSituation = (): JSX.Element => {
   const router = useRouter();
@@ -23,12 +29,33 @@ const YourSituation = (): JSX.Element => {
   );
 
   const { resident } = router.query as { resident: string };
-
   const applicant = useAppSelector(selectApplicant(resident)) as Applicant;
+  const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [userError, setUserError] = useState<string | null>(null);
+  const [isLastFormPageSubmit, setIsLastFormPageSubmit] = useState<boolean>(
+    false
+  );
+  const saveApplicationStatus = useAppSelector(selectSaveApplicationStatus);
 
   if (!applicant) {
     return <Custom404 />;
   }
+
+  const baseHref = `/apply/${applicant.person?.id}`;
+
+  useEffect(() => {
+    if (saveApplicationStatus?.callStatus === ApiCallStatusCode.FULFILLED) {
+      setIsSaving(false);
+      if (isLastFormPageSubmit) {
+        router.push(baseHref);
+      }
+    }
+    if (saveApplicationStatus?.callStatus === ApiCallStatusCode.REJECTED) {
+      setIsSaving(false);
+      setUserError('Unable to save application');
+      scrollToError();
+    }
+  }, [saveApplicationStatus?.callStatus]);
 
   // If JSON has routeSelect set to true we can pass multiple possible values to activeStepID.
   // See if statement at end of nextStep() below
@@ -56,7 +83,6 @@ const YourSituation = (): JSX.Element => {
 
   const formData = getFormData(activeStepID);
 
-  const baseHref = `/apply/${applicant.person?.id}`;
   const returnHref = '/apply/overview';
 
   const breadcrumbs = [
@@ -80,6 +106,8 @@ const YourSituation = (): JSX.Element => {
     ) ?? { nextFormId: 'exit', routeSelect: false };
 
     if (nextFormId === 'exit') {
+      setIsLastFormPageSubmit(true);
+
       dispatch(
         updateWithFormValues({
           formID: FormID.YOUR_SITUATION,
@@ -88,7 +116,6 @@ const YourSituation = (): JSX.Element => {
           markAsComplete: true,
         })
       );
-      router.push(baseHref);
       return;
     }
 
@@ -102,6 +129,7 @@ const YourSituation = (): JSX.Element => {
   };
 
   const onSave = (values: FormikValues) => {
+    setIsSaving(true);
     dispatch(
       updateWithFormValues({
         formID: activeStepID,
@@ -115,6 +143,11 @@ const YourSituation = (): JSX.Element => {
   return (
     <Layout pageName="Your situation" breadcrumbs={breadcrumbs}>
       <HeadingOne content="Your situation" />
+      {userError && (
+        <ErrorSummary dataTestId="test-agree-terms-error-summary">
+          {userError}
+        </ErrorSummary>
+      )}
       <Form
         // Intentional key outside of an array. Force a fresh form component when we change steps to avoid values persisting between forms.
         key={activeStepID}
@@ -122,6 +155,7 @@ const YourSituation = (): JSX.Element => {
         formData={formData}
         onSave={onSave}
         onSubmit={nextStep}
+        isSavingToDatabase={isSaving}
       />
     </Layout>
   );

--- a/pages/apply/expect.tsx
+++ b/pages/apply/expect.tsx
@@ -44,7 +44,12 @@ const WhatToExpect = (): JSX.Element => {
         qualify to join the housing register.
       </Paragraph>
 
-      <ButtonLink href="/apply/overview">Save and continue</ButtonLink>
+      <ButtonLink
+        href="/apply/overview"
+        dataTestId="test-apply-expect-save-and-continue-button"
+      >
+        Save and continue
+      </ButtonLink>
       <DeleteLink content="Cancel this application" onDelete={onCancel} />
     </Layout>
   );

--- a/pages/apply/household/index.tsx
+++ b/pages/apply/household/index.tsx
@@ -82,7 +82,12 @@ const ApplicationHouseholdOverview = (): JSX.Element => {
         </strong>{' '}
         in this application.
       </Paragraph>
-      <ButtonLink href="/apply/expect">Continue to next step</ButtonLink>
+      <ButtonLink
+        href="/apply/expect"
+        dataTestId="test-apply-household-index-continue-to-next-step-button"
+      >
+        Continue to next step
+      </ButtonLink>
       <DeleteLink
         content="Cancel this application"
         details="This application will be permanently deleted."

--- a/pages/apply/overview.tsx
+++ b/pages/apply/overview.tsx
@@ -54,7 +54,11 @@ const ApplicationPersonsOverview = (): JSX.Element => {
 
   return (
     <>
-      <Layout pageName="Application overview" breadcrumbs={breadcrumbs}>
+      <Layout
+        pageName="Application overview"
+        breadcrumbs={breadcrumbs}
+        dataTestId="test-apply-resident-overview-page"
+      >
         <HeadingOne content="Provide information about your household" />
         <p className="lbh-body lbh-body-l lbh-body--grey">
           You've completed information for {applicantsCompletedCount} of{' '}

--- a/pages/apply/overview.tsx
+++ b/pages/apply/overview.tsx
@@ -28,7 +28,6 @@ const ApplicationPersonsOverview = (): JSX.Element => {
   ];
 
   const { query } = useRouter();
-  console.dir(query);
 
   useEffect(() => {
     if (query.error) {
@@ -86,6 +85,7 @@ const ApplicationPersonsOverview = (): JSX.Element => {
                     }
                     applicantNumber={index + 1}
                     tasks={tasks}
+                    applicantLinkTestId={applicant.person?.id}
                   />
                 </Key>
                 {/* <Actions>

--- a/pages/apply/overview.tsx
+++ b/pages/apply/overview.tsx
@@ -13,15 +13,29 @@ import { Applicant } from '../../domain/HousingApi';
 import { useAppSelector } from '../../lib/store/hooks';
 import { applicationSteps } from '../../lib/utils/resident';
 import withApplication from '../../lib/hoc/withApplication';
-import Custom404 from '../404';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { scrollToError } from 'lib/utils/scroll';
+import ErrorSummary from 'components/errors/error-summary';
 
 const ApplicationPersonsOverview = (): JSX.Element => {
+  const [userError, setUserError] = useState<string | null>(null);
   const breadcrumbs = [
     {
       href: '/apply/overview',
       name: 'Application',
     },
   ];
+
+  const { query } = useRouter();
+  console.dir(query);
+
+  useEffect(() => {
+    if (query.error) {
+      setUserError(query.error as string);
+      scrollToError();
+    }
+  }, [query]);
 
   const mainResident = useAppSelector((s) => s.application.mainApplicant);
   const application = useAppSelector((store) => store.application);
@@ -47,7 +61,11 @@ const ApplicationPersonsOverview = (): JSX.Element => {
           You've completed information for {applicantsCompletedCount} of{' '}
           {applicants.length} people.
         </p>
-
+        {userError && (
+          <ErrorSummary dataTestId="test-apply-overciw-error-summary">
+            {userError}
+          </ErrorSummary>
+        )}
         <SummaryListSpaced>
           {applicants.map((applicant, index) => {
             const tasks = applicationSteps(

--- a/testUtils/applicationHelper.ts
+++ b/testUtils/applicationHelper.ts
@@ -53,3 +53,78 @@ export const generateApplication = (
     importedFromLegacyDatabase: false,
   };
 };
+
+export const completedApplicationFormSections = [
+  {
+    answer: 'true',
+    id: 'personal-details/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'immigration-status/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'medical-needs/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'residential-status/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'address-history/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'current-accommodation/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'current-accommodation-landlord-details/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'situation-armed-forces/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'homelessness/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'property-ownership/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'sold-property/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'arrears/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'breach-of-tenancy/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'legal-restrictions/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'unspent-convictions/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'your-situation/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'employment/sectionCompleted',
+  },
+  {
+    answer: 'true',
+    id: 'income-savings/sectionCompleted',
+  },
+];

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -54,7 +54,7 @@ declare global {
         delay?: number,
         statusCode?: number
       ): Chainable<void>;
-
+      mockAddressAPISearchByPostcode(postcode: string);
       mount: typeof mount;
     }
   }

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -31,7 +31,8 @@ declare global {
         applicationId: string,
         body?: Application,
         delay?: number,
-        statusCode?: number
+        statusCode?: number,
+        persist?: boolean
       ): Chainable<void>;
       mockHousingRegisterApiCompleteApplication(
         applicationId: string,


### PR DESCRIPTION
## WHAT
Currently pages under `/apply/[resident]` path are not handling API calls and error handling as well as they should. This update ensures API PATCH calls are awaited correctly before user is pushed to the next page.

## WHY
This ensures database is always up to date before new state is created from the data on follow up pages.

## HOW
Use combination of custom hook, useEffect and async thunk modifications to ensure API calls are handled correctly. Error handling has also been improved where feasible within the limited timeframe available for refactoring.