### PR TITLE
ci: Unset env var in CI build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,23 +160,20 @@ jobs:
           account: $AWS_ACCOUNT_DEVELOPMENT
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
-
-      # aws_assume_role/assume_role stores credentials in ~/.aws/credentials, however
-      # environment variables take precence. These are set to do the initial config, so
-      # the role isn't actually assumed. We need to remove the environment variables in
-      # order for the aws_assume_role/assume_role output to be picked up.
-      #
-      # I think the lbh-hackit orb setup here could be replaced with direct use of the aws-cli/setup and
-      # aws-cli/role_arn_setup, which would remove the need for this cleanup.
-      - run:
-          name: Clean up AWS credentials
-          command: |
-              unset AWS_ACCESS_KEY_ID
-              unset AWS_SECRET_ACCESS_KEY
-
       - run:
           name: deploy
-          command: npx --yes serverless@^3 deploy --stage development
+          command: |
+            # aws_assume_role/assume_role stores credentials in ~/.aws/credentials, however
+            # environment variables take precence. These are set to do the initial config, so
+            # the role isn't actually assumed. We need to remove the environment variables in
+            # order for the aws_assume_role/assume_role output to be picked up.
+            #
+            # I think the lbh-hackit orb setup here could be replaced with direct use of the aws-cli/setup and
+            # aws-cli/role_arn_setup, which would remove the need for this cleanup.
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
+
+            npx --yes serverless@^3 deploy --stage development
 
   deploy-staging:
     executor: aws-cli/default
@@ -188,22 +185,20 @@ jobs:
           account: $AWS_ACCOUNT_STAGING
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
-
-      # aws_assume_role/assume_role stores credentials in ~/.aws/credentials, however
-      # environment variables take precence. These are set to do the initial config, so
-      # the role isn't actually assumed. We need to remove the environment variables in
-      # order for the aws_assume_role/assume_role output to be picked up.
-      #
-      # I think the lbh-hackit orb setup here could be replaced with direct use of the aws-cli/setup and
-      # aws-cli/role_arn_setup, which would remove the need for this cleanup.
-      - run:
-          name: Clean up AWS credentials
-          command: |
-              unset AWS_ACCESS_KEY_ID
-              unset AWS_SECRET_ACCESS_KEY
       - run:
           name: deploy
-          command: npx --yes serverless@^3 deploy --stage staging
+          command: |
+            # aws_assume_role/assume_role stores credentials in ~/.aws/credentials, however
+            # environment variables take precence. These are set to do the initial config, so
+            # the role isn't actually assumed. We need to remove the environment variables in
+            # order for the aws_assume_role/assume_role output to be picked up.
+            #
+            # I think the lbh-hackit orb setup here could be replaced with direct use of the aws-cli/setup and
+            # aws-cli/role_arn_setup, which would remove the need for this cleanup.
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
+
+            npx --yes serverless@^3 deploy --stage staging
 
   deploy-production:
     executor: aws-cli/default
@@ -215,23 +210,20 @@ jobs:
           account: $AWS_ACCOUNT_PRODUCTION
           profile_name: default
           role: 'LBH_Circle_CI_Deployment_Role'
-
-      # aws_assume_role/assume_role stores credentials in ~/.aws/credentials, however
-      # environment variables take precence. These are set to do the initial config, so
-      # the role isn't actually assumed. We need to remove the environment variables in
-      # order for the aws_assume_role/assume_role output to be picked up.
-      #
-      # I think the lbh-hackit orb setup here could be replaced with direct use of the aws-cli/setup and
-      # aws-cli/role_arn_setup, which would remove the need for this cleanup.
-      - run:
-          name: Clean up AWS credentials
-          command: |
-              unset AWS_ACCESS_KEY_ID
-              unset AWS_SECRET_ACCESS_KEY
-
       - run:
           name: deploy
-          command: npx --yes serverless@^3 deploy --stage production
+          command: |
+            # aws_assume_role/assume_role stores credentials in ~/.aws/credentials, however
+            # environment variables take precence. These are set to do the initial config, so
+            # the role isn't actually assumed. We need to remove the environment variables in
+            # order for the aws_assume_role/assume_role output to be picked up.
+            #
+            # I think the lbh-hackit orb setup here could be replaced with direct use of the aws-cli/setup and
+            # aws-cli/role_arn_setup, which would remove the need for this cleanup.
+            unset AWS_ACCESS_KEY_ID
+            unset AWS_SECRET_ACCESS_KEY
+
+            npx --yes serverless@^3 deploy --stage production
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 workflows:


### PR DESCRIPTION
In #487 we unset the AWS credential environment variables before running the deploy step, so that `aws-cli` would use the credentials stored on disk by the assume-role step.

However, it looks like the environment variables may be reset for each step, because although unsetting them in an SSH debug session succeeded, the deployment failed:
https://app.circleci.com/pipelines/github/LBHackney-IT/lbh-housing-register/1616/workflows/6a32b504-27fa-4824-b702-59fce56128e0/jobs/7102.

If that assumption is correct, this change will resolve the deployment failure by unsetting the environment variable in the same bash shell as the deploy command is run.

If this change continues to fail, then #487 wasn't an effective fix and we can revert both this and that change.