### PR TITLE
Bugfix/verify fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,14 +334,14 @@ workflows:
               only: [development]
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
-          requires:
-            - run-tests
-            - run-cypress-e2e
+          # requires:
+          #   - run-tests
+          #   - run-cypress-e2e
           filters:
             tags:
               ignore: /.*/
             branches:
-              only: main
+              only: bugfix/verify-fail
       - deploy-to-staging:
           context:
             - central-parameter-store-context
@@ -354,7 +354,7 @@ workflows:
             tags:
               ignore: /.*/
             branches:
-              only: main
+              only: bugfix/verify-fail
       - assume-role-production:
           context: api-assume-role-housing-production-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,14 +334,14 @@ workflows:
               only: [development]
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
-          # requires:
-          #   - run-tests
-          #   - run-cypress-e2e
+          requires:
+            - run-tests
+            - run-cypress-e2e
           filters:
             tags:
               ignore: /.*/
             branches:
-              only: bugfix/verify-fail
+              only: main
       - deploy-to-staging:
           context:
             - central-parameter-store-context
@@ -354,7 +354,7 @@ workflows:
             tags:
               ignore: /.*/
             branches:
-              only: bugfix/verify-fail
+              only: main
       - assume-role-production:
           context: api-assume-role-housing-production-context
           requires:

--- a/lib/gateways/internal-api.ts
+++ b/lib/gateways/internal-api.ts
@@ -12,6 +12,7 @@ export const lookUpAddress = async (postCode: string) => {
 export const updateApplication = async (application: Application) => {
   const res = await fetch(`/api/applications/${application.id}`, {
     method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(application),
   });
 
@@ -25,6 +26,7 @@ export const updateApplication = async (application: Application) => {
 export const createApplication = async (application: Application) => {
   const res = await fetch(`/api/applications`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(application),
   });
 
@@ -70,6 +72,7 @@ export const addNoteToHistory = async (
 ) => {
   const res = await fetch(`/api/applications/${applicationId}/note`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(request),
   });
   return await res.json();

--- a/lib/store/application.ts
+++ b/lib/store/application.ts
@@ -33,6 +33,7 @@ export const updateApplication = createAsyncThunk(
   async (application: Application, { rejectWithValue }) => {
     const res = await fetch(`/api/applications/${application.id}`, {
       method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(application),
     });
 
@@ -53,6 +54,7 @@ export const disqualifyApplication = createAsyncThunk(
     };
     const res = await fetch(`/api/applications/${id}`, {
       method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request),
     });
     if (res.ok) {
@@ -94,6 +96,7 @@ export const createEvidenceRequest = createAsyncThunk(
     };
     const res = await fetch(`/api/applications/${application.id}/evidence`, {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request),
     });
     if (res.ok) {
@@ -119,6 +122,7 @@ export const sendConfirmation = createAsyncThunk(
 
     const res = await fetch(`/api/notify/new-application`, {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(notifyRequest),
     });
 
@@ -147,6 +151,7 @@ export const sendMedicalNeed = createAsyncThunk(
 
     const res = await fetch(`/api/notify/medical`, {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(notifyRequest),
     });
 
@@ -176,6 +181,7 @@ export const sendDisqualifyEmail = createAsyncThunk(
 
     const res = await fetch(`/api/notify/disqualify`, {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(notifyRequest),
     });
 

--- a/lib/store/auth.ts
+++ b/lib/store/auth.ts
@@ -16,6 +16,7 @@ export const createVerifyCode = createAsyncThunk(
 
     const res = await fetch(`/api/auth/generate`, {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request),
     });
 
@@ -39,6 +40,7 @@ export const confirmVerifyCode = createAsyncThunk(
     };
     const res = await fetch(`/api/auth/verify`, {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request),
     });
 

--- a/pages/api/auth/generate.tsx
+++ b/pages/api/auth/generate.tsx
@@ -15,6 +15,21 @@ function logE2eGenerateError(payload: Record<string, unknown>): void {
   }
 }
 
+/**
+ * Read the raw request body from the stream.
+ * Used as a fallback when Next.js body-parser has not already populated
+ * req.body (e.g. in the Lambda/serverless-http environment where the parser
+ * may not fire for every content-type or runtime combination).
+ */
+function readRawBody(req: NextApiRequest): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
 const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
@@ -28,10 +43,24 @@ const endpoint: NextApiHandler = async (
 
   let request: CreateAuthRequest;
   try {
-    // body is usually an object when Next JSON body parsing runs but it can be a string in some test paths. So make sure both shapes are parsed before request.
+    // Resolve to a raw string regardless of how the Lambda/serverless-http
+    // environment delivered the body:
+    //   • object  — Next.js JSON body-parser already ran (normal dev/prod)
+    //   • string  — text/plain or test path
+    //   • Buffer  — binary Lambda payload not decoded by the framework
+    //   • undefined — body-parser did not fire; read from the stream directly
+    let rawBodyStr: string | undefined;
+    if (typeof req.body === 'string') {
+      rawBodyStr = req.body;
+    } else if (Buffer.isBuffer(req.body)) {
+      rawBodyStr = req.body.toString('utf8');
+    } else if (req.body === undefined || req.body === null) {
+      rawBodyStr = await readRawBody(req);
+    }
+
     request =
-      typeof req.body === 'string'
-        ? (JSON.parse(req.body) as CreateAuthRequest)
+      rawBodyStr !== undefined
+        ? (JSON.parse(rawBodyStr) as CreateAuthRequest)
         : (req.body as CreateAuthRequest);
   } catch (parseErr) {
     logE2eGenerateError({
@@ -52,6 +81,14 @@ const endpoint: NextApiHandler = async (
     typeof request.email !== 'string' ||
     request.email.trim() === ''
   ) {
+    // Always log — visible in CloudWatch on Lambda deployments, not just E2E.
+    if (process.env.JEST_WORKER_ID === undefined) {
+      console.error('[api/auth/generate] validation failed', {
+        reason: 'missing or invalid email',
+        bodyType: typeof req.body,
+        requestKeys: request ? Object.keys(request) : null,
+      });
+    }
     logE2eGenerateError({
       phase: 'validation failed',
       reason: 'missing or invalid email',

--- a/pages/api/auth/generate.tsx
+++ b/pages/api/auth/generate.tsx
@@ -26,22 +26,6 @@ const endpoint: NextApiHandler = async (
     return;
   }
 
-  // Temporary diagnostic: set LOG_BODY_TYPE=true on the Lambda to confirm
-  // how the body is being delivered by API Gateway + serverless-http.
-  // Logs on every request, success or failure. Remove once the question
-  // about Buffer-bodies is resolved.
-  if (
-    process.env.LOG_BODY_TYPE === 'true' &&
-    process.env.JEST_WORKER_ID === undefined
-  ) {
-    console.info('[api/auth/generate] body diagnostic', {
-      bodyType: typeof req.body,
-      bodyIsBuffer: Buffer.isBuffer(req.body),
-      contentType: req.headers['content-type'] ?? null,
-      contentLength: req.headers['content-length'] ?? null,
-    });
-  }
-
   let request: CreateAuthRequest;
   try {
     // Behind API Gateway + serverless-http the body can arrive as a Buffer

--- a/pages/api/auth/generate.tsx
+++ b/pages/api/auth/generate.tsx
@@ -28,11 +28,16 @@ const endpoint: NextApiHandler = async (
 
   let request: CreateAuthRequest;
   try {
-    // body is usually an object when Next JSON body parsing runs but it can be a string in some test paths. So make sure both shapes are parsed before request.
-    request =
-      typeof req.body === 'string'
-        ? (JSON.parse(req.body) as CreateAuthRequest)
-        : (req.body as CreateAuthRequest);
+    // Behind API Gateway + serverless-http the body can arrive as a Buffer
+    // even when the client sets Content-Type: application/json, so normalise
+    // here. Standard Next dev/prod gives us a parsed object.
+    if (typeof req.body === 'string') {
+      request = JSON.parse(req.body) as CreateAuthRequest;
+    } else if (Buffer.isBuffer(req.body)) {
+      request = JSON.parse(req.body.toString('utf8')) as CreateAuthRequest;
+    } else {
+      request = req.body as CreateAuthRequest;
+    }
   } catch (parseErr) {
     logE2eGenerateError({
       phase: 'body parse failed',
@@ -52,6 +57,13 @@ const endpoint: NextApiHandler = async (
     typeof request.email !== 'string' ||
     request.email.trim() === ''
   ) {
+    if (process.env.JEST_WORKER_ID === undefined) {
+      console.error('[api/auth/generate] validation failed', {
+        bodyType: typeof req.body,
+        bodyIsBuffer: Buffer.isBuffer(req.body),
+        requestKeys: request ? Object.keys(request) : null,
+      });
+    }
     logE2eGenerateError({
       phase: 'validation failed',
       reason: 'missing or invalid email',

--- a/pages/api/auth/generate.tsx
+++ b/pages/api/auth/generate.tsx
@@ -26,6 +26,22 @@ const endpoint: NextApiHandler = async (
     return;
   }
 
+  // Temporary diagnostic: set LOG_BODY_TYPE=true on the Lambda to confirm
+  // how the body is being delivered by API Gateway + serverless-http.
+  // Logs on every request, success or failure. Remove once the question
+  // about Buffer-bodies is resolved.
+  if (
+    process.env.LOG_BODY_TYPE === 'true' &&
+    process.env.JEST_WORKER_ID === undefined
+  ) {
+    console.info('[api/auth/generate] body diagnostic', {
+      bodyType: typeof req.body,
+      bodyIsBuffer: Buffer.isBuffer(req.body),
+      contentType: req.headers['content-type'] ?? null,
+      contentLength: req.headers['content-length'] ?? null,
+    });
+  }
+
   let request: CreateAuthRequest;
   try {
     // Behind API Gateway + serverless-http the body can arrive as a Buffer

--- a/pages/api/auth/generate.tsx
+++ b/pages/api/auth/generate.tsx
@@ -15,21 +15,6 @@ function logE2eGenerateError(payload: Record<string, unknown>): void {
   }
 }
 
-/**
- * Read the raw request body from the stream.
- * Used as a fallback when Next.js body-parser has not already populated
- * req.body (e.g. in the Lambda/serverless-http environment where the parser
- * may not fire for every content-type or runtime combination).
- */
-function readRawBody(req: NextApiRequest): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    req.on('data', (chunk: Buffer) => chunks.push(chunk));
-    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
-    req.on('error', reject);
-  });
-}
-
 const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
@@ -43,24 +28,10 @@ const endpoint: NextApiHandler = async (
 
   let request: CreateAuthRequest;
   try {
-    // Resolve to a raw string regardless of how the Lambda/serverless-http
-    // environment delivered the body:
-    //   • object  — Next.js JSON body-parser already ran (normal dev/prod)
-    //   • string  — text/plain or test path
-    //   • Buffer  — binary Lambda payload not decoded by the framework
-    //   • undefined — body-parser did not fire; read from the stream directly
-    let rawBodyStr: string | undefined;
-    if (typeof req.body === 'string') {
-      rawBodyStr = req.body;
-    } else if (Buffer.isBuffer(req.body)) {
-      rawBodyStr = req.body.toString('utf8');
-    } else if (req.body === undefined || req.body === null) {
-      rawBodyStr = await readRawBody(req);
-    }
-
+    // body is usually an object when Next JSON body parsing runs but it can be a string in some test paths. So make sure both shapes are parsed before request.
     request =
-      rawBodyStr !== undefined
-        ? (JSON.parse(rawBodyStr) as CreateAuthRequest)
+      typeof req.body === 'string'
+        ? (JSON.parse(req.body) as CreateAuthRequest)
         : (req.body as CreateAuthRequest);
   } catch (parseErr) {
     logE2eGenerateError({
@@ -81,14 +52,6 @@ const endpoint: NextApiHandler = async (
     typeof request.email !== 'string' ||
     request.email.trim() === ''
   ) {
-    // Always log — visible in CloudWatch on Lambda deployments, not just E2E.
-    if (process.env.JEST_WORKER_ID === undefined) {
-      console.error('[api/auth/generate] validation failed', {
-        reason: 'missing or invalid email',
-        bodyType: typeof req.body,
-        requestKeys: request ? Object.keys(request) : null,
-      });
-    }
     logE2eGenerateError({
       phase: 'validation failed',
       reason: 'missing or invalid email',

--- a/pages/api/auth/generate.tsx
+++ b/pages/api/auth/generate.tsx
@@ -28,9 +28,8 @@ const endpoint: NextApiHandler = async (
 
   let request: CreateAuthRequest;
   try {
-    // Behind API Gateway + serverless-http the body can arrive as a Buffer
-    // even when the client sets Content-Type: application/json, so normalise
-    // here. Standard Next dev/prod gives us a parsed object.
+    // The body can arrive as a Buffer even when the client sets
+    // Content-Type header to application/json, so normalise.
     if (typeof req.body === 'string') {
       request = JSON.parse(req.body) as CreateAuthRequest;
     } else if (Buffer.isBuffer(req.body)) {
@@ -57,13 +56,6 @@ const endpoint: NextApiHandler = async (
     typeof request.email !== 'string' ||
     request.email.trim() === ''
   ) {
-    if (process.env.JEST_WORKER_ID === undefined) {
-      console.error('[api/auth/generate] validation failed', {
-        bodyType: typeof req.body,
-        bodyIsBuffer: Buffer.isBuffer(req.body),
-        requestKeys: request ? Object.keys(request) : null,
-      });
-    }
     logE2eGenerateError({
       phase: 'validation failed',
       reason: 'missing or invalid email',

--- a/pages/api/auth/verify.tsx
+++ b/pages/api/auth/verify.tsx
@@ -10,6 +10,10 @@ function parseVerifyBody(req: NextApiRequest): VerifyAuthRequest | null {
   try {
     if (typeof req.body === 'string') {
       return JSON.parse(req.body) as VerifyAuthRequest;
+    } else if (Buffer.isBuffer(req.body)) {
+      // Behind API Gateway + serverless-http the body can arrive as a Buffer
+      // even when the client sets Content-Type: application/json.
+      return JSON.parse(req.body.toString('utf8')) as VerifyAuthRequest;
     } else if (req.body && typeof req.body === 'object') {
       return req.body as VerifyAuthRequest;
     }

--- a/pages/api/auth/verify.tsx
+++ b/pages/api/auth/verify.tsx
@@ -11,8 +11,8 @@ function parseVerifyBody(req: NextApiRequest): VerifyAuthRequest | null {
     if (typeof req.body === 'string') {
       return JSON.parse(req.body) as VerifyAuthRequest;
     } else if (Buffer.isBuffer(req.body)) {
-      // Behind API Gateway + serverless-http the body can arrive as a Buffer
-      // even when the client sets Content-Type: application/json.
+      // The body can arrive as a Buffer even when the client sets
+      // Content-Type header to application/json, so normalise here.
       return JSON.parse(req.body.toString('utf8')) as VerifyAuthRequest;
     } else if (req.body && typeof req.body === 'object') {
       return req.body as VerifyAuthRequest;


### PR DESCRIPTION
What
--
On entering email or the verify code a 400 was being returned along with "must have email" response. Investigating this the body of the request was being sent as a buffer. I tried to set the header to json but still; 

<img width="951" height="257" alt="Screenshot_2026-05-21_at_14 50 30-c772903c-1674-42" src="https://github.com/user-attachments/assets/e7b35693-b26f-4d55-9c1d-98e5ec5fa209" />

1. Browser sends application/json JSON body
2. API deliver req.body to app as a Buffer
3. Next req.body would deliver a Buffer-shaped object and the current handler can't handle it so email is undefined

So to solve this 

* Sets the header to application/json, doesn't change things but it is accurate.
* Update the handlers to parse buffer type

