### PR TITLE
fix: update next to version 12.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "lbh-frontend": "^3.6.1",
         "lodash.throttle": "^4.1.1",
         "nested-object-diff": "^1.1.0",
-        "next": "12.3.4",
+        "next": "^12.3.5",
         "next-redux-wrapper": "^6.0.2",
         "notifications-node-client": "^8.2.1",
         "react": "^17.0.2",
@@ -3626,9 +3626,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.4.tgz",
-      "integrity": "sha512-H/69Lc5Q02dq3o+dxxy5O/oNxFsZpdL6WREtOOtOM1B/weonIwDXkekr1KV5DPVPr12IHFPrMrcJQ6bgPMfn7A==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.5.tgz",
+      "integrity": "sha512-OdUAOzbOFA4N170bpn3vLXEmQyFW+PHWuz6ic9v8C/BveS1YfmTE7pa07nBOgS9780t2tdnsMBcRycvWcQyPBw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -3641,42 +3641,10 @@
         "glob": "7.1.7"
       }
     },
-    "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.4.tgz",
-      "integrity": "sha512-cM42Cw6V4Bz/2+j/xIzO8nK/Q3Ly+VSlZJTa1vHzsocJRYz8KT6MrreXaci2++SIZCF1rVRCDgAg5PpqRibdIA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-android-arm64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.4.tgz",
-      "integrity": "sha512-5jf0dTBjL+rabWjGj3eghpLUxCukRhBcEJgwLedewEA/LJk2HyqCvGIwj5rH+iwmq1llCWbOky2dO3pVljrapg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.4.tgz",
-      "integrity": "sha512-DqsSTd3FRjQUR6ao0E1e2OlOcrF5br+uegcEGPVonKYJpcr0MJrtYmPxd4v5T6UCJZ+XzydF7eQo5wdGvSZAyA==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.5.tgz",
+      "integrity": "sha512-820++QiPnadIBPsV0CDLWxMe3BDXpHpSDqHy9wm1T0dHiG4O7tjgILrDJZ8LbeYXHNPr9S/7USKm93H3CWvbKw==",
       "cpu": [
         "arm64"
       ],
@@ -3684,81 +3652,17 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.4.tgz",
-      "integrity": "sha512-PPF7tbWD4k0dJ2EcUSnOsaOJ5rhT3rlEt/3LhZUGiYNL8KvoqczFrETlUx0cUYaXe11dRA3F80Hpt727QIwByQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.4.tgz",
-      "integrity": "sha512-KM9JXRXi/U2PUM928z7l4tnfQ9u8bTco/jb939pdFUHqc28V43Ohd31MmZD1QzEK4aFlMRaIBQOWQZh4D/E5lQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
       ],
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.4.tgz",
-      "integrity": "sha512-3zqD3pO+z5CZyxtKDTnOJ2XgFFRUBciOox6EWkoZvJfc9zcidNAQxuwonUeNts6Xbm8Wtm5YGIRC0x+12YH7kw==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.5.tgz",
+      "integrity": "sha512-QXMAObv8ISC+H0vKtPsyUwDtaSwZaI/2n7iWCl/C7GL/+dsGCXG4lMwzxsZ48Mx35rmAw8ksdUcLwpEzGoIA9A==",
       "cpu": [
         "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.4.tgz",
-      "integrity": "sha512-kiX0vgJGMZVv+oo1QuObaYulXNvdH/IINmvdZnVzMO/jic/B8EEIGlZ8Bgvw8LCjH3zNVPO3mGrdMvnEEPEhKA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.4.tgz",
-      "integrity": "sha512-EETZPa1juczrKLWk5okoW2hv7D7WvonU+Cf2CgsSoxgsYbUCZ1voOpL4JZTOb6IbKMDo6ja+SbY0vzXZBUMvkQ==",
-      "cpu": [
-        "arm64"
       ],
       "license": "MIT",
       "optional": true,
@@ -3770,9 +3674,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.4.tgz",
-      "integrity": "sha512-4csPbRbfZbuWOk3ATyWcvVFdD9/Rsdq5YHKvRuEni68OCLkfy4f+4I9OBpyK1SKJ00Cih16NJbHE+k+ljPPpag==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.5.tgz",
+      "integrity": "sha512-cYyp3yzJL/iYqUhJl4WKTBI0hOLfBsdkm01QomVVoWmy0TTT6zjn1wnxI5tEgyDjXK8pjDVUiivSY1TVLaP2+A==",
       "cpu": [
         "x64"
       ],
@@ -3786,9 +3690,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.4.tgz",
-      "integrity": "sha512-YeBmI+63Ro75SUiL/QXEVXQ19T++58aI/IINOyhpsRL1LKdyfK/35iilraZEFz9bLQrwy1LYAR5lK200A9Gjbg==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.5.tgz",
+      "integrity": "sha512-2M9tFsg330+gqaHSBPwTpA9YW9FAxE0nuat1rwfx6hix5sVi9u8liRW4+9lHuGensmz8V3/VdLoRVsBCQyzx2Q==",
       "cpu": [
         "x64"
       ],
@@ -3802,9 +3706,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.4.tgz",
-      "integrity": "sha512-Sd0qFUJv8Tj0PukAYbCCDbmXcMkbIuhnTeHm9m4ZGjCf6kt7E/RMs55Pd3R5ePjOkN7dJEuxYBehawTR/aPDSQ==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.5.tgz",
+      "integrity": "sha512-yZHzSBRhsiFv2moJ44d7bApJC+Sirbar/ZyKzCPNck0mqSMVgO3dvHQJme9X+kDydpIeLezxV70xoXpdEPgUvg==",
       "cpu": [
         "arm64"
       ],
@@ -3818,9 +3722,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.4.tgz",
-      "integrity": "sha512-rt/vv/vg/ZGGkrkKcuJ0LyliRdbskQU+91bje+PgoYmxTZf/tYs6IfbmgudBJk6gH3QnjHWbkphDdRQrseRefQ==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.5.tgz",
+      "integrity": "sha512-TE75XiG60YwPh/ADJ5oQ11bDbfEoFYGczaP6AucopPraLedpMtu9TokC9mAGq+tfNFxktIEPubDCwZZALlKm1w==",
       "cpu": [
         "ia32"
       ],
@@ -3834,9 +3738,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.4.tgz",
-      "integrity": "sha512-DQ20JEfTBZAgF8QCjYfJhv2/279M6onxFjdG/+5B0Cyj00/EdBxiWb2eGGFgQhrBbNv/lsvzFbbi0Ptf8Vw/bg==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.5.tgz",
+      "integrity": "sha512-wX0Q9dzQkL5v2+ypGHgrPtE7G1hiXSSv9nLCbl1ni7InDqnNAJk40VgmkToapcrjXASd9F1CAJmhg9G+I+RT/w==",
       "cpu": [
         "x64"
       ],
@@ -15200,12 +15104,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "12.3.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.3.4.tgz",
-      "integrity": "sha512-VcyMJUtLZBGzLKo3oMxrEF0stxh8HwuW976pAzlHhI3t8qJ4SROjCrSh1T24bhrbjw55wfZXAbXPGwPt5FLRfQ==",
+      "version": "12.3.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.3.5.tgz",
+      "integrity": "sha512-hrr2xzsSOVQ7XYrY09KjT9u4DQS3fdOJ89ng44r3+Kufxf4a9b9ngALJQYcQpreWiGvdiNRB5YlG8wq04ECeBw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "12.3.4",
+        "@next/env": "12.3.5",
         "@swc/helpers": "0.4.11",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
@@ -15219,19 +15123,19 @@
         "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.3.4",
-        "@next/swc-android-arm64": "12.3.4",
-        "@next/swc-darwin-arm64": "12.3.4",
-        "@next/swc-darwin-x64": "12.3.4",
-        "@next/swc-freebsd-x64": "12.3.4",
-        "@next/swc-linux-arm-gnueabihf": "12.3.4",
-        "@next/swc-linux-arm64-gnu": "12.3.4",
-        "@next/swc-linux-arm64-musl": "12.3.4",
-        "@next/swc-linux-x64-gnu": "12.3.4",
-        "@next/swc-linux-x64-musl": "12.3.4",
-        "@next/swc-win32-arm64-msvc": "12.3.4",
-        "@next/swc-win32-ia32-msvc": "12.3.4",
-        "@next/swc-win32-x64-msvc": "12.3.4"
+        "@next/swc-android-arm-eabi": "12.3.5",
+        "@next/swc-android-arm64": "12.3.5",
+        "@next/swc-darwin-arm64": "12.3.5",
+        "@next/swc-darwin-x64": "12.3.5",
+        "@next/swc-freebsd-x64": "12.3.5",
+        "@next/swc-linux-arm-gnueabihf": "12.3.5",
+        "@next/swc-linux-arm64-gnu": "12.3.5",
+        "@next/swc-linux-arm64-musl": "12.3.5",
+        "@next/swc-linux-x64-gnu": "12.3.5",
+        "@next/swc-linux-x64-musl": "12.3.5",
+        "@next/swc-win32-arm64-msvc": "12.3.5",
+        "@next/swc-win32-ia32-msvc": "12.3.5",
+        "@next/swc-win32-x64-msvc": "12.3.5"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lbh-frontend": "^3.6.1",
     "lodash.throttle": "^4.1.1",
     "nested-object-diff": "^1.1.0",
-    "next": "12.3.4",
+    "next": "^12.3.5",
     "next-redux-wrapper": "^6.0.2",
     "notifications-node-client": "^8.2.1",
     "react": "^17.0.2",


### PR DESCRIPTION
Fixes [CVE-2025-29927](https://nextjs.org/blog/cve-2025-29927) by updating next to 12.3.5