### PR TITLE
Ts 1810 housing register ethnicity questions

### DIFF
--- a/cypress/e2e/local/eligibleApplicantWithMedicalCondition.cy.ts
+++ b/cypress/e2e/local/eligibleApplicantWithMedicalCondition.cy.ts
@@ -22,6 +22,7 @@ import {
   visitHomepageSignInAndVerify,
 } from '../../support/locale2eTestsHelper';
 import { interceptAddressSearchAPI } from '../../support/intercepts';
+import Components from '../../pages/components';
 
 //ensure age doesn't automatically make applicant eligible
 const birthDate = faker.date.birthdate({ mode: 'age', min: 18, max: 40 });
@@ -186,7 +187,19 @@ describe('Applicant with medical condition', () => {
       cy.get('.lbh-button').contains('Save and continue').click();
       cy.get('.lbh-button').contains('Save and continue').click();
 
-      cy.get(`[data-testid="test-radio-ethnicity-main-category.0"]`).check();
+      // get the first ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
+
+      ApplyResidentSectionPage.getSubmitButton().click();
+
+      // get the second ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
       ApplyResidentSectionPage.getSubmitButton().click();
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();
       DeclarationPage.getSubmitButton().click();

--- a/cypress/e2e/local/eligibleApplicantsBothOver55.cy.ts
+++ b/cypress/e2e/local/eligibleApplicantsBothOver55.cy.ts
@@ -25,6 +25,7 @@ import {
   SignUpFormDetails,
   visitHomepageSignInAndVerify,
 } from '../../support/locale2eTestsHelper';
+import Components from '../../pages/components';
 
 //ensure eligibility: both over 55
 const mainApplicantBirthDate = faker.date.birthdate({
@@ -267,7 +268,20 @@ describe('Applicant and household member both over 55', () => {
       cy.get('.lbh-button').contains('Save and continue').click();
       cy.get('.lbh-button').contains('Save and continue').click();
 
-      cy.get(`[data-testid="test-radio-ethnicity-main-category.0"]`).check();
+      // get the first ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
+
+      ApplyResidentSectionPage.getSubmitButton().click();
+
+      // get the second ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
+
       ApplyResidentSectionPage.getSubmitButton().click();
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();
       DeclarationPage.getSubmitButton().click();

--- a/cypress/e2e/local/eligibleApplicationWithHouseholdMembers.cy.ts
+++ b/cypress/e2e/local/eligibleApplicationWithHouseholdMembers.cy.ts
@@ -25,6 +25,7 @@ import {
   visitHomepageSignInAndVerify,
 } from '../../support/locale2eTestsHelper';
 import { interceptAddressSearchAPI } from '../../support/intercepts';
+import Components from '../../pages/components';
 
 const mainApplicantBirthDate = faker.date.birthdate({
   mode: 'age',
@@ -330,7 +331,20 @@ describe('Add and remove household members', () => {
       cy.get('.lbh-button').contains('Save and continue').click();
       cy.get('.lbh-button').contains('Save and continue').click();
 
-      cy.get(`[data-testid="test-radio-ethnicity-main-category.0"]`).check();
+      // get the first ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
+
+      ApplyResidentSectionPage.getSubmitButton().click();
+
+      // get the second ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
+
       ApplyResidentSectionPage.getSubmitButton().click();
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();
       DeclarationPage.getSubmitButton().click();

--- a/cypress/e2e/local/eligibleMainApplicantOnlyOver55.cy.ts
+++ b/cypress/e2e/local/eligibleMainApplicantOnlyOver55.cy.ts
@@ -23,6 +23,7 @@ import {
   SignUpFormDetails,
   visitHomepageSignInAndVerify,
 } from '../../support/locale2eTestsHelper';
+import Components from '../../pages/components';
 
 //ensure eligibility: over 55 and alone
 const birthDate = faker.date.birthdate({ mode: 'age', min: 56, max: 90 });
@@ -208,7 +209,20 @@ describe('Single main applicant, over 55', () => {
       cy.get('.lbh-button').contains('Save and continue').click();
       cy.get('.lbh-button').contains('Save and continue').click();
 
-      cy.get(`[data-testid="test-radio-ethnicity-main-category.0"]`).check();
+      // get the first ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
+
+      ApplyResidentSectionPage.getSubmitButton().click();
+
+      // get the second ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
+
       ApplyResidentSectionPage.getSubmitButton().click();
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();
       DeclarationPage.getSubmitButton().click();

--- a/cypress/e2e/local/managerActions.cy.ts
+++ b/cypress/e2e/local/managerActions.cy.ts
@@ -26,6 +26,7 @@ import {
 } from '../../support/locale2eTestsHelper';
 import { interceptAddressSearchAPI } from '../../support/intercepts';
 import AddHouseholdMemberPage from '../../pages/applications/edit/add-household-member';
+import Components from '../../pages/components';
 
 const mainApplicantBirthDate = faker.date.birthdate({
   mode: 'age',
@@ -331,7 +332,19 @@ describe('Manager actions', () => {
       cy.get('.lbh-button').contains('Save and continue').click();
       cy.get('.lbh-button').contains('Save and continue').click();
 
-      cy.get(`[data-testid="test-radio-ethnicity-main-category.0"]`).check();
+      // get the first ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
+
+      ApplyResidentSectionPage.getSubmitButton().click();
+
+      // get the second ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
       ApplyResidentSectionPage.getSubmitButton().click();
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();
       DeclarationPage.getSubmitButton().click();

--- a/cypress/e2e/local/sampleForSingleEligibleApplicant.cy.ts
+++ b/cypress/e2e/local/sampleForSingleEligibleApplicant.cy.ts
@@ -22,6 +22,7 @@ import {
   visitHomepageSignInAndVerify,
 } from '../../support/locale2eTestsHelper';
 import { interceptAddressSearchAPI } from '../../support/intercepts';
+import Components from '../../pages/components';
 
 //ensure eligibility: over 55 and alone
 const birthDate = faker.date.birthdate({ mode: 'age', min: 56, max: 90 });
@@ -197,7 +198,20 @@ describe('Single main applicant, over 55', () => {
       cy.get('.lbh-button').contains('Save and continue').click();
       cy.get('.lbh-button').contains('Save and continue').click();
 
-      cy.get(`[data-testid="test-radio-ethnicity-main-category.0"]`).check();
+      // get the first ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
+
+      ApplyResidentSectionPage.getSubmitButton().click();
+
+      // get the second ethnicity radio button.
+      Components.getRadioButtons().then((radioButtons) => {
+        const randomIndex = Math.floor(Math.random() * radioButtons.length);
+        radioButtons[randomIndex].click();
+      });
+
       ApplyResidentSectionPage.getSubmitButton().click();
 
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();

--- a/cypress/e2e/pages/apply/submit/ethnicityQuestions.cy.ts
+++ b/cypress/e2e/pages/apply/submit/ethnicityQuestions.cy.ts
@@ -63,6 +63,13 @@ describe('Ethnicity questions', () => {
       apiResponseDelay
     );
 
+    // nested form second patch
+    cy.mockHousingRegisterApiPatchApplication(
+      applicationId,
+      applicationWithMainApplicant,
+      apiResponseDelay
+    );
+
     cy.mockHousingRegisterApiGetApplications(
       applicationId,
       applicationWithMainApplicant
@@ -71,7 +78,17 @@ describe('Ethnicity questions', () => {
     EthnicityPage.visit();
     EthnicityPage.getEthnicityPage().should('be.visible');
 
-    Components.getRadioButtons().first().click();
+    Components.getRadioButtons().then((radioButtons) => {
+      const randomIndex = Math.floor(Math.random() * radioButtons.length);
+      radioButtons[randomIndex].click();
+    });
+
+    Components.getSaveButton().click();
+
+    Components.getRadioButtons().then((radioButtons) => {
+      const randomIndex = Math.floor(Math.random() * radioButtons.length);
+      radioButtons[randomIndex].click();
+    });
 
     Components.getSaveButton().click();
 

--- a/lib/hooks/useApiCallStatus.tsx
+++ b/lib/hooks/useApiCallStatus.tsx
@@ -8,7 +8,7 @@ import { ParsedUrlQueryInput } from 'querystring';
 interface UseApiCallStatusProps {
   selector: ApiCallStatus | undefined;
   userActionCompleted: boolean;
-  pathToPush: string;
+  pathToPush: string | null;
   query?: ParsedUrlQueryInput;
   setUserError: (error: string) => void;
   scrollToError: () => void;
@@ -44,7 +44,8 @@ const useApiCallStatus = ({
 
     if (
       selector?.callStatus === ApiCallStatusCode.FULFILLED &&
-      userActionCompleted
+      userActionCompleted &&
+      pathToPush
     ) {
       router.push({
         pathname: pathToPush,

--- a/pages/apply/submit/ethnicity-questions.tsx
+++ b/pages/apply/submit/ethnicity-questions.tsx
@@ -25,6 +25,7 @@ const EthnicityQuestions = (): JSX.Element => {
   const [formId, setFormId] = useState('ethnicity-questions');
   const [hasSaved, setHasSaved] = useState<boolean>(false);
   const [userError, setUserError] = useState<string | null>(null);
+  const [path, setPath] = useState<string | null>(null);
   const saveApplicationStatus = useAppSelector(selectSaveApplicationStatus);
   const [activeStepID, setActiveStepId] = useState(() => {
     switch (formId) {
@@ -53,7 +54,7 @@ const EthnicityQuestions = (): JSX.Element => {
     selector: saveApplicationStatus,
     userActionCompleted: hasSaved,
     setUserError,
-    pathToPush: '/apply/submit/declaration',
+    pathToPush: path,
     scrollToError,
   });
 
@@ -76,6 +77,7 @@ const EthnicityQuestions = (): JSX.Element => {
             markAsComplete: true,
           })
         );
+        setPath('/apply/submit/declaration');
         setHasSaved(true);
       } catch (error) {
         console.error('Error saving agreement:', error);
@@ -118,7 +120,7 @@ const EthnicityQuestions = (): JSX.Element => {
           {userError}
         </ErrorSummary>
       )}
-      {pendingStatus ? (
+      {pendingStatus && path ? (
         <Loading text="Saving..." />
       ) : (
         <Form


### PR DESCRIPTION
https://hackney.atlassian.net/browse/TS-1810?atlOrigin=eyJpIjoiOGY4NzA4OTVkZTQxNDkwMWExMjIxYjJhZWIyMWIzODQiLCJwIjoiaiJ9

**What**
User testing noted an error with the setting of ethnicity data.

Previously, the useApiCall status hook was pushing to the next page after data was saved. In the case of the ethnicity page, the second part of the form on the page was being skipped over after the initial save event. This change addresses this, so a user can set values in the second level of the form.

**Why**
Makes the hook more flexible to scenarios like this and ensures the user can engage with the whole form.

**How**
This changes the hook so if a path isn't provided, it won't push to a new page. In the case of this page, the path is only set on the final step of the ethnicity form.
