### PR TITLE
test: update tests where address missing will cause failure

### DIFF
--- a/cypress/e2e/pages/applications/edit/[id]/person/index.cy.ts
+++ b/cypress/e2e/pages/applications/edit/[id]/person/index.cy.ts
@@ -1,19 +1,17 @@
 import { faker } from '@faker-js/faker';
 import ApplicationEditPersonPage from '../../../../../../pages/applications/edit/[id]/person';
-import { generateApplication } from '../../../../../../../testUtils/applicationHelper';
+import {
+  generateApplication,
+  withMainApplicantAddressHistory,
+} from '../../../../../../../testUtils/applicationHelper';
 import ViewApplicationPage from '../../../../../../pages/viewApplication';
 import { StatusCodes } from 'http-status-codes';
 
 const applicationId = faker.string.uuid();
 const personId = faker.string.uuid();
 const submittedAt = faker.date.recent().toISOString();
-const application = generateApplication(
-  applicationId,
-  personId,
-  true,
-  false,
-  false,
-  submittedAt,
+const application = withMainApplicantAddressHistory(
+  generateApplication(applicationId, personId, true, false, false, submittedAt),
 );
 
 describe('Edit person in application', () => {

--- a/testUtils/applicationHelper.ts
+++ b/testUtils/applicationHelper.ts
@@ -1,7 +1,9 @@
 import { faker } from '@faker-js/faker';
+import { faker as fakerEnGB } from '@faker-js/faker/locale/en_GB';
 
 import { Application } from 'domain/HousingApi';
 
+import { type Address } from '../lib/utils/adminHelpers';
 import { generatePerson } from './personHelper';
 
 export const generateApplication = (
@@ -129,19 +131,24 @@ export const completedApplicationFormSections = [
   },
 ];
 
-export const sampleMainApplicantAddressHistory = [
-  {
-    address: {
-      line1: '18 Pitchford Street',
-      line2: '',
-      town: 'London',
-      county: '',
-      postcode: 'E154RX',
+export const generateSampleMainApplicantAddressHistory = (): Address[] => {
+  const dateFrom = faker.date.past({ years: 10 });
+  const dateTo = faker.date.between({ from: dateFrom, to: new Date() });
+
+  return [
+    {
+      address: {
+        line1: fakerEnGB.location.streetAddress(),
+        line2: fakerEnGB.location.secondaryAddress(),
+        town: fakerEnGB.location.city(),
+        county: fakerEnGB.location.county(),
+        postcode: fakerEnGB.location.zipCode(),
+      },
+      date: dateFrom.toISOString(),
+      dateTo: dateTo.toISOString(),
     },
-    date: '2020-01-01T00:00:00.000Z',
-    dateTo: '2024-01-01T00:00:00.000Z',
-  },
-];
+  ];
+};
 
 export const withMainApplicantAddressHistory = (
   application: Application,
@@ -158,7 +165,7 @@ export const withMainApplicantAddressHistory = (
         ...(application.mainApplicant.questions ?? []),
         {
           id: 'address-history/addressHistory',
-          answer: JSON.stringify(sampleMainApplicantAddressHistory),
+          answer: JSON.stringify(generateSampleMainApplicantAddressHistory()),
         },
       ],
     },

--- a/testUtils/applicationHelper.ts
+++ b/testUtils/applicationHelper.ts
@@ -128,3 +128,39 @@ export const completedApplicationFormSections = [
     id: 'income-savings/sectionCompleted',
   },
 ];
+
+export const sampleMainApplicantAddressHistory = [
+  {
+    address: {
+      line1: '18 Pitchford Street',
+      line2: '',
+      town: 'London',
+      county: '',
+      postcode: 'E154RX',
+    },
+    date: '2020-01-01T00:00:00.000Z',
+    dateTo: '2024-01-01T00:00:00.000Z',
+  },
+];
+
+export const withMainApplicantAddressHistory = (
+  application: Application,
+): Application => {
+  if (!application.mainApplicant) {
+    return application;
+  }
+
+  return {
+    ...application,
+    mainApplicant: {
+      ...application.mainApplicant,
+      questions: [
+        ...(application.mainApplicant.questions ?? []),
+        {
+          id: 'address-history/addressHistory',
+          answer: JSON.stringify(sampleMainApplicantAddressHistory),
+        },
+      ],
+    },
+  };
+};


### PR DESCRIPTION
## What
Fixes two failing Cypress tests in Edit person in application after address validation was added to MainApplicantForm.

- Added withMainApplicantAddressHistory helper in testUtils/applicationHelper.ts to seed realistic address history on mocked applications
- Updated cypress/e2e/pages/applications/edit/[id]/person/index.cy.ts to use it