### PR TITLE
Bugfix/cypress video config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,12 +95,8 @@ jobs:
           install-command: npm install
           post-install: npm run build
       - cypress/run-tests:
-          cypress-command: |
-            if [ "<< parameters.browser >>" = "chrome" ]; then
-              npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml" --video=true
-            else
-              npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml"
-            fi
+          cypress-command: npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml"
+
       - store_test_results:
           path: test_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ workflows:
                 width: 320
           filters:
             branches:
-              only: bugfix/cypress-video-config
+              only: development
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,6 @@ jobs:
           post-install: npm run build
       - cypress/run-tests:
           cypress-command: npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml"
-
       - store_test_results:
           path: test_results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       - cypress/run-tests:
           cypress-command: |
             if [ "<< parameters.browser >>" = "chrome" ]; then
-              npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml" --record
+              npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml" --video=true
             else
               npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,12 @@ jobs:
           install-command: npm install
           post-install: npm run build
       - cypress/run-tests:
-          cypress-command: npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml"
+          cypress-command: |
+            if [ "<< parameters.browser >>" = "chrome" ]; then
+              npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml" --record
+            else
+              npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml"
+            fi
       - store_test_results:
           path: test_results
 
@@ -237,7 +242,7 @@ workflows:
                 width: 320
           filters:
             branches:
-              only: development
+              only: bugfix/cypress-video-config
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -103,12 +103,10 @@ export default defineConfig({
     },
     baseUrl,
     experimentalWebKitSupport: true,
-    video: true,
     screenshotOnRunFailure: true,
     defaultCommandTimeout: 10000,
     videoCompression: true,
   },
-
   component: {
     devServer: {
       framework: 'next',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -83,7 +83,8 @@ export default defineConfig({
           return null;
         },
       });
-      if (config.video && config.browser.name === 'chrome') {
+      if (config.video && config.browser.name === 'Chrome 130') {
+        console.log('browsername:', config.browser.name);
         // delete video if test failed
         on('after:spec', (spec, results) => {
           if (results.video) {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -83,7 +83,7 @@ export default defineConfig({
           return null;
         },
       });
-      if (config.video) {
+      if (config.video && config.browser.name === 'chrome') {
         // delete video if test failed
         on('after:spec', (spec, results) => {
           if (results.video) {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -83,8 +83,7 @@ export default defineConfig({
           return null;
         },
       });
-      if (config.video && config.browser.name === 'Chrome 130') {
-        console.log('browsername:', config.browser.name);
+      if (config.video) {
         // delete video if test failed
         on('after:spec', (spec, results) => {
           if (results.video) {
@@ -106,7 +105,8 @@ export default defineConfig({
     experimentalWebKitSupport: true,
     screenshotOnRunFailure: true,
     defaultCommandTimeout: 10000,
-    videoCompression: true,
+    // video: true,
+    // videoCompression: true,
   },
   component: {
     devServer: {


### PR DESCRIPTION
https://hackney.atlassian.net/browse/TS-1766?atlOrigin=eyJpIjoiMzU2MDBjYmM5ZGQzNGJlZThlMzI4NTYxNGZjMDViZTYiLCJwIjoiaiJ9

**What**
As a result of the new configuration that only saves video for failed tests, firefox is throwing errors. 

This is to disable video until config is updated at a later point. 

