### PR TITLE
Add node_modules to paths to persist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
           root: *workspace_root
           paths:
             - build
+            - node_modules
 
   run-cypress-e2e:
     executor: node-executor


### PR DESCRIPTION
Deployed Lambda function is currently failing with `Runtime.ImportModuleError: Error: Cannot find module 'restana'`. This updates the workspace to include `node_modules` folder to make all dependencies available to the Lambda. 