### PR TITLE
TS-1793 improve sonar reliability scrore

### DIFF
--- a/lib/store/apiCallsStatus.ts
+++ b/lib/store/apiCallsStatus.ts
@@ -53,9 +53,6 @@ export const hrApiCallsStatus = createSlice({
           callStatus: ApiCallStatusCode.REJECTED,
           error: action.payload as string,
         };
-      })
-      .addDefaultCase(() => {
-        initialState;
       });
   },
 });

--- a/pages/apply/[resident]/your-situation.tsx
+++ b/pages/apply/[resident]/your-situation.tsx
@@ -37,12 +37,6 @@ const YourSituation = (): JSX.Element => {
   );
   const saveApplicationStatus = useAppSelector(selectSaveApplicationStatus);
 
-  if (!applicant) {
-    return <Custom404 />;
-  }
-
-  const baseHref = `/apply/${applicant.person?.id}`;
-
   useEffect(() => {
     if (saveApplicationStatus?.callStatus === ApiCallStatusCode.FULFILLED) {
       setIsSaving(false);
@@ -56,6 +50,12 @@ const YourSituation = (): JSX.Element => {
       scrollToError();
     }
   }, [saveApplicationStatus?.callStatus]);
+
+  if (!applicant) {
+    return <Custom404 />;
+  }
+
+  const baseHref = `/apply/${applicant.person?.id}`;
 
   // If JSON has routeSelect set to true we can pass multiple possible values to activeStepID.
   // See if statement at end of nextStep() below


### PR DESCRIPTION
## WHAT
SonarCloud has flagged two issues that affect the app's reliability. This update addresses those issues.

## WHY
We want to aim for a reliability score 'A', so any issues that prevents us getting there should be fixed.

## HOW
1. Address _"Expected an assignment or function call and instead saw an expression"_ issue by removig the `.addDefaultcase` from the `hrApiCallsStatus` slice altogether. This slice has extra reducers only and the default state is set on init, so it's not necessary to have the defaultCase in place.
2. Address _"React Hook "useEffect" is called conditionally"_ issue by moving the 404 return after `useEffect` 