### PR TITLE
Configures sentry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,20 +246,18 @@ workflows:
                 - development
       - assume-role-development:
           context: api-assume-role-housing-development-context
-          # requires:
-          #   - run-cypress-e2e
           requires:
-            - install-dependencies
+            - run-cypress-e2e
           filters:
             branches:
-              only: TS-1788-HR-staging-check-Sentry-for-new-errors-after-testing
+              only: development
       - build-deploy-development:
           context: housing-register-fe-build-context
           requires:
             - assume-role-development
           filters:
             branches:
-              only: TS-1788-HR-staging-check-Sentry-for-new-errors-after-testing
+              only: development
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,18 +246,18 @@ workflows:
                 - development
       - assume-role-development:
           context: api-assume-role-housing-development-context
-          requires:
-            - run-cypress-e2e
+          # requires:
+          #   - run-cypress-e2e
           filters:
             branches:
-              only: development
+              only: TS-1788-HR-staging-check-Sentry-for-new-errors-after-testing
       - build-deploy-development:
           context: housing-register-fe-build-context
           requires:
             - assume-role-development
           filters:
             branches:
-              only: development
+              only: TS-1788-HR-staging-check-Sentry-for-new-errors-after-testing
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,6 +248,8 @@ workflows:
           context: api-assume-role-housing-development-context
           # requires:
           #   - run-cypress-e2e
+          requires:
+            - install-dependencies
           filters:
             branches:
               only: TS-1788-HR-staging-check-Sentry-for-new-errors-after-testing

--- a/next.config.js
+++ b/next.config.js
@@ -52,10 +52,7 @@ const nextConfig = {
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
 module.exports = withSentryConfig(nextConfig, {
-  authToken: process.env.SENTRY_AUTH_TOKEN,
-  org: process.env.SENTRY_ORG,
-  project: process.env.SENTRY_PROJECT,
+  // Senty token, project, and org are all set in the build proceess.
   silent: true, // Suppresses all logs
   hideSourceMaps: true, // Will make sourcemaps invisible to the browser.
-  debug: true, // Will display some useful console logs.
 });

--- a/next.config.js
+++ b/next.config.js
@@ -38,21 +38,12 @@ const nextConfig = {
     // for staged files only as we clear the linting errors as we work.
     ignoreDuringBuilds: true,
   },
-  // ensure sentry debug is false during build process
-  // webpack: (config, { webpack }) => {
-  //   config.plugins.push(
-  //     new webpack.DefinePlugin({
-  //       __SENTRY_DEBUG__: false,
-  //     })
-  //   );
-  //   return config;
-  // },
 };
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
 module.exports = withSentryConfig(nextConfig, {
-  // Senty token, project, and org are all set in the build proceess.
+  // Senty token, project, and org are all set in the build proceess and are not necassary to be set here.
   silent: true, // Suppresses all logs
   hideSourceMaps: true, // Will make sourcemaps invisible to the browser.
 });

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -17,14 +17,8 @@ Sentry.init({
   // that it will also get attached to your source maps
 
   environment: ENVIRONMENT,
-  integrations: [
-    Sentry.browserTracingIntegration(),
-    Sentry.captureConsoleIntegration(),
-  ],
-  enabled:
-    ENVIRONMENT === 'production' ||
-    ENVIRONMENT === 'staging' ||
-    ENVIRONMENT === 'development',
+  integrations: [Sentry.captureConsoleIntegration()],
+  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging',
 
   // remove cookies from the event before sending
   beforeSend(event) {

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -17,7 +17,10 @@ Sentry.init({
   // that it will also get attached to your source maps
 
   environment: ENVIRONMENT,
-  integrations: [Sentry.captureConsoleIntegration()],
+  integrations: [
+    Sentry.browserTracingIntegration(),
+    Sentry.captureConsoleIntegration(),
+  ],
   enabled:
     ENVIRONMENT === 'production' ||
     ENVIRONMENT === 'staging' ||

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -18,7 +18,10 @@ Sentry.init({
 
   environment: ENVIRONMENT,
   integrations: [Sentry.captureConsoleIntegration()],
-  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging',
+  enabled:
+    ENVIRONMENT === 'production' ||
+    ENVIRONMENT === 'staging' ||
+    ENVIRONMENT === 'development',
 
   // remove cookies from the event before sending
   beforeSend(event) {

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -8,7 +8,7 @@ const ENVIRONMENT = process.env.NEXT_PUBLIC_ENV;
 
 Sentry.init({
   dsn:
-    'https://6fb0dd07e0fc4a75b0ab84b8e1f36460@o183917.ingest.sentry.io/6292602',
+    'https://6fb0dd07e0fc4a75b0ab84b8e1f36460@o183917.ingest.us.sentry.io/6292602',
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,
   // ...
@@ -16,18 +16,20 @@ Sentry.init({
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
 
-  environment: process.env.NEXT_PUBLIC_ENV,
+  environment: ENVIRONMENT,
   integrations: [Sentry.captureConsoleIntegration()],
   enabled:
     ENVIRONMENT === 'production' ||
     ENVIRONMENT === 'staging' ||
     ENVIRONMENT === 'development',
+
+  // remove cookies from the event before sending
   beforeSend(event) {
     if (event.request?.cookies['hackneyToken']) {
-      event.request.cookies['hackneyToken'] = '[FilteredBeforeSend]';
+      delete event.request.cookies['hackneyToken'];
     }
     if (event.request?.cookies['housing_user']) {
-      event.request.cookies['housing_user'] = '[FilteredBeforeSend]';
+      delete event.request.cookies['housing_user'];
     }
     return event;
   },

--- a/sentry.edge.config.js
+++ b/sentry.edge.config.js
@@ -13,7 +13,10 @@ Sentry.init({
   tracesSampleRate: 1.0,
   environment: ENVIRONMENT,
   integrations: [Sentry.captureConsoleIntegration()],
-  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging',
+  enabled:
+    ENVIRONMENT === 'production' ||
+    ENVIRONMENT === 'staging' ||
+    ENVIRONMENT === 'development',
 
   // remove cookies from the event before sending
   beforeSend(event) {

--- a/sentry.edge.config.js
+++ b/sentry.edge.config.js
@@ -13,10 +13,7 @@ Sentry.init({
   tracesSampleRate: 1.0,
   environment: ENVIRONMENT,
   integrations: [Sentry.captureConsoleIntegration()],
-  enabled:
-    ENVIRONMENT === 'production' ||
-    ENVIRONMENT === 'staging' ||
-    ENVIRONMENT === 'development',
+  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging',
 
   // remove cookies from the event before sending
   beforeSend(event) {

--- a/sentry.edge.config.js
+++ b/sentry.edge.config.js
@@ -9,20 +9,22 @@ const ENVIRONMENT = process.env.NEXT_PUBLIC_ENV;
 
 Sentry.init({
   dsn:
-    'https://6fb0dd07e0fc4a75b0ab84b8e1f36460@o183917.ingest.sentry.io/6292602',
+    'https://6fb0dd07e0fc4a75b0ab84b8e1f36460@o183917.ingest.us.sentry.io/6292602',
   tracesSampleRate: 1.0,
-  environment: process.env.NEXT_PUBLIC_ENV,
+  environment: ENVIRONMENT,
   integrations: [Sentry.captureConsoleIntegration()],
   enabled:
     ENVIRONMENT === 'production' ||
     ENVIRONMENT === 'staging' ||
     ENVIRONMENT === 'development',
+
+  // remove cookies from the event before sending
   beforeSend(event) {
     if (event.request?.cookies['hackneyToken']) {
-      event.request.cookies['hackneyToken'] = '[FilteredBeforeSend]';
+      delete event.request.cookies['hackneyToken'];
     }
     if (event.request?.cookies['housing_user']) {
-      event.request.cookies['housing_user'] = '[FilteredBeforeSend]';
+      delete event.request.cookies['housing_user'];
     }
     return event;
   },

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -18,7 +18,10 @@ Sentry.init({
 
   environment: ENVIRONMENT,
   integrations: [Sentry.captureConsoleIntegration()],
-  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging',
+  enabled:
+    ENVIRONMENT === 'production' ||
+    ENVIRONMENT === 'staging' ||
+    ENVIRONMENT === 'development',
 
   // remove cookies from the event before sending
   beforeSend(event) {

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -8,7 +8,7 @@ const ENVIRONMENT = process.env.NEXT_PUBLIC_ENV;
 
 Sentry.init({
   dsn:
-    'https://6fb0dd07e0fc4a75b0ab84b8e1f36460@o183917.ingest.sentry.io/6292602',
+    'https://6fb0dd07e0fc4a75b0ab84b8e1f36460@o183917.ingest.us.sentry.io/6292602',
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,
   // ...
@@ -16,18 +16,20 @@ Sentry.init({
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
 
-  environment: process.env.NEXT_PUBLIC_ENV,
+  environment: ENVIRONMENT,
   integrations: [Sentry.captureConsoleIntegration()],
   enabled:
     ENVIRONMENT === 'production' ||
     ENVIRONMENT === 'staging' ||
     ENVIRONMENT === 'development',
+
+  // remove cookies from the event before sending
   beforeSend(event) {
     if (event.request?.cookies['hackneyToken']) {
-      event.request.cookies['hackneyToken'] = '[FilteredBeforeSend]';
+      delete event.request.cookies['hackneyToken'];
     }
     if (event.request?.cookies['housing_user']) {
-      event.request.cookies['housing_user'] = '[FilteredBeforeSend]';
+      delete event.request.cookies['housing_user'];
     }
     return event;
   },

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -18,10 +18,7 @@ Sentry.init({
 
   environment: ENVIRONMENT,
   integrations: [Sentry.captureConsoleIntegration()],
-  enabled:
-    ENVIRONMENT === 'production' ||
-    ENVIRONMENT === 'staging' ||
-    ENVIRONMENT === 'development',
+  enabled: ENVIRONMENT === 'production' || ENVIRONMENT === 'staging',
 
   // remove cookies from the event before sending
   beforeSend(event) {


### PR DESCRIPTION
**What**

- Sets the Sentry DSN to the value from sentry
- Reverts setting sentry vars in the next.config as they're set in Pipeline
- Cleans up duplications of ENVIRONMENT in sentry configs
- Deletes the hackney token rather than changing it's value if sent to sentry

