### PR TITLE
Speed up end to end tests in CircleCI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,10 @@ jobs:
     executor: aws-cli/default
     steps:
       - checkout
+      - aws_assume_role/assume_role:
+          account: $AWS_ACCOUNT_DEVELOPMENT
+          profile_name: default
+          role: 'LBH_Circle_CI_Deployment_Role'
       - node/install-packages
       - run:
           name: deploy
@@ -168,6 +172,10 @@ jobs:
     executor: aws-cli/default
     steps:
       - checkout
+      - aws_assume_role/assume_role:
+          account: $AWS_ACCOUNT_STAGING
+          profile_name: default
+          role: 'LBH_Circle_CI_Deployment_Role'
       - node/install-packages
       - run:
           name: deploy
@@ -177,49 +185,14 @@ jobs:
     executor: aws-cli/default
     steps:
       - checkout
-      - node/install-packages
-      - run:
-          name: deploy
-          command: npm run build && sudo npm i -g serverless@^3 && sls deploy --stage production
-
-  assume-role-development:
-    executor: docker-python
-    steps:
-      - checkout
-      - aws_assume_role/assume_role:
-          account: $AWS_ACCOUNT_DEVELOPMENT
-          profile_name: default
-          role: 'LBH_Circle_CI_Deployment_Role'
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - .aws
-
-  assume-role-staging:
-    executor: docker-python
-    steps:
-      - checkout
-      - aws_assume_role/assume_role:
-          account: $AWS_ACCOUNT_STAGING
-          profile_name: default
-          role: 'LBH_Circle_CI_Deployment_Role'
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - .aws
-
-  assume-role-production:
-    executor: docker-python
-    steps:
-      - checkout
       - aws_assume_role/assume_role:
           account: $AWS_ACCOUNT_PRODUCTION
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - .aws
+      - node/install-packages
+      - run:
+          name: deploy
+          command: npm run build && sudo npm i -g serverless@^3 && sls deploy --stage production
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
@@ -227,6 +200,7 @@ workflows:
   continuous-delivery:
     jobs:
       - run-tests
+
       - run-cypress-e2e:
           matrix:
             parameters:
@@ -236,40 +210,34 @@ workflows:
               # mobile, tablet, chromebook, desktop
               width: [320, 1024, 1366, 1536]
             exclude: *exclude_combinations
+
       - sonar-scan:
           context: SonarCloud
           requires:
             - run-tests
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
-          requires:
-            - run-tests
-            - run-cypress-e2e
-          filters:
-            branches:
-              only: development
+
       - build-deploy-development:
-          context: housing-register-fe-build-context
+          context:
+            - api-assume-role-housing-development-context
+            - housing-register-fe-build-context
           requires:
-            - assume-role-development
+            - run-tests
+            - run-cypress-e2e
           filters:
             branches:
               only: development
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
+
+      - build-deploy-staging:
+          context:
+            - api-assume-role-housing-staging-context
+            - housing-register-fe-build-context
           requires:
             - run-tests
             - run-cypress-e2e
           filters:
             branches:
               only: main
-      - build-deploy-staging:
-          context: housing-register-fe-build-context
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: main
+
       - permit-deploy-production:
           type: approval
           requires:
@@ -277,17 +245,13 @@ workflows:
           filters:
             branches:
               only: main
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
+
+      - build-deploy-production:
+          context:
+            - api-assume-role-housing-production-context
+            - housing-register-fe-build-context
           requires:
             - permit-deploy-production
-          filters:
-            branches:
-              only: main
-      - build-deploy-production:
-          context: housing-register-fe-build-context
-          requires:
-            - assume-role-production
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,10 +95,6 @@ jobs:
           path: test_results
       - store_artifacts:
           path: coverage
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - .
 
   sonar-scan:
     executor: node-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   aws-cli: circleci/aws-cli@3.2.0
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
   cypress: cypress-io/cypress@3.3.1
+  node: circleci/node@6.3.0
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 executors:
@@ -80,29 +81,11 @@ exclude_combinations:
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Jobs ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 jobs:
-  install-dependencies:
-    executor: node-executor
-    steps:
-      - *attach_workspace
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: Install Dependencies
-          command: npm install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
-            - ./.next/cache
-            - ./.cache/Cypress
-      - persist_to_workspace:
-          root: *workspace_root
-          paths: .
-
   run-tests:
     executor: node-executor
     steps:
+      - checkout
+      - node/install-packages
       - cypress/install:
           package-manager: npm
           install-command: npm install
@@ -126,7 +109,8 @@ jobs:
   sonar-scan:
     executor: node-executor
     steps:
-      - *attach_workspace
+      - checkout
+      - node/install-packages
       - sonarcloud/scan
 
   run-cypress-e2e:
@@ -142,6 +126,8 @@ jobs:
         type: integer
         default: 1366
     steps:
+      - checkout
+      - node/install-packages
       - cypress/install:
           package-manager: npm
           install-browsers: true
@@ -155,7 +141,8 @@ jobs:
   build-deploy-development:
     executor: aws-cli/default
     steps:
-      - *attach_workspace
+      - checkout
+      - node/install-packages
       - run:
           name: deploy
           command: npm run build && sudo npm i -g serverless@^3 && sls deploy --stage development
@@ -163,7 +150,8 @@ jobs:
   build-deploy-staging:
     executor: aws-cli/default
     steps:
-      - *attach_workspace
+      - checkout
+      - node/install-packages
       - run:
           name: deploy
           command: npm run build && sudo npm i -g serverless@^3 && sls deploy --stage staging
@@ -171,7 +159,8 @@ jobs:
   build-deploy-production:
     executor: aws-cli/default
     steps:
-      - *attach_workspace
+      - checkout
+      - node/install-packages
       - run:
           name: deploy
           command: npm run build && sudo npm i -g serverless@^3 && sls deploy --stage production
@@ -220,13 +209,8 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - install-dependencies
-      - run-tests:
-          requires:
-            - install-dependencies
+      - run-tests
       - run-cypress-e2e:
-          requires:
-            - install-dependencies
           matrix:
             parameters:
               browser: [chrome, firefox]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
 
   run-cypress-e2e:
     executor: cypress-e2e-executor
+    parallelism: 8
     parameters:
       browser:
         type: string
@@ -133,10 +134,26 @@ jobs:
           install-browsers: true
           install-command: npm install
           post-install: npm run build
+      - run:
+          name: Split E2E tests for parallel run
+          command: |
+            find cypress/e2e -type f -name "*.[jt]s" | sort | uniq > circleci_test_files.txt
+            # Use time-based splitting for maximum efficiency. Cypress expects files to be separated with commas
+            circleci tests split --split-by=timings circleci_test_files.txt | perl -pe 'chomp if eof' | tr '\n' ',' > circleci_test_slice.txt
+            cat circleci_test_slice.txt
       - cypress/run-tests:
-          cypress-command: npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=test_results/cypress-e2e-[hash].xml"
+          cypress-command: npx cypress run --browser=<< parameters.browser >> --config viewportHeight=<< parameters.height >>,viewportWidth=<< parameters.width >> --reporter junit --reporter-options "mochaFile=cypress/results/results-[hash].xml" --spec "$(cat circleci_test_slice.txt)"
+      - run:
+          name: Fix up JUnit output
+          command: node scripts/fix-junit-xml.js
+
+      # Store the test results so CircleCI can provide insights and do parallel test splitting
       - store_test_results:
-          path: test_results
+          path: cypress/results
+
+      # We also store the test results as an artefact so we can download/access them when we need
+      - store_artifacts:
+          path: cypress/results
 
   build-deploy-development:
     executor: aws-cli/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,6 @@ executors:
   node-executor:
     docker:
       - image: cimg/node:20.17-browsers
-  docker-python:
-    docker:
-      - image: cimg/python:3.7
-  cypress-e2e-executor:
-    docker:
-      - image: cimg/node:20.17-browsers
 
 references:
   workspace_root: &workspace_root '~'
@@ -114,7 +108,7 @@ jobs:
       - sonarcloud/scan
 
   run-cypress-e2e:
-    executor: cypress-e2e-executor
+    executor: node-executor
     parallelism: 8
     parameters:
       browser:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,6 @@ jobs:
     executor: node-executor
     steps:
       - checkout
-      - node/install-packages
       - sonarcloud/scan
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ jobs:
 
   run-cypress-e2e:
     executor: node-executor
+    resource_class: medium+
     parallelism: 8
     parameters:
       browser:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
       - image: cimg/node:20.17-browsers
 
 references:
-  workspace_root: &workspace_root '~'
+  workspace_root: &workspace_root '.'
   attach_workspace: &attach_workspace
     attach_workspace:
       at: *workspace_root
@@ -107,6 +107,19 @@ jobs:
       - node/install-packages
       - sonarcloud/scan
 
+  build:
+    executor: node-executor
+    steps:
+      - checkout
+      - node/install-packages
+      - run:
+          name: Build Next application
+          command: npm run build
+      - persist_to_workspace:
+          root: *workspace_root
+          paths:
+            - build
+
   run-cypress-e2e:
     executor: node-executor
     parallelism: 8
@@ -121,13 +134,9 @@ jobs:
         type: integer
         default: 1366
     steps:
-      - checkout
-      - node/install-packages
+      # cypress/install checks out the code, installs dependencies (including NPM), etc. It uses optimal caching strategies for NPM with npm ci.
       - cypress/install:
-          package-manager: npm
           install-browsers: true
-          install-command: npm install
-          post-install: npm run build
       - run:
           name: Split E2E tests for parallel run
           command: |
@@ -149,44 +158,47 @@ jobs:
       - store_artifacts:
           path: cypress/results
 
-  build-deploy-development:
+  deploy-development:
     executor: aws-cli/default
     steps:
       - checkout
+      - attach_workspace:
+          at: *workspace_root
       - aws_assume_role/assume_role:
           account: $AWS_ACCOUNT_DEVELOPMENT
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
-      - node/install-packages
       - run:
           name: deploy
-          command: npm run build && sudo npm i -g serverless@^3 && sls deploy --stage development
+          command: npx --yes serverless@^3 deploy --stage development
 
-  build-deploy-staging:
+  deploy-staging:
     executor: aws-cli/default
     steps:
       - checkout
+      - attach_workspace:
+          at: *workspace_root
       - aws_assume_role/assume_role:
           account: $AWS_ACCOUNT_STAGING
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
-      - node/install-packages
       - run:
           name: deploy
-          command: npm run build && sudo npm i -g serverless@^3 && sls deploy --stage staging
+          command: npx --yes serverless@^3 deploy --stage staging
 
-  build-deploy-production:
+  deploy-production:
     executor: aws-cli/default
     steps:
       - checkout
+      - attach_workspace:
+          at: *workspace_root
       - aws_assume_role/assume_role:
           account: $AWS_ACCOUNT_PRODUCTION
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
-      - node/install-packages
       - run:
           name: deploy
-          command: npm run build && sudo npm i -g serverless@^3 && sls deploy --stage production
+          command: npx --yes serverless@^3 deploy --stage production
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:
@@ -194,6 +206,7 @@ workflows:
   continuous-delivery:
     jobs:
       - run-tests
+      - build
 
       - run-cypress-e2e:
           matrix:
@@ -204,13 +217,15 @@ workflows:
               # mobile, tablet, chromebook, desktop
               width: [320, 1024, 1366, 1536]
             exclude: *exclude_combinations
+          requires:
+            - build
 
       - sonar-scan:
           context: SonarCloud
           requires:
             - run-tests
 
-      - build-deploy-development:
+      - deploy-development:
           context:
             - api-assume-role-housing-development-context
             - housing-register-fe-build-context
@@ -221,7 +236,7 @@ workflows:
             branches:
               only: development
 
-      - build-deploy-staging:
+      - deploy-staging:
           context:
             - api-assume-role-housing-staging-context
             - housing-register-fe-build-context
@@ -235,12 +250,12 @@ workflows:
       - permit-deploy-production:
           type: approval
           requires:
-            - build-deploy-staging
+            - deploy-staging
           filters:
             branches:
               only: main
 
-      - build-deploy-production:
+      - deploy-production:
           context:
             - api-assume-role-housing-production-context
             - housing-register-fe-build-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,8 +78,7 @@ jobs:
   run-tests:
     executor: node-executor
     steps:
-      - cypress/install:
-          install-command: npm install
+      - cypress/install
       - cypress/run-tests:
           cypress-command: npx cypress run --component --reporter junit
       - run:
@@ -97,16 +96,14 @@ jobs:
     executor: node-executor
     steps:
       - checkout
-      - node/install-packages:
-          override-ci-command: npm install
+      - node/install-packages
       - sonarcloud/scan
 
   build:
     executor: node-executor
     steps:
       - checkout
-      - node/install-packages:
-          override-ci-command: npm install
+      - node/install-packages
       - run:
           name: Build Next application
           command: npm run build
@@ -131,7 +128,6 @@ jobs:
     steps:
       # cypress/install checks out the code, installs dependencies (including NPM), etc. It uses optimal caching strategies for NPM with npm ci.
       - cypress/install:
-          install-command: npm install
           install-browsers: true
       - run:
           name: Split E2E tests for parallel run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,11 +78,7 @@ jobs:
   run-tests:
     executor: node-executor
     steps:
-      - checkout
-      - node/install-packages
-      - cypress/install:
-          package-manager: npm
-          install-command: npm install
+      - cypress/install
       - cypress/run-tests:
           cypress-command: npx cypress run --component --reporter junit
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,11 +236,6 @@ workflows:
               # mobile, tablet, chromebook, desktop
               width: [320, 1024, 1366, 1536]
             exclude: *exclude_combinations
-          filters:
-            branches:
-              only:
-                - main
-                - development
       - sonar-scan:
           context: SonarCloud
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,8 @@ jobs:
   run-tests:
     executor: node-executor
     steps:
-      - cypress/install
+      - cypress/install:
+          install-command: npm install
       - cypress/run-tests:
           cypress-command: npx cypress run --component --reporter junit
       - run:
@@ -96,14 +97,16 @@ jobs:
     executor: node-executor
     steps:
       - checkout
-      - node/install-packages
+      - node/install-packages:
+          override-ci-command: npm install
       - sonarcloud/scan
 
   build:
     executor: node-executor
     steps:
       - checkout
-      - node/install-packages
+      - node/install-packages:
+          override-ci-command: npm install
       - run:
           name: Build Next application
           command: npm run build
@@ -128,6 +131,7 @@ jobs:
     steps:
       # cypress/install checks out the code, installs dependencies (including NPM), etc. It uses optimal caching strategies for NPM with npm ci.
       - cypress/install:
+          install-command: npm install
           install-browsers: true
       - run:
           name: Split E2E tests for parallel run

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,8 @@
         "prettier": "2.2.1",
         "sass": "^1.32.12",
         "ts-node": "^10.9.2",
-        "typescript": "4.9.5"
+        "typescript": "4.9.5",
+        "xml2js": "^0.6.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -15473,6 +15474,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -17284,6 +17292,30 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "prettier": "2.2.1",
     "sass": "^1.32.12",
     "ts-node": "^10.9.2",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "xml2js": "^0.6.2"
   }
 }

--- a/scripts/fix-junit-xml.js
+++ b/scripts/fix-junit-xml.js
@@ -1,0 +1,43 @@
+// Update JUnit output from Cypress to match the information expected by CircleCI,
+// primarily adding the path to each test suite.
+//
+// This is necessary for CircleCI's parallelism/test splitting feature, as it reads the JUnit output
+// to understand how long tests take to run.
+//
+// Taken from https://github.com/michaelleeallen/mocha-junit-reporter/issues/132#issuecomment-721943600
+
+const fs = require('fs')
+const xml2js = require('xml2js')
+
+fs.readdir('./cypress/results', (err, files) => {
+  if (err) {
+    return console.log(err)
+  }
+  files.forEach((file) => {
+    const filePath = `./cypress/results/${file}`
+    fs.readFile(filePath, 'utf8', (err, data) => {
+      if (err) {
+        return console.log(err)
+      }
+
+      xml2js.parseString(data, (err, xml) => {
+        if (err) {
+          return console.log(err)
+        }
+
+        const file = xml.testsuites.testsuite[0].$.file
+        xml.testsuites.testsuite.forEach((testsuite, index) => {
+          if (index > 0) {
+            testsuite.$.file = file
+          }
+        })
+
+        const builder = new xml2js.Builder()
+        const xmlOut = builder.buildObject(xml)
+        fs.writeFile(filePath, xmlOut, (err) => {
+          if (err) throw err
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces end to end tests to CircleCI builds on all branches.

Prior to this PR, end to end tests were only run on the `development` and `main` branches because they take around 11-15 minutes to complete. A typical full pipeline run including deployment looked like this:

![Screenshot 2024-11-27 at 12 31 (Brave Browser)@2x](https://github.com/user-attachments/assets/910af581-af90-41a2-b146-e807e9d12d1f)

This PR makes a bunch of changes to the CircleCI config to improve clock time of builds:

1. Remove the separate dependency installation step, instead relying on the Node orb's built in caching of  `~/.npm` for efficient `npm ci` dependency installs.
2. Consolidate the   `npm build` step and cache the build artefact, preventing the deployment steps from having to rebuild the app. This improves overall deployment time without impacting feature branch test runs.
3. Consolidate the "assume AWS role" steps into the deployment job, removing the job spin up time. **Note this hasn't been tested because it runs on `development` and `main` branches only. This portion can be rolled back if the assumption that python is available on the  `aws-cli` executor isn't true.
4. Introduce parallel testing for Cypress. Using built-in CircleCI tooling and a script to clean up Cypress' test output we can split tests across multiple nodes, bringing the elapsed time down to just over 3 minutes from.
5. Bump the resource class from `Medium` to `Medium+` becuase the nodes were hitting max CPU.

There are also a minor tweak to the deploy command to use `npx` rather than an NPM install step. The effect is to apply the same command.

Following this change the CircleCI build looks like this for a feature branch:

![Screenshot 2024-11-27 at 12 33 (Brave Browser)@2x](https://github.com/user-attachments/assets/aeb1b72c-ad43-46f1-987f-bcbb1f1c367f)

I haven't timed (or tested) the deployment job but I expect that to save around 1.5 minutes in spin-up and `npm build` time for each environment.

### Overall impact on feature branch builds

The build time including end to end tests is approximately the same as other branches without these changes applied:

![Screenshot 2024-11-27 at 12 50 (Brave Browser)@2x](https://github.com/user-attachments/assets/d2d3dd84-07b4-4499-abd5-80ca3d388e29)
![Screenshot 2024-11-27 at 12 52 (Brave Browser)@2x](https://github.com/user-attachments/assets/343cc987-8235-439b-a1dd-322779890f60)

### Considerations

1. This increases the cost of the CircleCI builds, both by running end to end tests for every branch and by parallelising the runs - around half of the parallel run is spent in setup. The resource class has been bumped as well. If this is problematic we can experiment with less parallelisation or fewer browser permutations for feature branches.
2. **The deployment pipelines haven't been tested (!)**. It would be reasonable to test this by deploying to development, either by just merging this PR and reverting it if it fails, or by changing the branch filter to allow a development deploy from the feature branch. I'm happy with either approach – what would work best for you?

### Future work

It _feels_ like there's still room for improvement around dependency installation and spin-up time, for example feature branches could save 20 seconds by not installing (or testing on) Firefox. If we could avoid the `npm run build` step for Cypress testing that could save around a minute too. 

I didn't pursue these because my goal was just to enable end to end testing in feature branches.