### PR TITLE
Test/fix local tests

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -40,8 +40,5 @@ NOTIFY_TEMPLATE_MEDICAL_NEED=
 # Activity History API
 ACTIVITY_HISTORY_API=http://localhost:3600/api/v1
 
-# Set to true to exclude running e2e/local test folder in the environment. These tests require a running localstack config outlined in readme.
-LOCAL_E2E=
-
 # Enable /api/e2e/* routes for Cypress (Nock + JWT helpers in the Next.js process). Required for mocked e2e.
 E2E_HTTP_MOCKS=

--- a/README.md
+++ b/README.md
@@ -130,16 +130,23 @@ Repository enforces [Conventional Commits](https://www.conventionalcommits.org/e
 
 ### E2E tests
 
-A suite of e2e tests have been written with cypress. Check the env vars are set correctly for AUTHORISED\_\* groups before running tests.
+End-to-end tests use Cypress. Set env vars for **AUTHORISED\_\*** groups (and the rest of `.env`) before running; see `.env.sample`.
 
-Standard e2e tests use nock to intercept network requests and mock responses. The configuration will start the application from within the cypress.config.ts to allow nock to work within the next environment sucessfully. These will also run in the pipeline and record video of failed tests.
+**How it works**
 
-Local e2e tests in the cypress/e2e/local folder require all nock configuration to be commented out in cypress.config.ts, a [local backend](https://github.com/LBHackney-IT/housing-register-local-backend) to be running and the LOCAL_E2E to be set to true. These tests are designed to run against a production build of the application. To build and start the application run these commands.
+- Cypress `baseUrl` is `http://localdev.hackney.gov.uk:3000` (see `cypress.config.ts`). Run Next with `npm run dev` (same hostname) or use `npm run build` / `npm run start` if you prefer a production build.
+- **Standard** specs live under `cypress/e2e/` (excluding `local/`). They rely on **server-side HTTP mocks**: Cypress registers mocks via `/api/e2e/nock`, and the Next server must run with **`E2E_HTTP_MOCKS=true`** so those routes and in-process nock are enabled. CI sets this in CircleCI; locally add it to `.env` or export it when starting Next.
+- **`npm run cypress:open`** / **`npm run e2e:run`** set `E2E_HTTP_MOCKS=true` for the Cypress process; your Next process still needs the same flag if tests register mocks.
 
-```
-npm run build
-npm run start
-```
+**Local e2e** (`cypress/e2e/local/`)
+
+- Set **`LOCAL_E2E=true`** so Cypress includes the `local` folder (see `cypress.config.ts` `excludeSpecPattern`). Use **`npm run cypress:open:local`** or **`npm run e2e:run:local`**.
+- Check your env vars for **AUTHORISED\_\*** groups, as these are largely testing public user behaviour - you'll need to have empty groups in your token.
+- Run a [local backend](https://github.com/LBHackney-IT/housing-register-local-backend) (Housing Register API, DynamoDB, LocalStack, etc.) and point `.env` at it (`HOUSING_REGISTER_API`).
+- Local flows hit the real API for almost everything. For declaration submit, **`POST /api/applications/:id/evidence`** is **stubbed in the browser** (`cypress/support/e2e.ts` when running with `LOCAL_E2E=true`) so you do not need a real Evidence API or server-side nock for that call.
+- If **`PATCH …/complete`** (or other outbound Housing API calls) still fail against your stack, enable **`E2E_HTTP_MOCKS=true`** on the Next server and register mocks via `/api/e2e/nock` from tests (same pattern as standard e2e), or fix the backend / LocalStack wiring.
+
+Failed runs record video (see `cypress.config.ts`).
 
 ## 🚀 Deployment
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ End-to-end tests use Cypress. Set env vars for **AUTHORISED\_\*** groups (and th
 
 **How it works**
 
-- Cypress `baseUrl` is `http://localdev.hackney.gov.uk:3000` (see `cypress.config.ts`). Run Next with `npm run dev` (same hostname) or use `npm run build` / `npm run start` if you prefer a production build.
+- Run Next with `npm run dev` or use `npm run build` / `npm run start` if you prefer a production build.
 - **Standard** specs live under `cypress/e2e/` (excluding `local/`). They rely on **server-side HTTP mocks**: Cypress registers mocks via `/api/e2e/nock`, and the Next server must run with **`E2E_HTTP_MOCKS=true`** so those routes and in-process nock are enabled. CI sets this in CircleCI; locally add it to `.env` or export it when starting Next.
 - **`npm run cypress:open`** / **`npm run e2e:run`** set `E2E_HTTP_MOCKS=true` for the Cypress process; your Next process still needs the same flag if tests register mocks.
 
@@ -142,9 +142,8 @@ End-to-end tests use Cypress. Set env vars for **AUTHORISED\_\*** groups (and th
 
 - Set **`LOCAL_E2E=true`** so Cypress includes the `local` folder (see `cypress.config.ts` `excludeSpecPattern`). Use **`npm run cypress:open:local`** or **`npm run e2e:run:local`**.
 - Check your env vars for **AUTHORISED\_\*** groups, as these are largely testing public user behaviour - you'll need to have empty groups in your token.
-- Run a [local backend](https://github.com/LBHackney-IT/housing-register-local-backend) (Housing Register API, DynamoDB, LocalStack, etc.) and point `.env` at it (`HOUSING_REGISTER_API`).
+- Run a [local backend](https://github.com/LBHackney-IT/housing-register-local-backend) (Housing Register API, DynamoDB, LocalStack, etc.) and point `.env` at it (`HOUSING_REGISTER_API`). This will also need a modification as detailed in the README.md to avoid hitting GovUK Notify.
 - Local flows hit the real API for almost everything. For declaration submit, **`POST /api/applications/:id/evidence`** is **stubbed in the browser** (`cypress/support/e2e.ts` when running with `LOCAL_E2E=true`) so you do not need a real Evidence API or server-side nock for that call.
-- If **`PATCH …/complete`** (or other outbound Housing API calls) still fail against your stack, enable **`E2E_HTTP_MOCKS=true`** on the Next server and register mocks via `/api/e2e/nock` from tests (same pattern as standard e2e), or fix the backend / LocalStack wiring.
 
 Failed runs record video (see `cypress.config.ts`).
 

--- a/__tests__/pages/api/auth/generate.spec.ts
+++ b/__tests__/pages/api/auth/generate.spec.ts
@@ -29,7 +29,7 @@ const mockCreateAuthRequest: CreateAuthRequest = {
   email: email,
 };
 
-/** String body so the handler takes the `JSON.parse(req.body)` branch (see generate.tsx). */
+/** String body so the handler takes the `JSON.parse(req.body)` path. */
 const mockCreateAuthRequestBody = JSON.stringify(mockCreateAuthRequest);
 
 const mockCreateAuthResponse: CreateAuthResponse = { success: true };

--- a/__tests__/pages/api/auth/generate.spec.ts
+++ b/__tests__/pages/api/auth/generate.spec.ts
@@ -29,6 +29,9 @@ const mockCreateAuthRequest: CreateAuthRequest = {
   email: email,
 };
 
+/** String body so the handler takes the `JSON.parse(req.body)` branch (see generate.tsx). */
+const mockCreateAuthRequestBody = JSON.stringify(mockCreateAuthRequest);
+
 const mockCreateAuthResponse: CreateAuthResponse = { success: true };
 
 jest.mock('../../../../lib/gateways/applications-api', () => ({
@@ -47,7 +50,8 @@ describe('POST', () => {
 
   const requestOptions: RequestOptions = {
     method: 'POST',
-    body: mockCreateAuthRequest,
+    // createMocks accepts a JSON string body; `Body` typings omit `string`.
+    body: mockCreateAuthRequestBody as unknown as RequestOptions['body'],
   };
 
   it('returns status code 200 when JSON.parse succeeds and verify code is created successfully', async () => {
@@ -69,7 +73,7 @@ describe('POST', () => {
 
   it('returns status code 400 when JSON.parse fails', async () => {
     jsonParseSpy.mockImplementationOnce(() => {
-      throw SyntaxError('Unexpected token');
+      throw new SyntaxError('Unexpected token');
     });
 
     createVerifyCodeMock.mockReturnValueOnce(mockCreateAuthResponse);
@@ -97,7 +101,7 @@ describe('POST', () => {
 
     const reqOptions: RequestOptions = {
       method: 'POST',
-      body: mockCreateAuthRequest,
+      body: mockCreateAuthRequestBody as unknown as RequestOptions['body'],
     };
 
     const { req, res }: { req: ApiRequest; res: ApiResponse } =

--- a/components/admin/snapshot.spec.tsx
+++ b/components/admin/snapshot.spec.tsx
@@ -1,0 +1,197 @@
+import { render, screen } from '@testing-library/react';
+import Snapshot from './snapshot';
+import { Applicant, Application } from '../../domain/HousingApi';
+
+function makeApplicant({
+  id,
+  firstName,
+  surname,
+  hasMedicalNeed,
+}: {
+  id: string;
+  firstName?: string;
+  surname?: string;
+  hasMedicalNeed: boolean;
+}): Applicant {
+  return {
+    person: { id, firstName, surname },
+    questions: [
+      {
+        id: 'medical-needs/medical-needs',
+        answer: hasMedicalNeed ? '"yes"' : '"no"',
+      },
+    ],
+  };
+}
+
+const APPLICATION_ID = 'app-123';
+
+const baseApplication: Application = {
+  id: APPLICATION_ID,
+  calculatedBedroomNeed: 1,
+  mainApplicant: makeApplicant({
+    id: 'person-1',
+    firstName: 'Alice',
+    surname: 'Smith',
+    hasMedicalNeed: false,
+  }),
+  otherMembers: [],
+};
+
+describe('Snapshot – medical need', () => {
+  it('shows "No one has stated a medical need." when nobody has a medical need', () => {
+    const { container } = render(<Snapshot data={baseApplication} />);
+
+    expect(container).toHaveTextContent('No one has stated a medical need.');
+  });
+
+  it('renders no links when nobody has a medical need', () => {
+    render(<Snapshot data={baseApplication} />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('uses singular phrasing when 1 person has a medical need', () => {
+    const data: Application = {
+      ...baseApplication,
+      mainApplicant: makeApplicant({
+        id: 'person-1',
+        firstName: 'Alice',
+        surname: 'Smith',
+        hasMedicalNeed: true,
+      }),
+    };
+    const { container } = render(<Snapshot data={data} />);
+
+    expect(container).toHaveTextContent('1 person');
+    expect(container).toHaveTextContent('has stated a medical need');
+  });
+
+  it('renders a link with the person name when they have a medical need', () => {
+    const data: Application = {
+      ...baseApplication,
+      mainApplicant: makeApplicant({
+        id: 'person-1',
+        firstName: 'Alice',
+        surname: 'Smith',
+        hasMedicalNeed: true,
+      }),
+    };
+    render(<Snapshot data={data} />);
+
+    expect(
+      screen.getByRole('link', { name: 'Alice Smith' }),
+    ).toBeInTheDocument();
+  });
+
+  it('links to the correct applicant view page', () => {
+    const data: Application = {
+      ...baseApplication,
+      mainApplicant: makeApplicant({
+        id: 'person-1',
+        firstName: 'Alice',
+        surname: 'Smith',
+        hasMedicalNeed: true,
+      }),
+    };
+    render(<Snapshot data={data} />);
+
+    expect(screen.getByRole('link', { name: 'Alice Smith' })).toHaveAttribute(
+      'href',
+      `/applications/view/${APPLICATION_ID}/person-1`,
+    );
+  });
+
+  it('uses plural phrasing when multiple people have a medical need', () => {
+    const data: Application = {
+      ...baseApplication,
+      mainApplicant: makeApplicant({
+        id: 'person-1',
+        firstName: 'Alice',
+        surname: 'Smith',
+        hasMedicalNeed: true,
+      }),
+      otherMembers: [
+        makeApplicant({
+          id: 'person-2',
+          firstName: 'Bob',
+          surname: 'Jones',
+          hasMedicalNeed: true,
+        }),
+      ],
+    };
+    const { container } = render(<Snapshot data={data} />);
+
+    expect(container).toHaveTextContent('2 people');
+    expect(container).toHaveTextContent('have stated a medical need');
+  });
+
+  it('renders a link for each person with a medical need', () => {
+    const data: Application = {
+      ...baseApplication,
+      mainApplicant: makeApplicant({
+        id: 'person-1',
+        firstName: 'Alice',
+        surname: 'Smith',
+        hasMedicalNeed: true,
+      }),
+      otherMembers: [
+        makeApplicant({
+          id: 'person-2',
+          firstName: 'Bob',
+          surname: 'Jones',
+          hasMedicalNeed: true,
+        }),
+      ],
+    };
+    render(<Snapshot data={data} />);
+
+    expect(screen.getByRole('link', { name: 'Alice Smith' })).toHaveAttribute(
+      'href',
+      `/applications/view/${APPLICATION_ID}/person-1`,
+    );
+    expect(screen.getByRole('link', { name: 'Bob Jones' })).toHaveAttribute(
+      'href',
+      `/applications/view/${APPLICATION_ID}/person-2`,
+    );
+  });
+
+  it('only links to people who have stated a medical need', () => {
+    const data: Application = {
+      ...baseApplication,
+      mainApplicant: makeApplicant({
+        id: 'person-1',
+        firstName: 'Alice',
+        surname: 'Smith',
+        hasMedicalNeed: false,
+      }),
+      otherMembers: [
+        makeApplicant({
+          id: 'person-2',
+          firstName: 'Bob',
+          surname: 'Jones',
+          hasMedicalNeed: true,
+        }),
+      ],
+    };
+    render(<Snapshot data={data} />);
+
+    expect(screen.getByRole('link', { name: 'Bob Jones' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Alice Smith' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows "Unknown" as the link text when the person has no name data', () => {
+    const data: Application = {
+      ...baseApplication,
+      mainApplicant: {
+        person: { id: 'person-1' },
+        questions: [{ id: 'medical-needs/medical-needs', answer: '"yes"' }],
+      },
+    };
+    render(<Snapshot data={data} />);
+
+    expect(screen.getByRole('link', { name: 'Unknown' })).toBeInTheDocument();
+  });
+});

--- a/components/admin/snapshot.tsx
+++ b/components/admin/snapshot.tsx
@@ -1,6 +1,10 @@
+import Link from 'next/link';
 import { Application } from '../../domain/HousingApi';
 import Paragraph from '../content/paragraph';
-import { applicantsWithMedicalNeed } from '../../lib/utils/medicalNeed';
+import {
+  applicantHasMedicalNeed,
+  applicantsWithMedicalNeed,
+} from '../../lib/utils/medicalNeed';
 import { questionLookup } from '../../lib/utils/applicationQuestions';
 
 interface PageProps {
@@ -20,16 +24,59 @@ export default function Snapshot({ data }: PageProps): JSX.Element {
       : `There are ${totalInApplication} people in this application.`;
   }
 
-  function medicalNeedText() {
+  function medicalNeedText(): JSX.Element | string {
     const totalNumberOfPeopleWithMedicalNeeds = applicantsWithMedicalNeed(data);
+    const names = medicalNeedNames();
+
     switch (totalNumberOfPeopleWithMedicalNeeds) {
       case 0:
         return 'No one has stated a medical need.';
       case 1:
-        return '1 person has stated a medical need.';
+        return names ? (
+          <span>1 person, {names}, has stated a medical need.</span>
+        ) : (
+          '1 person has stated a medical need.'
+        );
       default:
+        return names ? (
+          <span>
+            {totalNumberOfPeopleWithMedicalNeeds} people, ( {names} ), have
+            stated a medical need.
+          </span>
+        ) : (
+          `${totalNumberOfPeopleWithMedicalNeeds} people have stated a medical need.`
+        );
     }
-    return `${totalNumberOfPeopleWithMedicalNeeds} people have stated a medical need.`;
+  }
+
+  function medicalNeedNames(): JSX.Element | null {
+    const applicantsWithNeeds = [
+      data.mainApplicant,
+      ...(data.otherMembers ?? []),
+    ].filter((a): a is NonNullable<typeof a> => applicantHasMedicalNeed(a));
+
+    if (applicantsWithNeeds.length === 0) return null;
+
+    return (
+      <span>
+        {applicantsWithNeeds.map((applicant, index) => {
+          const name =
+            `${applicant.person?.firstName ?? ''} ${applicant.person?.surname ?? ''}`.trim() ||
+            'Unknown';
+          return (
+            <span key={applicant.person?.id ?? index}>
+              {index > 0 && ', '}
+              <Link
+                href={`/applications/view/${data.id}/${applicant.person?.id}`}
+                className="lbh-link"
+              >
+                {name}
+              </Link>
+            </span>
+          );
+        })}
+      </span>
+    );
   }
 
   function bedroomNeedText() {
@@ -66,7 +113,7 @@ export default function Snapshot({ data }: PageProps): JSX.Element {
       {`${totalPeopleInApplication()} `}
       {`${livingSituation()} `}
       {`${bedroomNeedText()} `}
-      {`${medicalNeedText()}`}
+      {medicalNeedText()}
     </Paragraph>
   );
 }

--- a/components/form/form.tsx
+++ b/components/form/form.tsx
@@ -22,6 +22,7 @@ interface FormProps {
   initialValues?: FormikValues;
   activeStep?: string;
   isSavingToDatabase?: boolean;
+  submitButtonDataTestId?: string;
 }
 
 export default function Form({
@@ -31,6 +32,7 @@ export default function Form({
   onSubmit,
   initialValues,
   isSavingToDatabase = false,
+  submitButtonDataTestId = 'test-submit-form-button',
 }: FormProps): JSX.Element {
   const [stepNumber, setStepNumber] = useState(0);
 
@@ -127,7 +129,7 @@ export default function Form({
                     <Button
                       disabled={isSubmitting}
                       type="submit"
-                      dataTestId={`test-submit-form-button`}
+                      dataTestId={submitButtonDataTestId}
                     >
                       {buttonText ? buttonText : 'Save'}
                     </Button>

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,7 +3,8 @@ import { existsSync, unlinkSync } from 'fs';
 import { loadEnvConfig } from '@next/env';
 import { defineConfig } from 'cypress';
 
-const baseUrl = 'http://localhost:3000';
+// const baseUrl = 'http://localhost:3000';
+const baseUrl = 'http://localdev.hackney.gov.uk:3000';
 
 // Populate process.env from .env when Cypress loads this file (e2e and component).
 loadEnvConfig(process.cwd());
@@ -14,6 +15,7 @@ loadEnvConfig(process.cwd());
  */
 function buildCypressExpose(): Record<string, string | undefined> {
   return {
+    LOCAL_E2E: process.env.LOCAL_E2E?.trim() === 'true' ? 'true' : undefined,
     ACTIVITY_HISTORY_API:
       process.env.ACTIVITY_HISTORY_API?.trim() ||
       'http://127.0.0.1:3600/api/v1',

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,8 +3,8 @@ import { existsSync, unlinkSync } from 'fs';
 import { loadEnvConfig } from '@next/env';
 import { defineConfig } from 'cypress';
 
-// const baseUrl = 'http://localhost:3000';
-const baseUrl = 'http://localdev.hackney.gov.uk:3000';
+const baseUrl = 'http://localhost:3000';
+// const baseUrl = 'http://localdev.hackney.gov.uk:3000';
 
 // Populate process.env from .env when Cypress loads this file (e2e and component).
 loadEnvConfig(process.cwd());

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,7 +4,6 @@ import { loadEnvConfig } from '@next/env';
 import { defineConfig } from 'cypress';
 
 const baseUrl = 'http://localhost:3000';
-// const baseUrl = 'http://localdev.hackney.gov.uk:3000';
 
 // Populate process.env from .env when Cypress loads this file (e2e and component).
 loadEnvConfig(process.cwd());

--- a/cypress/e2e/local/eligibleApplicantWithMedicalCondition.cy.ts
+++ b/cypress/e2e/local/eligibleApplicantWithMedicalCondition.cy.ts
@@ -22,7 +22,9 @@ import {
   visitHomepageSignInAndVerify,
 } from '../../support/locale2eTestsHelper';
 import { interceptAddressSearchAPI } from '../../support/intercepts';
-import Components from '../../pages/components';
+import ApplyOverviewPage from '../../pages/apply/overview';
+import AdditionalQuestionsPage from '../../pages/additionalQuestions';
+import EthnicityPage from '../../pages/ethnicity';
 
 //ensure age doesn't automatically make applicant eligible
 const birthDate = faker.date.birthdate({ mode: 'age', min: 18, max: 40 });
@@ -184,24 +186,20 @@ describe('Applicant with medical condition', () => {
       ApplyResidentSummaryPage.getConfirmDetailsButton().click();
       cy.contains("You've completed information for 1 of 1 people.");
 
-      cy.get('.lbh-button').contains('Save and continue').click();
-      cy.get('.lbh-button').contains('Save and continue').click();
+      ApplyOverviewPage.clickSaveAndContinueToAdditionalQuestions();
+      AdditionalQuestionsPage.expectLoaded();
+      AdditionalQuestionsPage.clickSaveAndContinue();
+      EthnicityPage.expectLoaded();
 
-      // get the first ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
-
+      EthnicityPage.clickRandomRadioOption();
       ApplyResidentSectionPage.getSubmitButton().click();
 
-      // get the second ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
+      // Second ethnicity radio button - two step process.
+      EthnicityPage.clickRandomRadioOption();
+
       ApplyResidentSectionPage.getSubmitButton().click();
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();
+
       DeclarationPage.getSubmitButton().click();
       cy.contains('Application complete');
     });

--- a/cypress/e2e/local/eligibleApplicantsBothOver55.cy.ts
+++ b/cypress/e2e/local/eligibleApplicantsBothOver55.cy.ts
@@ -25,7 +25,9 @@ import {
   SignUpFormDetails,
   visitHomepageSignInAndVerify,
 } from '../../support/locale2eTestsHelper';
-import Components from '../../pages/components';
+import ApplyOverviewPage from '../../pages/apply/overview';
+import AdditionalQuestionsPage from '../../pages/additionalQuestions';
+import EthnicityPage from '../../pages/ethnicity';
 
 //ensure eligibility: both over 55
 const mainApplicantBirthDate = faker.date.birthdate({
@@ -265,22 +267,16 @@ describe('Applicant and household member both over 55', () => {
       ApplyResidentSummaryPage.getConfirmDetailsButton().click();
       cy.contains("You've completed information for 2 of 2 people.");
 
-      cy.get('.lbh-button').contains('Save and continue').click();
-      cy.get('.lbh-button').contains('Save and continue').click();
+      ApplyOverviewPage.clickSaveAndContinueToAdditionalQuestions();
+      AdditionalQuestionsPage.expectLoaded();
+      AdditionalQuestionsPage.clickSaveAndContinue();
+      EthnicityPage.expectLoaded();
 
-      // get the first ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
-
+      EthnicityPage.clickRandomRadioOption();
       ApplyResidentSectionPage.getSubmitButton().click();
 
-      // get the second ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
+      // Second ethnicity radio button - two step process.
+      EthnicityPage.clickRandomRadioOption();
 
       ApplyResidentSectionPage.getSubmitButton().click();
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();

--- a/cypress/e2e/local/eligibleApplicationWithHouseholdMembers.cy.ts
+++ b/cypress/e2e/local/eligibleApplicationWithHouseholdMembers.cy.ts
@@ -25,7 +25,9 @@ import {
   visitHomepageSignInAndVerify,
 } from '../../support/locale2eTestsHelper';
 import { interceptAddressSearchAPI } from '../../support/intercepts';
-import Components from '../../pages/components';
+import EthnicityPage from '../../pages/ethnicity';
+import AdditionalQuestionsPage from '../../pages/additionalQuestions';
+import ApplyOverviewPage from '../../pages/apply/overview';
 
 const mainApplicantBirthDate = faker.date.birthdate({
   mode: 'age',
@@ -328,22 +330,16 @@ describe('Add and remove household members', () => {
       ApplyResidentSummaryPage.getConfirmDetailsButton().click();
       cy.contains("You've completed information for 3 of 3 people.");
 
-      cy.get('.lbh-button').contains('Save and continue').click();
-      cy.get('.lbh-button').contains('Save and continue').click();
+      ApplyOverviewPage.clickSaveAndContinueToAdditionalQuestions();
+      AdditionalQuestionsPage.expectLoaded();
+      AdditionalQuestionsPage.clickSaveAndContinue();
+      EthnicityPage.expectLoaded();
 
-      // get the first ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
-
+      EthnicityPage.clickRandomRadioOption();
       ApplyResidentSectionPage.getSubmitButton().click();
 
-      // get the second ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
+      // Second ethnicity radio button - two step process.
+      EthnicityPage.clickRandomRadioOption();
 
       ApplyResidentSectionPage.getSubmitButton().click();
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();

--- a/cypress/e2e/local/eligibleMainApplicantOnlyOver55.cy.ts
+++ b/cypress/e2e/local/eligibleMainApplicantOnlyOver55.cy.ts
@@ -23,7 +23,9 @@ import {
   SignUpFormDetails,
   visitHomepageSignInAndVerify,
 } from '../../support/locale2eTestsHelper';
-import Components from '../../pages/components';
+import EthnicityPage from '../../pages/ethnicity';
+import AdditionalQuestionsPage from '../../pages/additionalQuestions';
+import ApplyOverviewPage from '../../pages/apply/overview';
 
 //ensure eligibility: over 55 and alone
 const birthDate = faker.date.birthdate({ mode: 'age', min: 56, max: 90 });
@@ -206,22 +208,17 @@ describe('Single main applicant, over 55', () => {
       ApplyResidentIndexPage.getCheckAnswersButton().click();
       ApplyResidentSummaryPage.getConfirmDetailsButton().click();
       cy.contains("You've completed information for 1 of 1 people.");
-      cy.get('.lbh-button').contains('Save and continue').click();
-      cy.get('.lbh-button').contains('Save and continue').click();
 
-      // get the first ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
+      ApplyOverviewPage.clickSaveAndContinueToAdditionalQuestions();
+      AdditionalQuestionsPage.expectLoaded();
+      AdditionalQuestionsPage.clickSaveAndContinue();
+      EthnicityPage.expectLoaded();
 
+      EthnicityPage.clickRandomRadioOption();
       ApplyResidentSectionPage.getSubmitButton().click();
 
-      // get the second ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
+      // Second ethnicity radio button - two step process.
+      EthnicityPage.clickRandomRadioOption();
 
       ApplyResidentSectionPage.getSubmitButton().click();
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();

--- a/cypress/e2e/local/managerActions.cy.ts
+++ b/cypress/e2e/local/managerActions.cy.ts
@@ -26,7 +26,9 @@ import {
 } from '../../support/locale2eTestsHelper';
 import { interceptAddressSearchAPI } from '../../support/intercepts';
 import AddHouseholdMemberPage from '../../pages/applications/edit/add-household-member';
-import Components from '../../pages/components';
+import EthnicityPage from '../../pages/ethnicity';
+import AdditionalQuestionsPage from '../../pages/additionalQuestions';
+import ApplyOverviewPage from '../../pages/apply/overview';
 
 const mainApplicantBirthDate = faker.date.birthdate({
   mode: 'age',
@@ -328,23 +330,16 @@ describe('Manager actions', () => {
       ApplyResidentIndexPage.getCheckAnswersButton().click();
       ApplyResidentSummaryPage.getConfirmDetailsButton().click();
       cy.contains("You've completed information for 3 of 3 people.");
+      ApplyOverviewPage.clickSaveAndContinueToAdditionalQuestions();
+      AdditionalQuestionsPage.expectLoaded();
+      AdditionalQuestionsPage.clickSaveAndContinue();
+      EthnicityPage.expectLoaded();
 
-      cy.get('.lbh-button').contains('Save and continue').click();
-      cy.get('.lbh-button').contains('Save and continue').click();
-
-      // get the first ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
-
+      EthnicityPage.clickRandomRadioOption();
       ApplyResidentSectionPage.getSubmitButton().click();
 
-      // get the second ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
+      // Second ethnicity radio button - two step process.
+      EthnicityPage.clickRandomRadioOption();
       ApplyResidentSectionPage.getSubmitButton().click();
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();
       DeclarationPage.getSubmitButton().click();

--- a/cypress/e2e/local/sampleForSingleEligibleApplicant.cy.ts
+++ b/cypress/e2e/local/sampleForSingleEligibleApplicant.cy.ts
@@ -22,7 +22,9 @@ import {
   visitHomepageSignInAndVerify,
 } from '../../support/locale2eTestsHelper';
 import { interceptAddressSearchAPI } from '../../support/intercepts';
-import Components from '../../pages/components';
+import EthnicityPage from '../../pages/ethnicity';
+import AdditionalQuestionsPage from '../../pages/additionalQuestions';
+import ApplyOverviewPage from '../../pages/apply/overview';
 
 //ensure eligibility: over 55 and alone
 const birthDate = faker.date.birthdate({ mode: 'age', min: 56, max: 90 });
@@ -195,26 +197,22 @@ describe('Single main applicant, over 55', () => {
       //confirm details
       ApplyResidentIndexPage.getCheckAnswersButton().click();
       ApplyResidentSummaryPage.getConfirmDetailsButton().click();
-      cy.get('.lbh-button').contains('Save and continue').click();
-      cy.get('.lbh-button').contains('Save and continue').click();
 
-      // get the first ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
+      ApplyOverviewPage.clickSaveAndContinueToAdditionalQuestions();
+      AdditionalQuestionsPage.expectLoaded();
+      AdditionalQuestionsPage.clickSaveAndContinue();
+      EthnicityPage.expectLoaded();
 
+      EthnicityPage.clickRandomRadioOption();
       ApplyResidentSectionPage.getSubmitButton().click();
 
-      // get the second ethnicity radio button.
-      Components.getRadioButtons().then((radioButtons) => {
-        const randomIndex = Math.floor(Math.random() * radioButtons.length);
-        radioButtons[randomIndex].click();
-      });
+      // Second ethnicity radio button - two step process.
+      EthnicityPage.clickRandomRadioOption();
 
       ApplyResidentSectionPage.getSubmitButton().click();
 
       cy.get(`[data-testid="test-checkbox-declaration-0"]`).check();
+
       DeclarationPage.getSubmitButton().click();
     });
   });

--- a/cypress/pages/additionalQuestions.ts
+++ b/cypress/pages/additionalQuestions.ts
@@ -6,6 +6,26 @@ class AdditionalQuestionsPage {
   static visit() {
     cy.visit(`/apply/submit/additional-questions`);
   }
+  static getSaveAndContinueButton() {
+    const testId = 'test-additional-questions-save-and-continue';
+    return AdditionalQuestionsPage.getAdditionalQuestionsPage().find(
+      `[data-testid="${testId}"]`,
+    );
+  }
+  static clickSaveAndContinue() {
+    return AdditionalQuestionsPage.getSaveAndContinueButton()
+      .scrollIntoView()
+      .should('be.visible')
+      .and('not.be.disabled')
+      .click();
+  }
+  static expectLoaded() {
+    cy.url({ timeout: 30000 }).should(
+      'include',
+      '/apply/submit/additional-questions',
+    );
+    AdditionalQuestionsPage.getAdditionalQuestionsPage().should('exist');
+  }
   static getAdditionalQuestionsNotes() {
     const testId = 'test-checkbox-conditional-container';
     return cy.get(`[data-testid*="${testId}"]`);

--- a/cypress/pages/additionalQuestions.ts
+++ b/cypress/pages/additionalQuestions.ts
@@ -7,7 +7,7 @@ class AdditionalQuestionsPage {
     cy.visit(`/apply/submit/additional-questions`);
   }
   static getSaveAndContinueButton() {
-    const testId = 'test-additional-questions-save-and-continue';
+    const testId = 'test-submit-form-button';
     return AdditionalQuestionsPage.getAdditionalQuestionsPage().find(
       `[data-testid="${testId}"]`,
     );

--- a/cypress/pages/apply/overview.ts
+++ b/cypress/pages/apply/overview.ts
@@ -18,6 +18,17 @@ class ApplyOverviewPage {
       .should('be.visible')
       .click({ force: true });
   }
+
+  static getSaveAndContinueToAdditionalQuestionsLink() {
+    return cy.get('[data-testid="test-apply-overview-save-and-continue"]');
+  }
+
+  static clickSaveAndContinueToAdditionalQuestions() {
+    return ApplyOverviewPage.getSaveAndContinueToAdditionalQuestionsLink()
+      .scrollIntoView()
+      .should('be.visible')
+      .click();
+  }
 }
 
 export default ApplyOverviewPage;

--- a/cypress/pages/ethnicity.ts
+++ b/cypress/pages/ethnicity.ts
@@ -6,6 +6,26 @@ class EthnicityPage {
   static visit() {
     cy.visit(`/apply/submit/ethnicity-questions`);
   }
+  static expectLoaded() {
+    cy.url({ timeout: 30000 }).should(
+      'include',
+      '/apply/submit/ethnicity-questions',
+    );
+    EthnicityPage.getEthnicityPage().should('exist');
+  }
+
+  static getRadioButtons() {
+    return EthnicityPage.getEthnicityPage().find(
+      '[data-testid*="test-radio-"]',
+    );
+  }
+
+  static clickRandomRadioOption() {
+    EthnicityPage.getRadioButtons().then((radioButtons) => {
+      const randomIndex = Math.floor(Math.random() * radioButtons.length);
+      cy.wrap(radioButtons.eq(randomIndex)).click();
+    });
+  }
 
   static getErrorSummary() {
     const testId = 'test-ethnicity-questions-error-summary';

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -15,6 +15,18 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
+import { interceptLocalE2eApplicationEvidencePost } from './intercepts';
+
+/**
+ * Local e2e hits a real backend without Evidence API wiring. Stub the BFF evidence POST
+ * in the browser so declaration submit can reach the confirmation page.
+ */
+beforeEach(() => {
+  // allowCypressEnv is false — use Cypress.expose (see cypress.config.ts buildCypressExpose).
+  if (Cypress.expose('LOCAL_E2E') === 'true') {
+    interceptLocalE2eApplicationEvidencePost();
+  }
+});
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -18,11 +18,9 @@ import './commands';
 import { interceptLocalE2eApplicationEvidencePost } from './intercepts';
 
 /**
- * Local e2e hits a real backend without Evidence API wiring. Stub the BFF evidence POST
- * in the browser so declaration submit can reach the confirmation page.
+ * e2e against localstack (local backend) hits a real backend without Evidence API wiring. Stub the evidence POST in the browser so declaration submit can reach the confirmation page.
  */
 beforeEach(() => {
-  // allowCypressEnv is false — use Cypress.expose (see cypress.config.ts buildCypressExpose).
   if (Cypress.expose('LOCAL_E2E') === 'true') {
     interceptLocalE2eApplicationEvidencePost();
   }

--- a/cypress/support/intercepts.ts
+++ b/cypress/support/intercepts.ts
@@ -9,7 +9,7 @@ const localE2eEvidenceResponseBody = [
 ];
 
 /**
- * Stubs the Next BFF evidence endpoint from the browser. Use for `LOCAL_E2E` when the
+ * Stubs the Next evidence endpoint from the browser. Use for `LOCAL_E2E` when the
  * Housing Register API has no Evidence service (e.g. localstack) — no `E2E_HTTP_MOCKS` required.
  */
 export const interceptLocalE2eApplicationEvidencePost = () => {

--- a/cypress/support/intercepts.ts
+++ b/cypress/support/intercepts.ts
@@ -1,5 +1,24 @@
 import { AddressApiResponse } from './locale2eTestsHelper';
 
+/** Minimal shape returned by `POST /api/applications/:id/evidence` for the resident thunk. */
+const localE2eEvidenceResponseBody = [
+  {
+    id: '00000000-0000-4000-8000-000000000001',
+    createdAt: new Date().toISOString(),
+  },
+];
+
+/**
+ * Stubs the Next BFF evidence endpoint from the browser. Use for `LOCAL_E2E` when the
+ * Housing Register API has no Evidence service (e.g. localstack) — no `E2E_HTTP_MOCKS` required.
+ */
+export const interceptLocalE2eApplicationEvidencePost = () => {
+  cy.intercept('POST', '**/api/applications/*/evidence', {
+    statusCode: 200,
+    body: localE2eEvidenceResponseBody,
+  });
+};
+
 export const interceptAddressSearchAPI = (response: AddressApiResponse) => {
   cy.intercept(
     {

--- a/cypress/support/locale2eTestsHelper.ts
+++ b/cypress/support/locale2eTestsHelper.ts
@@ -54,6 +54,8 @@ export const visitHomepageSignInAndVerify = (
     .int({ min: 100000, max: 999999 })
     .toString();
 
+  cy.intercept('POST', '**/api/auth/generate').as('localAuthGenerate');
+
   HomePage.visit(applicationId);
   HomePage.getCookiesButton().click();
 
@@ -62,6 +64,7 @@ export const visitHomepageSignInAndVerify = (
   SignInPage.getEmailInput().scrollIntoView().type(`${email}`, { delay: 0 });
 
   SignInPage.getSubmitButton().click();
+  cy.wait('@localAuthGenerate').its('response.statusCode').should('eq', 200);
 
   VerifyPage.getVerifyCodePage().should('be.visible');
   VerifyPage.getVerifyCodeInput()

--- a/cypress/support/locale2eTestsHelper.ts
+++ b/cypress/support/locale2eTestsHelper.ts
@@ -54,7 +54,7 @@ export const visitHomepageSignInAndVerify = (
     .int({ min: 100000, max: 999999 })
     .toString();
 
-  cy.intercept('POST', '**/api/auth/generate').as('localAuthGenerate');
+  cy.intercept('POST', '**/api/auth/generate').as('localAuthGenerate'); // This intercept doens't actually mock anything. We capture the request so we can wait for sign-in backend completion before entering the verification code. This avoids breaking tests on first load.
 
   HomePage.visit(applicationId);
   HomePage.getCookiesButton().click();

--- a/domain/HousingApi.ts
+++ b/domain/HousingApi.ts
@@ -594,6 +594,7 @@ export interface PaginatedApplicationListResponse {
 
 export interface CreateAuthRequest {
   email: string;
+  applicationId?: string;
 }
 export interface CreateAuthResponse {
   success: boolean;

--- a/lib/store/auth.ts
+++ b/lib/store/auth.ts
@@ -5,6 +5,7 @@ import {
   VerifyAuthRequest,
   VerifyAuthResponse,
 } from '../../domain/HousingApi';
+import { Errors } from '../types/errors';
 
 export const createVerifyCode = createAsyncThunk(
   'auth/create',
@@ -43,9 +44,11 @@ export const confirmVerifyCode = createAsyncThunk(
 
     if (res.ok) {
       return (await res.json()) as VerifyAuthResponse;
-    } else {
-      return rejectWithValue(`Unable to confirm verify code (${res.status})`);
     }
+    if (res.status === 404) {
+      return rejectWithValue(Errors.VERIFY_CODE_NOT_CONFIRMED);
+    }
+    return rejectWithValue(`Unable to confirm verify code (${res.status})`);
   },
 );
 

--- a/lib/types/errors.ts
+++ b/lib/types/errors.ts
@@ -3,4 +3,5 @@ export enum Errors {
   API_ERROR = 'We were unable to action your request. Please try again.',
   SIGNIN_ERROR = 'We were unable to email you a verification code. Please try again.',
   VERIFY_ERROR = 'We were unable to verify your email. Please try again.',
+  VERIFY_CODE_NOT_CONFIRMED = 'That verification code is not valid or has expired. You can request a new code below.',
 }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './build/_next/types/routes.d.ts';
+import './build/_next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './build/_next/dev/types/routes.d.ts';
+import './build/_next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "commit": "czg",
     "prepare": "husky || true",
     "cypress:open": "E2E_HTTP_MOCKS=true cypress open --browser chrome",
-    "cypress:open:local": "LOCAL_E2E=true cypress open --browser chrome",
+    "cypress:open:local": "LOCAL_E2E=true E2E_HTTP_MOCKS=true cypress open --browser chrome",
     "e2e:run": "E2E_HTTP_MOCKS=true cypress run --e2e --browser electron",
-    "e2e:run:local": "LOCAL_E2E=true cypress run --e2e --browser electron --spec 'cypress/e2e/local/**/*.cy.ts'",
+    "e2e:run:local": "LOCAL_E2E=true E2E_HTTP_MOCKS=true cypress run --e2e --browser electron --spec 'cypress/e2e/local/**/*.cy.ts'",
     "component:run": "cypress run --component --browser electron"
   },
   "lint-staged": {

--- a/pages/api/applications/index.ts
+++ b/pages/api/applications/index.ts
@@ -1,4 +1,5 @@
 import { wrapApiHandlerWithSentry } from '@sentry/nextjs';
+import axios from 'axios';
 import { StatusCodes } from 'http-status-codes';
 
 import { Application } from '../../../domain/HousingApi';
@@ -31,6 +32,12 @@ const endpoint: NextApiHandler = async (
             .json({ message: 'Unable to get application' });
         }
       } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status) {
+          res
+            .status(error.response.status)
+            .json({ message: 'Unable to get application' });
+          return;
+        }
         console.error(error);
         res
           .status(StatusCodes.INTERNAL_SERVER_ERROR)

--- a/pages/api/auth/generate.tsx
+++ b/pages/api/auth/generate.tsx
@@ -28,6 +28,7 @@ const endpoint: NextApiHandler = async (
 
   let request: CreateAuthRequest;
   try {
+    // body is usually an object when Next JSON body parsing runs but it can be a string in some test paths. So make sure both shapes are parsed before request.
     request =
       typeof req.body === 'string'
         ? (JSON.parse(req.body) as CreateAuthRequest)

--- a/pages/api/auth/generate.tsx
+++ b/pages/api/auth/generate.tsx
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { CreateAuthRequest } from '../../../domain/HousingApi';
 import { createVerifyCode } from '../../../lib/gateways/applications-api';
+import { getUser } from '../../../lib/utils/users';
 
 /** Verbose API errors for mocked e2e / CI — not during Jest (avoids noise and spy interference). */
 function logE2eGenerateError(payload: Record<string, unknown>): void {
@@ -27,7 +28,10 @@ const endpoint: NextApiHandler = async (
 
   let request: CreateAuthRequest;
   try {
-    request = JSON.parse(req.body) as CreateAuthRequest;
+    request =
+      typeof req.body === 'string'
+        ? (JSON.parse(req.body) as CreateAuthRequest)
+        : (req.body as CreateAuthRequest);
   } catch (parseErr) {
     logE2eGenerateError({
       phase: 'body parse failed',
@@ -41,7 +45,15 @@ const endpoint: NextApiHandler = async (
   }
 
   try {
-    const data = await createVerifyCode(request);
+    // In local Cypress we pre-seed a resident token cookie with application_id.
+    // Forward it so API can create/verify against the same application record.
+    const cookieApplicationId = getUser(req)?.application_id;
+    const requestWithApplicationId: CreateAuthRequest = {
+      ...request,
+      applicationId: request.applicationId ?? cookieApplicationId,
+    };
+
+    const data = await createVerifyCode(requestWithApplicationId);
     res.status(StatusCodes.OK).json(data);
   } catch (err) {
     logE2eGenerateError({

--- a/pages/api/auth/verify.tsx
+++ b/pages/api/auth/verify.tsx
@@ -1,8 +1,24 @@
 import { wrapApiHandlerWithSentry } from '@sentry/nextjs';
+import axios from 'axios';
 import { StatusCodes } from 'http-status-codes';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+import type { VerifyAuthRequest } from '../../../domain/HousingApi';
 import { confirmVerifyCode } from '../../../lib/gateways/applications-api';
 import { setAuthCookie } from '../../../lib/utils/users';
+
+function parseVerifyBody(req: NextApiRequest): VerifyAuthRequest | null {
+  try {
+    if (typeof req.body === 'string') {
+      return JSON.parse(req.body) as VerifyAuthRequest;
+    }
+    if (req.body && typeof req.body === 'object') {
+      return req.body as VerifyAuthRequest;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 const endpoint: NextApiHandler = async (
   req: NextApiRequest,
@@ -11,7 +27,14 @@ const endpoint: NextApiHandler = async (
   switch (req.method) {
     case 'POST':
       try {
-        const request = JSON.parse(req.body);
+        const request = parseVerifyBody(req);
+        if (!request) {
+          res
+            .status(StatusCodes.BAD_REQUEST)
+            .json({ message: 'Unable to parse request' });
+          return;
+        }
+
         const data = await confirmVerifyCode(request);
 
         // set cookie with access token (JWT)
@@ -21,6 +44,13 @@ const endpoint: NextApiHandler = async (
 
         res.status(StatusCodes.OK).json(data);
       } catch (error) {
+        if (axios.isAxiosError(error) && error.response?.status) {
+          res
+            .status(error.response.status)
+            .json({ message: 'Unable to confirm verify code' });
+          return;
+        }
+
         console.error(error);
         res
           .status(StatusCodes.INTERNAL_SERVER_ERROR)

--- a/pages/api/auth/verify.tsx
+++ b/pages/api/auth/verify.tsx
@@ -10,8 +10,7 @@ function parseVerifyBody(req: NextApiRequest): VerifyAuthRequest | null {
   try {
     if (typeof req.body === 'string') {
       return JSON.parse(req.body) as VerifyAuthRequest;
-    }
-    if (req.body && typeof req.body === 'object') {
+    } else if (req.body && typeof req.body === 'object') {
       return req.body as VerifyAuthRequest;
     }
     return null;

--- a/pages/apply/overview.tsx
+++ b/pages/apply/overview.tsx
@@ -122,7 +122,10 @@ const ApplicationPersonsOverview = (): JSX.Element => {
           <Paragraph>
             Please make sure you have checked your answers for each applicant.
           </Paragraph>
-          <ButtonLink href="/apply/submit/additional-questions">
+          <ButtonLink
+            href="/apply/submit/additional-questions"
+            dataTestId="test-apply-overview-save-and-continue"
+          >
             Save and continue
           </ButtonLink>
         </>

--- a/pages/apply/submit/additional-questions.tsx
+++ b/pages/apply/submit/additional-questions.tsx
@@ -84,6 +84,7 @@ const AdditonalQuestions = (): JSX.Element => {
           buttonText="Save and continue"
           formData={getFormData(FormID.ADDITIONAL_QUESTIONS)}
           onSubmit={onSubmit}
+          submitButtonDataTestId="test-additional-questions-save-and-continue"
         />
       )}
     </Layout>

--- a/pages/apply/submit/additional-questions.tsx
+++ b/pages/apply/submit/additional-questions.tsx
@@ -84,7 +84,6 @@ const AdditonalQuestions = (): JSX.Element => {
           buttonText="Save and continue"
           formData={getFormData(FormID.ADDITIONAL_QUESTIONS)}
           onSubmit={onSubmit}
-          submitButtonDataTestId="test-additional-questions-save-and-continue"
         />
       )}
     </Layout>


### PR DESCRIPTION
What
-- 
The previous flow was flaky on first load due to page changes where similarly named ids existed across pages. This PR fixes the local cypress submit flow around `/apply/overview` → `/apply/submit/additional-questions` → `/apply/submit/ethnicity-questions` by using page-specific test IDs.

This also adds a small visual feature that was requested to display the user names of those with stated medical needs. As user had to open each application to find the medical needs, this was a small FE addition to save time.

<img width="603" height="208" alt="Screenshot 2026-05-01 at 15 17 26" src="https://github.com/user-attachments/assets/e671baaf-35d4-4f14-b05a-aca8fafa1e60" />

How
--
- Uses page objects instead of flaky `.lbh-button`/radio selectors.
- Added test IDs for:
  - overview “Save and continue”
  - additional-questions submit button
- Moved ethnicity radio interactions into existing `EthnicityPage` helpers.
- Removed incorrect summary “save and continue” page-objects.


