### PR TITLE
TS-1790 update @sentry/nextjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.7",
-        "@sentry/nextjs": "^7.119.0",
+        "@sentry/nextjs": "^7.119.2",
         "axios": "^0.21.1",
         "cookie": "^0.4.2",
         "csv-writer": "^1.6.0",
@@ -3603,62 +3603,62 @@
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.0.tgz",
-      "integrity": "sha512-om8TkAU5CQGO8nkmr7qsSBVkP+/vfeS4JgtW3sjoTK0fhj26+DljR6RlfCGWtYQdPSP6XV7atcPTjbSnsmG9FQ==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.119.2.tgz",
+      "integrity": "sha512-bnR1yJWVBZfXGx675nMXE8hCXsxluCBfIFy9GQT8PTN/urxpoS9cGz+5F7MA7Xe3Q06/7TT0Mz3fcDvjkqTu3Q==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.0.tgz",
-      "integrity": "sha512-NL02VQx6ekPxtVRcsdp1bp5Tb5w6vnfBKSIfMKuDRBy5A10Uc3GSoy/c3mPyHjOxB84452A+xZSx6bliEzAnuA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.119.2.tgz",
+      "integrity": "sha512-Lqo8IFyeKkdOrOGRqm9jCEqeBl8kINe5+c2VqULpkO/I6ql6ISwPSYnmG6yL8cCVIaT1893CLog/pS4FxCv8/Q==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/replay": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry/core": "7.119.2",
+        "@sentry/replay": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.0.tgz",
-      "integrity": "sha512-oKdFJnn+56f0DHUADlL8o9l8jTib3VDLbWQBVkjD9EprxfaCwt2m8L5ACRBdQ8hmpxCEo4I8/6traZ7qAdBUqA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.119.2.tgz",
+      "integrity": "sha512-V2W+STWrafyGJhQv3ulMFXYDwWHiU6wHQAQBShsHVACiFaDrJ2kPRet38FKv4dMLlLlP2xN+ss2e5zv3tYlTiQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.0.tgz",
-      "integrity": "sha512-WwmW1Y4D764kVGeKmdsNvQESZiAn9t8LmCWO0ucBksrjL2zw9gBPtOpRcO6l064sCLeSxxzCN+kIxhRm1gDFEA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.119.2.tgz",
+      "integrity": "sha512-Wb2RzCsJBTNCmS9KPmbVyV5GGzFXjFdUThAN9xlnN5GgemMBwdQjGu/tRYr8yJAVsRb0EOFH8IuJBNKKNnO49g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/feedback": "7.119.0",
-        "@sentry-internal/replay-canvas": "7.119.0",
-        "@sentry-internal/tracing": "7.119.0",
-        "@sentry/core": "7.119.0",
-        "@sentry/integrations": "7.119.0",
-        "@sentry/replay": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry-internal/feedback": "7.119.2",
+        "@sentry-internal/replay-canvas": "7.119.2",
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/replay": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
@@ -3686,27 +3686,27 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.0.tgz",
-      "integrity": "sha512-CS2kUv9rAJJEjiRat6wle3JATHypB0SyD7pt4cpX5y0dN5dZ1JrF57oLHRMnga9fxRivydHz7tMTuBhSSwhzjw==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.119.2.tgz",
+      "integrity": "sha512-hQr3d2yWq/2lMvoyBPOwXw1IHqTrCjOsU1vYKhAa6w9vGbJZFGhKGGE2KEi/92c3gqGn+gW/PC7cV6waCTDuVA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.0.tgz",
-      "integrity": "sha512-OHShvtsRW0A+ZL/ZbMnMqDEtJddPasndjq+1aQXw40mN+zeP7At/V1yPZyFaURy86iX7Ucxw5BtmzuNy7hLyTA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.119.2.tgz",
+      "integrity": "sha512-dCuXKvbUE3gXVVa696SYMjlhSP6CxpMH/gl4Jk26naEB8Xjsn98z/hqEoXLg6Nab73rjR9c/9AdKqBbwVMHyrQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0",
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2",
         "localforage": "^1.8.1"
       },
       "engines": {
@@ -3714,23 +3714,23 @@
       }
     },
     "node_modules/@sentry/nextjs": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-7.119.0.tgz",
-      "integrity": "sha512-D2P0LmgQbF/d7Ar6u2OKj+strM1id6OFfsHAKeTYd6KVipwc4YBpbS5OYkwH3BhtofCXvtfU3VmayVJD1onOiw==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-7.119.2.tgz",
+      "integrity": "sha512-lIhWohka8kNeBd31uIgrid27t7C2MVhAz5ZElAvmOuxKJJOKB4ctgC9DYwSs31KX9ep/kR2MqDgN9qM3+cJ0Zw==",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "24.0.0",
-        "@sentry/core": "7.119.0",
-        "@sentry/integrations": "7.119.0",
-        "@sentry/node": "7.119.0",
-        "@sentry/react": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0",
-        "@sentry/vercel-edge": "7.119.0",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/node": "7.119.2",
+        "@sentry/react": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2",
+        "@sentry/vercel-edge": "7.119.2",
         "@sentry/webpack-plugin": "1.21.0",
         "chalk": "3.0.0",
         "resolve": "1.22.8",
-        "rollup": "2.78.0",
+        "rollup": "2.79.2",
         "stacktrace-parser": "^0.1.10"
       },
       "engines": {
@@ -3815,31 +3815,31 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.119.0.tgz",
-      "integrity": "sha512-9PFzN8xS6U0oZCflpVxS2SSIsHkCaj7qYBlsvHj4CTGWfao9ImwrU6+smy4qoG6oxwPfoVb5pOOMb4WpWOvXcQ==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.119.2.tgz",
+      "integrity": "sha512-TPNnqxh+Myooe4jTyRiXrzrM2SH08R4+nrmBls4T7lKp2E5R/3mDSe/YTn5rRcUt1k1hPx1NgO/taG0DoS5cXA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.119.0",
-        "@sentry/core": "7.119.0",
-        "@sentry/integrations": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.119.0.tgz",
-      "integrity": "sha512-cf8Cei+qdSA26gx+IMAuc/k44PeBImNzIpXi3930SLhUe44ypT5OZ/44L6xTODHZzTIyMSJPduf59vT2+eW9yg==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.119.2.tgz",
+      "integrity": "sha512-fE48R/mtb/bpc4/YVvKurKSAZ0ueUI5Ma0cVSr/Fi09rFdGwLRMcweM1UydREO/ILiyt8FezyZg7L20VAp4/TQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "7.119.0",
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0",
+        "@sentry/browser": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2",
         "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
@@ -3850,52 +3850,52 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.0.tgz",
-      "integrity": "sha512-BnNsYL+X5I4WCH6wOpY6HQtp4MgVt0NVlhLUsEyrvMUiTs0bPkDBrulsgZQBUKJsbOr3l9nHrFoNVB/0i6WNLA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.119.2.tgz",
+      "integrity": "sha512-nHDsBt0mlJXTWAHjzQdCzDbhV2fv8B62PPB5mu5SpI+G5h+ir3r5lR0lZZrMT8eurVowb/HnLXAs+XYVug3blg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.119.0",
-        "@sentry/core": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.0.tgz",
-      "integrity": "sha512-27qQbutDBPKGbuJHROxhIWc1i0HJaGLA90tjMu11wt0E4UNxXRX+UQl4Twu68v4EV3CPvQcEpQfgsViYcXmq+w==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.119.2.tgz",
+      "integrity": "sha512-ydq1tWsdG7QW+yFaTp0gFaowMLNVikIqM70wxWNK+u98QzKnVY/3XTixxNLsUtnAB4Y+isAzFhrc6Vb5GFdFeg==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.0.tgz",
-      "integrity": "sha512-ZwyXexWn2ZIe2bBoYnXJVPc2esCSbKpdc6+0WJa8eutXfHq3FRKg4ohkfCBpfxljQGEfP1+kfin945lA21Ka+A==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.119.2.tgz",
+      "integrity": "sha512-TLdUCvcNgzKP0r9YD7tgCL1PEUp42TObISridsPJ5rhpVGQJvpr+Six0zIkfDUxerLYWZoK8QMm9KgFlPLNQzA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.119.0"
+        "@sentry/types": "7.119.2"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/vercel-edge": {
-      "version": "7.119.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-7.119.0.tgz",
-      "integrity": "sha512-9gi5SrBSHhHFYBq/+vG1qC9r80eEskCf7ti/qYSvXc6zij5ieilurF5tunyAle+ayxfHdPTdkhUnDZT6G9jdmA==",
+      "version": "7.119.2",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-7.119.2.tgz",
+      "integrity": "sha512-EEWjqp7WoTuS08+cVh2+Dh5TLdW1vgRwjL/UkHcQ+ZMG3OfVq6OlYf/7NCyf8NrwruXQslV/H2RwamCsbeUT1w==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.119.0",
-        "@sentry/core": "7.119.0",
-        "@sentry/integrations": "7.119.0",
-        "@sentry/types": "7.119.0",
-        "@sentry/utils": "7.119.0"
+        "@sentry-internal/tracing": "7.119.2",
+        "@sentry/core": "7.119.2",
+        "@sentry/integrations": "7.119.2",
+        "@sentry/types": "7.119.2",
+        "@sentry/utils": "7.119.2"
       },
       "engines": {
         "node": ">=8"
@@ -15346,9 +15346,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.78.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.0.tgz",
-      "integrity": "sha512-4+YfbQC9QEVvKTanHhIAFVUFSRsezvQF8vFOJwtGfb9Bb+r014S+qryr9PSmw8x6sMnPkmFBGAvIFVQxvJxjtg==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.7",
-    "@sentry/nextjs": "^7.119.0",
+    "@sentry/nextjs": "^7.119.2",
     "axios": "^0.21.1",
     "cookie": "^0.4.2",
     "csv-writer": "^1.6.0",


### PR DESCRIPTION
Update `@sentry/nextjs` to version `7.119.2` to resolve security vulnerability in the `rollup` library. https://github.com/getsentry/sentry-javascript/releases/tag/7.119.2