### PR TITLE
TS-1755 improve save handling on personal details page

### DIFF
--- a/cypress/e2e/pages/apply/start.cy.ts
+++ b/cypress/e2e/pages/apply/start.cy.ts
@@ -8,6 +8,7 @@ import {
 import { faker } from '@faker-js/faker/locale/en_GB';
 import AgreeTermsPage from '../../../pages/agreeTerms';
 import { StatusCodes } from 'http-status-codes';
+import Components from '../../../pages/components';
 
 const applicationId = faker.string.uuid();
 const personId = faker.string.uuid();
@@ -123,7 +124,10 @@ describe('Application', () => {
     fillInTheSignUpForm();
     StartPage.getSubmitButton().click();
 
+    Components.getLoadingSpinner().should('exist');
+    cy.contains('Saving...');
     StartPage.getErrorSummary().should('be.visible');
     cy.contains(expectedErrorMessage);
+    Components.getLoadingSpinner().should('not.exist');
   });
 });

--- a/lib/hooks/useApiCallStatus.tsx
+++ b/lib/hooks/useApiCallStatus.tsx
@@ -13,6 +13,7 @@ interface UseApiCallStatusProps {
   setUserError: (error: string) => void;
   scrollToError: () => void;
   pendingStatusStateDelay?: number;
+  clearPendingStatus?: boolean;
 }
 
 const useApiCallStatus = ({
@@ -23,6 +24,7 @@ const useApiCallStatus = ({
   pathToPush,
   query,
   pendingStatusStateDelay = 0,
+  clearPendingStatus = false,
 }: UseApiCallStatusProps) => {
   const router = useRouter();
   const [pendingStatus, setPendingStatus] = useState<boolean>(false);
@@ -34,7 +36,9 @@ const useApiCallStatus = ({
         setPendingStatus(true);
       }, pendingStatusStateDelay);
     } else {
-      setPendingStatus(false);
+      if (clearPendingStatus) {
+        setPendingStatus(false);
+      }
       clearTimeout(timer);
     }
 
@@ -42,11 +46,13 @@ const useApiCallStatus = ({
       selector?.callStatus === ApiCallStatusCode.FULFILLED &&
       userActionCompleted
     ) {
+      console.log('save complete in the hook, pushing');
       router.push({
         pathname: pathToPush,
         query,
       });
     } else if (selector?.callStatus === ApiCallStatusCode.REJECTED) {
+      setPendingStatus(false);
       setUserError(selector.error ?? 'API error');
       scrollToError();
     }

--- a/lib/hooks/useApiCallStatus.tsx
+++ b/lib/hooks/useApiCallStatus.tsx
@@ -46,7 +46,6 @@ const useApiCallStatus = ({
       selector?.callStatus === ApiCallStatusCode.FULFILLED &&
       userActionCompleted
     ) {
-      console.log('save complete in the hook, pushing');
       router.push({
         pathname: pathToPush,
         query,


### PR DESCRIPTION
## WHAT
Currently when transitioning between `start` and `agree-terms` pages start page form flashes briefly on the screen after save is complete and before user is pushed to the agree-terms page. 

## WHY
We don't want the current page render again after save before user is pushed to the next page.

## HOW
This update changes the `useApiCallStatus` hook to not clear the save status before `router.push` unless it's specifically requested by the hook consumer. This ensures the start page in this use case never renders again before the `router.push` is complete. Also update the start page test to ensure save status is cleared in case of rejected API call.  