### PR TITLE
Fix under 18 local e2e test

### DIFF
--- a/cypress/e2e/local/ineligibleApplicantUnder18.cy.ts
+++ b/cypress/e2e/local/ineligibleApplicantUnder18.cy.ts
@@ -74,3 +74,4 @@ describe('Ineligible main applicant', () => {
       );
     });
   });
+});


### PR DESCRIPTION
Fix a broken test that was missed in the earlier test tidy up [PR](https://github.com/LBHackney-IT/lbh-housing-register/pull/459).