### PR TITLE
🐛 Fix deployment by using assumed AWS role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,6 +160,20 @@ jobs:
           account: $AWS_ACCOUNT_DEVELOPMENT
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
+
+      # aws_assume_role/assume_role stores credentials in ~/.aws/credentials, however
+      # environment variables take precence. These are set to do the initial config, so
+      # the role isn't actually assumed. We need to remove the environment variables in
+      # order for the aws_assume_role/assume_role output to be picked up.
+      #
+      # I think the lbh-hackit orb setup here could be replaced with direct use of the aws-cli/setup and
+      # aws-cli/role_arn_setup, which would remove the need for this cleanup.
+      - run:
+          name: Clean up AWS credentials
+          command: |
+              unset AWS_ACCESS_KEY_ID
+              unset AWS_SECRET_ACCESS_KEY
+
       - run:
           name: deploy
           command: npx --yes serverless@^3 deploy --stage development
@@ -174,6 +188,19 @@ jobs:
           account: $AWS_ACCOUNT_STAGING
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
+
+      # aws_assume_role/assume_role stores credentials in ~/.aws/credentials, however
+      # environment variables take precence. These are set to do the initial config, so
+      # the role isn't actually assumed. We need to remove the environment variables in
+      # order for the aws_assume_role/assume_role output to be picked up.
+      #
+      # I think the lbh-hackit orb setup here could be replaced with direct use of the aws-cli/setup and
+      # aws-cli/role_arn_setup, which would remove the need for this cleanup.
+      - run:
+          name: Clean up AWS credentials
+          command: |
+              unset AWS_ACCESS_KEY_ID
+              unset AWS_SECRET_ACCESS_KEY
       - run:
           name: deploy
           command: npx --yes serverless@^3 deploy --stage staging
@@ -188,6 +215,20 @@ jobs:
           account: $AWS_ACCOUNT_PRODUCTION
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
+
+      # aws_assume_role/assume_role stores credentials in ~/.aws/credentials, however
+      # environment variables take precence. These are set to do the initial config, so
+      # the role isn't actually assumed. We need to remove the environment variables in
+      # order for the aws_assume_role/assume_role output to be picked up.
+      #
+      # I think the lbh-hackit orb setup here could be replaced with direct use of the aws-cli/setup and
+      # aws-cli/role_arn_setup, which would remove the need for this cleanup.
+      - run:
+          name: Clean up AWS credentials
+          command: |
+              unset AWS_ACCESS_KEY_ID
+              unset AWS_SECRET_ACCESS_KEY
+
       - run:
           name: deploy
           command: npx --yes serverless@^3 deploy --stage production


### PR DESCRIPTION
In #485 we optimised the build by merging two jobs into one: assuming the deployment role, and carrying out the deployment. The two steps passed an AWS credentials file between them using workspace persistence. Merging the jobs removed some spin-up time from the overall run.

However, in
https://app.circleci.com/pipelines/github/LBHackney-IT/lbh-housing-register/1613/workflows/68ba707c-0862-45cd-a55d-6940a82a64eb/jobs/7067/parallel-runs/0/steps/0-107 the deployment step failed because Serverless was unable to retrieve secrets from AWS.

It turns out this failure cropped up because the`lbh-hackit/aws_assume_role` orb/command uses environment variables but outputs a credentials file. Environment variables take precedence, therefore the orb effectively no-ops unless a clean environment is present.

Ideally we would/could/should fix this upstream. There are two promising routes:

1. Update the LBH orb to use the new role credentials (i.e. unset the environment variables _or_ update them to match the assumed role creds); or

2. Use the `aws-cli` orb's setup and role assumption commands directly, and deprecate the LBH orb

Option 2 is (probably) the better one, as it removes a Hackney-maintained dependency.

I've not attempted this as part of this change as the goal is to make the build succeed again. I've also not refactored the three similar deployment jobs into a common command to reduce duplication for the same reason.

### Verification that the fix works

In a CircleCI SSH debug session we can validate the fix:

```bash
# aws ssm get-parameter --name arn:aws:ssm:eu-west-2:<REDACTED>:parameter/housing-register/development/activity-history-api-url

An error occurred (AccessDeniedException) when calling the GetParameter operation: User: arn:aws:iam::<REDACTED>:user/circleci-assume-role-user is not authorized to perform: ssm:GetParameter on resource: arn:aws:ssm:eu-west-2:<REDACTED>:parameter/housing-register/development/activity-history-api-url because no identity-based policy allows the ssm:GetParameter action

# unset AWS_ACCESS_KEY_ID
# unset AWS_SECRET_ACCESS_KEY

# aws ssm get-parameter --name arn:aws:ssm:eu-west-2:<REDACTED>:parameter/housing-register/development/activity-history-api-url
{
    "Parameter": {
        "Name": "/housing-register/development/activity-history-api-url",
        "Type": "String",
        "Value": "<REDACTED, but it's correct>",
        "Version": 1,
        "LastModifiedDate": 1638801189.257,
        "ARN": "arn:aws:ssm:<REDACTED, but it's correct>",
        "DataType": "text"
    }
}
```