### PR TITLE
fix: remove headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ workflows:
             tags:
               only: /^hackney-housing-register-v[0-9]+(\.[0-9]+)*$/
             branches:
-              only: [development, main, bugfix/failing-e2e]
+              only: [development, main]
           matrix:
             parameters:
               browser: [chrome, firefox]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ workflows:
             tags:
               only: /^hackney-housing-register-v[0-9]+(\.[0-9]+)*$/
             branches:
-              only: [development, main]
+              only: [development, main, bugfix/failing-e2e]
           matrix:
             parameters:
               browser: [chrome, firefox]

--- a/lib/gateways/internal-api.ts
+++ b/lib/gateways/internal-api.ts
@@ -12,7 +12,6 @@ export const lookUpAddress = async (postCode: string) => {
 export const updateApplication = async (application: Application) => {
   const res = await fetch(`/api/applications/${application.id}`, {
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(application),
   });
 
@@ -26,7 +25,6 @@ export const updateApplication = async (application: Application) => {
 export const createApplication = async (application: Application) => {
   const res = await fetch(`/api/applications`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(application),
   });
 
@@ -72,7 +70,6 @@ export const addNoteToHistory = async (
 ) => {
   const res = await fetch(`/api/applications/${applicationId}/note`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(request),
   });
   return await res.json();

--- a/lib/store/application.ts
+++ b/lib/store/application.ts
@@ -33,7 +33,6 @@ export const updateApplication = createAsyncThunk(
   async (application: Application, { rejectWithValue }) => {
     const res = await fetch(`/api/applications/${application.id}`, {
       method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(application),
     });
 
@@ -54,7 +53,6 @@ export const disqualifyApplication = createAsyncThunk(
     };
     const res = await fetch(`/api/applications/${id}`, {
       method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request),
     });
     if (res.ok) {
@@ -96,7 +94,6 @@ export const createEvidenceRequest = createAsyncThunk(
     };
     const res = await fetch(`/api/applications/${application.id}/evidence`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request),
     });
     if (res.ok) {
@@ -122,7 +119,6 @@ export const sendConfirmation = createAsyncThunk(
 
     const res = await fetch(`/api/notify/new-application`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(notifyRequest),
     });
 
@@ -151,7 +147,6 @@ export const sendMedicalNeed = createAsyncThunk(
 
     const res = await fetch(`/api/notify/medical`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(notifyRequest),
     });
 
@@ -181,7 +176,6 @@ export const sendDisqualifyEmail = createAsyncThunk(
 
     const res = await fetch(`/api/notify/disqualify`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(notifyRequest),
     });
 


### PR DESCRIPTION
What
-- 

Remove headers introduced in https://github.com/LBHackney-IT/lbh-housing-register/pull/538 on the application fetches as they [break e2e tests](https://app.circleci.com/pipelines/github/LBHackney-IT/lbh-housing-register/1861/workflows/56fab1b8-8a3d-420d-aeda-b5139bee00e8/jobs/10103/tests). Auth fetches can keep the header as they handle all types.

I think this is what's happening when running locally; without the header, req.body is a string, so JSON.parse in routes like pages/api/applications/[id]/index.tsx works fine. With the header it parses req.body into an object, so JSON.parse throws a 500 ([object Object]).

The headers were not a requirement of that PR - they just seem sensible to keep as they reflect the request type. That header in theory doesn't do anything because the request is coming through as buffer on the deployed site anyway. But in the local env it's changing the request structure. 

Future
--

Best practice might be to set the header types across all requests and make sure the request is parsed in the e2e test properly (and in the routes). 

However serverless-http is being dropped in https://github.com/LBHackney-IT/lbh-housing-register/pull/532 which is the source of the buffer issue. So I think it's more valuable to address from that point onwards.