### PR TITLE
fix: require authentication on /api/notify/[template] and stop trusting client-supplied email data

### DIFF
--- a/__tests__/pages/api/notify/[template].spec.ts
+++ b/__tests__/pages/api/notify/[template].spec.ts
@@ -1,0 +1,253 @@
+/**
+ * @jest-environment node
+ */
+
+import { StatusCodes } from 'http-status-codes';
+import { createMocks, RequestMethod, RequestOptions } from 'node-mocks-http';
+
+import { Application } from '../../../../domain/HousingApi';
+import { NotifyRequest, NotifyResponse } from '../../../../domain/govukNotify';
+import endpoint from '../../../../pages/api/notify/[template]';
+import { ApiRequest, ApiResponse } from '../../../../testUtils/types';
+
+jest.mock('../../../../lib/utils/users', () => ({
+  getUser: jest.fn(),
+}));
+
+jest.mock('../../../../lib/gateways/applications-api', () => ({
+  getApplication: jest.fn(),
+}));
+
+jest.mock('../../../../lib/gateways/notify-api', () => ({
+  sendNewApplicationEmail: jest.fn(),
+  sendMedicalNeedEmail: jest.fn(),
+  sendDisqualifyEmail: jest.fn(),
+}));
+
+jest.mock('../../../../lib/utils/notifyRequestBuilders', () => ({
+  buildNewApplicationNotifyRequest: jest.fn(),
+  buildMedicalNeedNotifyRequest: jest.fn(),
+  buildDisqualifyNotifyRequest: jest.fn(),
+}));
+
+import { getApplication } from '../../../../lib/gateways/applications-api';
+import {
+  sendDisqualifyEmail,
+  sendMedicalNeedEmail,
+  sendNewApplicationEmail,
+} from '../../../../lib/gateways/notify-api';
+import {
+  buildDisqualifyNotifyRequest,
+  buildMedicalNeedNotifyRequest,
+  buildNewApplicationNotifyRequest,
+} from '../../../../lib/utils/notifyRequestBuilders';
+import { getUser } from '../../../../lib/utils/users';
+
+const getUserMock = getUser as jest.Mock;
+const getApplicationMock = getApplication as jest.Mock;
+const sendNewApplicationEmailMock = sendNewApplicationEmail as jest.Mock;
+const sendMedicalNeedEmailMock = sendMedicalNeedEmail as jest.Mock;
+const sendDisqualifyEmailMock = sendDisqualifyEmail as jest.Mock;
+const buildNewApplicationNotifyRequestMock =
+  buildNewApplicationNotifyRequest as jest.Mock;
+const buildMedicalNeedNotifyRequestMock =
+  buildMedicalNeedNotifyRequest as jest.Mock;
+const buildDisqualifyNotifyRequestMock =
+  buildDisqualifyNotifyRequest as jest.Mock;
+
+const applicationId = 'application-id-1';
+
+const mockApplication: Application = {
+  id: applicationId,
+  reference: 'REF123',
+  mainApplicant: {
+    person: { firstName: 'Jane' },
+    contactInformation: { emailAddress: 'jane@example.com' },
+  },
+};
+
+const mockNotifyRequest: NotifyRequest = {
+  emailAddress: 'jane@example.com',
+  reference: 'REF123',
+  personalisation: { resident_name: 'Jane' },
+};
+
+const mockNotifyResponse: NotifyResponse = {
+  id: 'notify-id',
+  reference: 'REF123',
+  content: {
+    subject: 'subject',
+    body: 'body',
+    from_email: 'from@example.com',
+  },
+};
+
+function mockRequest(
+  template: string,
+  method: RequestMethod = 'POST',
+  body?: unknown,
+): { req: ApiRequest; res: ApiResponse } {
+  return createMocks({
+    method,
+    query: { template },
+    body: body as unknown as RequestOptions['body'],
+  });
+}
+
+describe('/api/notify/[template]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getUserMock.mockReturnValue({ application_id: applicationId });
+    getApplicationMock.mockResolvedValue(mockApplication);
+    buildNewApplicationNotifyRequestMock.mockReturnValue(mockNotifyRequest);
+    buildMedicalNeedNotifyRequestMock.mockReturnValue(mockNotifyRequest);
+    buildDisqualifyNotifyRequestMock.mockReturnValue(mockNotifyRequest);
+    sendNewApplicationEmailMock.mockResolvedValue(mockNotifyResponse);
+    sendMedicalNeedEmailMock.mockResolvedValue(mockNotifyResponse);
+    sendDisqualifyEmailMock.mockResolvedValue(mockNotifyResponse);
+  });
+
+  it('returns 400 for non-POST methods without checking the session', async () => {
+    const { req, res } = mockRequest('new-application', 'GET');
+
+    await endpoint(req, res);
+
+    expect(getUserMock).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res._getJSONData()).toStrictEqual({
+      message: 'Invalid request method',
+    });
+  });
+
+  describe('authorisation', () => {
+    it('returns 401 and never calls Notify when there is no session', async () => {
+      getUserMock.mockReturnValue(undefined);
+
+      const { req, res } = mockRequest('disqualify');
+
+      await endpoint(req, res);
+
+      expect(getApplicationMock).not.toHaveBeenCalled();
+      expect(sendDisqualifyEmailMock).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+      expect(res._getJSONData()).toStrictEqual({ message: 'Unauthorized' });
+    });
+
+    it('returns 401 when the session has no application_id', async () => {
+      getUserMock.mockReturnValue({});
+
+      const { req, res } = mockRequest('disqualify');
+
+      await endpoint(req, res);
+
+      expect(getApplicationMock).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+    });
+
+    it('returns 404 and never calls Notify when the application cannot be found', async () => {
+      getApplicationMock.mockResolvedValue(null);
+
+      const { req, res } = mockRequest('disqualify');
+
+      await endpoint(req, res);
+
+      expect(sendDisqualifyEmailMock).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
+      expect(res._getJSONData()).toStrictEqual({
+        message: 'Application not found',
+      });
+    });
+
+    it('never parses the request body and ignores any attacker-supplied fields', async () => {
+      const attackerBody = JSON.stringify({
+        emailAddress: 'attacker@evil.example',
+        reference: 'attacker-ref',
+        personalisation: { resident_name: 'Attacker' },
+      });
+      const jsonParseSpy = jest.spyOn(JSON, 'parse');
+
+      const { req, res } = mockRequest('disqualify', 'POST', attackerBody);
+
+      await endpoint(req, res);
+
+      expect(jsonParseSpy).not.toHaveBeenCalled();
+      expect(getApplicationMock).toHaveBeenCalledWith(applicationId);
+      expect(buildDisqualifyNotifyRequestMock).toHaveBeenCalledWith(
+        mockApplication,
+      );
+      expect(sendDisqualifyEmailMock).toHaveBeenCalledWith(mockNotifyRequest);
+      expect(res.statusCode).toBe(StatusCodes.OK);
+    });
+
+    it("looks up the caller's own application by their session, not by any request input", async () => {
+      const { req, res } = mockRequest('disqualify');
+
+      await endpoint(req, res);
+
+      expect(getUserMock).toHaveBeenCalledWith(req);
+      expect(getApplicationMock).toHaveBeenCalledTimes(1);
+      expect(getApplicationMock).toHaveBeenCalledWith(applicationId);
+    });
+  });
+
+  describe.each([
+    [
+      'new-application',
+      buildNewApplicationNotifyRequestMock,
+      sendNewApplicationEmailMock,
+    ],
+    ['medical', buildMedicalNeedNotifyRequestMock, sendMedicalNeedEmailMock],
+    ['disqualify', buildDisqualifyNotifyRequestMock, sendDisqualifyEmailMock],
+  ] as const)('template=%s', (template, buildMock, sendMock) => {
+    it('builds the notify request from the fetched application and sends it', async () => {
+      const { req, res } = mockRequest(template);
+
+      await endpoint(req, res);
+
+      expect(buildMock).toHaveBeenCalledWith(mockApplication);
+      expect(sendMock).toHaveBeenCalledWith(mockNotifyRequest);
+      expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res._getJSONData()).toStrictEqual(mockNotifyResponse);
+    });
+  });
+
+  it('returns 400 for an unknown template without calling Notify', async () => {
+    const { req, res } = mockRequest('not-a-real-template');
+
+    await endpoint(req, res);
+
+    expect(sendNewApplicationEmailMock).not.toHaveBeenCalled();
+    expect(sendMedicalNeedEmailMock).not.toHaveBeenCalled();
+    expect(sendDisqualifyEmailMock).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res._getJSONData()).toStrictEqual({
+      message: 'Invalid template request',
+    });
+  });
+
+  it('returns 500 when fetching the application throws', async () => {
+    getApplicationMock.mockRejectedValue(new Error('boom'));
+
+    const { req, res } = mockRequest('disqualify');
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(res._getJSONData()).toStrictEqual({
+      message: 'Unable to send email',
+    });
+  });
+
+  it('returns 500 when the Notify send fails', async () => {
+    sendDisqualifyEmailMock.mockRejectedValue(new Error('notify down'));
+
+    const { req, res } = mockRequest('disqualify');
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(res._getJSONData()).toStrictEqual({
+      message: 'Unable to send email',
+    });
+  });
+});

--- a/__tests__/pages/api/notify/[template].spec.ts
+++ b/__tests__/pages/api/notify/[template].spec.ts
@@ -107,15 +107,16 @@ describe('/api/notify/[template]', () => {
     sendDisqualifyEmailMock.mockResolvedValue(mockNotifyResponse);
   });
 
-  it('returns 400 for non-POST methods without checking the session', async () => {
+  it('returns 405 for non-POST methods without checking the session', async () => {
     const { req, res } = mockRequest('new-application', 'GET');
 
     await endpoint(req, res);
 
     expect(getUserMock).not.toHaveBeenCalled();
-    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.statusCode).toBe(StatusCodes.METHOD_NOT_ALLOWED);
+    expect(res.getHeader('Allow')).toBe('POST');
     expect(res._getJSONData()).toStrictEqual({
-      message: 'Invalid request method',
+      message: 'Method not allowed',
     });
   });
 
@@ -155,6 +156,27 @@ describe('/api/notify/[template]', () => {
       expect(res.statusCode).toBe(StatusCodes.NOT_FOUND);
       expect(res._getJSONData()).toStrictEqual({
         message: 'Application not found',
+      });
+    });
+
+    it('returns 422 and never calls Notify when the application has no email address', async () => {
+      getApplicationMock.mockResolvedValue({
+        ...mockApplication,
+        mainApplicant: {
+          ...mockApplication.mainApplicant,
+          contactInformation: { emailAddress: '   ' },
+        },
+      });
+
+      const { req, res } = mockRequest('disqualify');
+
+      await endpoint(req, res);
+
+      expect(buildDisqualifyNotifyRequestMock).not.toHaveBeenCalled();
+      expect(sendDisqualifyEmailMock).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(StatusCodes.UNPROCESSABLE_ENTITY);
+      expect(res._getJSONData()).toStrictEqual({
+        message: 'Application has no email address',
       });
     });
 
@@ -234,7 +256,7 @@ describe('/api/notify/[template]', () => {
 
     expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
     expect(res._getJSONData()).toStrictEqual({
-      message: 'Unable to send email',
+      message: 'Unable to load application',
     });
   });
 

--- a/cypress/e2e/pages/api/notify/[template].cy.ts
+++ b/cypress/e2e/pages/api/notify/[template].cy.ts
@@ -1,0 +1,115 @@
+import { faker } from '@faker-js/faker/locale/en_GB';
+import { StatusCodes } from 'http-status-codes';
+
+import { Application } from '../../../../../domain/HousingApi';
+import { generateApplication } from '../../../../../testUtils/applicationHelper';
+import { generatePerson } from '../../../../../testUtils/personHelper';
+
+// This spec proves the authorisation fix on /api/notify/[template] holds at
+// the HTTP level (real session cookie, real routing) rather than just in the
+// mocked jest unit tests - specifically that:
+//   1. a request with no resident session is rejected, and Notify is never
+//      contacted, and
+//   2. a request with a valid session sends the *server's* application
+//      record to Notify, ignoring any client-supplied email/personalisation.
+//
+// Note: `lib/gateways/notify-api.ts` deliberately swallows Notify's
+// response/error and always reports success upstream (so a failed send
+// doesn't block a resident's application), so the endpoint's HTTP status
+// can't be used to infer what was sent to Notify. These tests instead use
+// `cy.getE2eCapturedRequests` to inspect the actual request body the server
+// sent, and always register `cy.mockNotifyEmailResponse()` so a bug can
+// never cause a real call to the live GOV.UK Notify API.
+
+const notifyHostname = 'https://api.notifications.service.gov.uk';
+const notifyPath = '/v2/notifications/email';
+
+const applicationId = faker.string.uuid();
+const personId = faker.string.uuid();
+
+const realFirstName = 'RealApplicant';
+const realEmail = faker.internet.email({ provider: 'hackneyTEST.gov.uk' });
+
+const application: Application = (() => {
+  const base = generateApplication(applicationId, personId, true, false);
+  return {
+    ...base,
+    mainApplicant: {
+      ...base.mainApplicant,
+      person: { ...generatePerson(personId), firstName: realFirstName },
+      contactInformation: { emailAddress: realEmail },
+    },
+  };
+})();
+
+const attackerSuppliedBody = {
+  emailAddress: 'attacker@evil.example',
+  reference: 'attacker-controlled-reference',
+  personalisation: {
+    resident_name: 'Attacker Controlled Name',
+    reason: 'attacker controlled reason',
+  },
+};
+
+describe('/api/notify/[template] authorisation', () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.clearE2eNock();
+    // Always mocked, regardless of what each test asserts: guarantees a bug
+    // in these tests (or the endpoint) can never result in a real call to
+    // the live GOV.UK Notify API.
+    cy.mockNotifyEmailResponse();
+  });
+
+  it('rejects a request with no resident session and never contacts Notify', () => {
+    cy.request({
+      method: 'POST',
+      url: '/api/notify/disqualify',
+      body: attackerSuppliedBody,
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(res.status).to.eq(StatusCodes.UNAUTHORIZED);
+    });
+
+    cy.getE2eCapturedRequests(notifyHostname, 'POST', notifyPath).then(
+      (requests) => {
+        expect(requests).to.have.length(0);
+      },
+    );
+  });
+
+  it("sends the caller's own application data to Notify, ignoring any client-supplied body", () => {
+    cy.loginAsResident(applicationId, true);
+    cy.mockHousingRegisterApiGetApplications(applicationId, application, true);
+
+    cy.request({
+      method: 'POST',
+      url: '/api/notify/disqualify',
+      body: attackerSuppliedBody,
+      failOnStatusCode: false,
+    }).then((res) => {
+      expect(res.status).to.eq(StatusCodes.OK);
+    });
+
+    cy.getE2eCapturedRequests(notifyHostname, 'POST', notifyPath).then(
+      (requests) => {
+        expect(requests).to.have.length(1);
+
+        const [{ body }] = requests as {
+          body: {
+            email_address: string;
+            personalisation: Record<string, string>;
+          };
+        }[];
+
+        expect(body.email_address).to.eq(realEmail);
+        expect(body.personalisation.resident_name).to.eq(realFirstName);
+
+        expect(body.email_address).not.to.eq(attackerSuppliedBody.emailAddress);
+        expect(body.personalisation.resident_name).not.to.eq(
+          attackerSuppliedBody.personalisation.resident_name,
+        );
+      },
+    );
+  });
+});

--- a/cypress/e2e/pages/apply/[resident]/summary.cy.ts
+++ b/cypress/e2e/pages/apply/[resident]/summary.cy.ts
@@ -98,11 +98,18 @@ describe('Apply resident summary page', () => {
       true,
     );
 
+    cy.intercept('POST', '**/api/notify/disqualify').as('sendDisqualify');
+
     ApplyHouseholdPage.visit();
     ApplyHouseholdPage.getContinueToNextStepLink().scrollIntoView().click();
     ApplyExpectPage.getContinueToNextStepButton().click();
     ApplyOverviewPage.getApplicantButton(personId).click();
     ApplyResidentSummaryPage.getConfirmDetailsButton().click();
+
+    // Proves /api/notify/disqualify authorised the request and successfully
+    // looked up the application server-side (not silently failing now that
+    // the endpoint requires a session and looks the application up itself).
+    cy.wait('@sendDisqualify').its('response.statusCode').should('eq', 200);
 
     cy.contains('Saving...');
   });

--- a/cypress/e2e/pages/apply/submit/declaration.cy.ts
+++ b/cypress/e2e/pages/apply/submit/declaration.cy.ts
@@ -74,6 +74,15 @@ describe('Declaration', () => {
       applicationWithMainApplicant,
     );
 
+    // /api/notify/new-application now looks up the application itself
+    // (rather than trusting the client-supplied body), so it makes its own
+    // GET /applications/{id} call - this covers that, in addition to the
+    // page's own load above.
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithMainApplicant,
+    );
+
     cy.mockHousingRegisterApiPatchApplication(
       applicationId,
       applicationWithMainApplicant,
@@ -90,6 +99,10 @@ describe('Declaration', () => {
       apiResponseDelay,
     );
 
+    cy.intercept('POST', '**/api/notify/new-application').as(
+      'sendConfirmation',
+    );
+
     DeclarationPage.visit();
     DeclarationPage.getDeclarationPage().should('be.visible');
 
@@ -103,6 +116,12 @@ describe('Declaration', () => {
     );
 
     cy.contains('Saving...');
+
+    // Proves /api/notify/new-application authorised the request and
+    // successfully looked up the application server-side, rather than
+    // failing (e.g. because a mocked backend call ran out) and silently
+    // being swallowed by code that never checks the dispatch result.
+    cy.wait('@sendConfirmation').its('response.statusCode').should('eq', 200);
 
     ConfirmationPage.getConfirmationPage().should('be.visible');
     Components.getLoadingSpinner().should('not.exist');
@@ -121,11 +140,21 @@ describe('Declaration', () => {
       applicationWithNoNeed,
     );
 
+    cy.intercept('POST', '**/api/notify/disqualify').as('sendDisqualify');
+
     DeclarationPage.visit();
     DeclarationPage.getDeclarationPage().should('be.visible');
 
     Components.getCheckboxes().first().click();
 
+    // Two GETs are needed from here: one made by /api/notify/disqualify
+    // itself (it now looks up the application server-side rather than
+    // trusting the client body) and one for the RejectionPage load after
+    // redirect.
+    cy.mockHousingRegisterApiGetApplications(
+      applicationId,
+      applicationWithNoNeed,
+    );
     cy.mockHousingRegisterApiGetApplications(
       applicationId,
       applicationWithNoNeed,
@@ -133,6 +162,12 @@ describe('Declaration', () => {
 
     Components.getSaveButton().click();
     Components.getLoadingSpinner().should('be.visible');
+
+    // Proves /api/notify/disqualify authorised the request and successfully
+    // looked up the application server-side, rather than failing (e.g.
+    // because a mocked backend call ran out) and silently being swallowed
+    // by code that never checks the dispatch result.
+    cy.wait('@sendDisqualify').its('response.statusCode').should('eq', 200);
 
     RejectionPage.getRejectionPage().should('be.visible');
     Components.getLoadingSpinner().should('be.visible');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -422,6 +422,29 @@ Cypress.Commands.add(
   },
 );
 
+/**
+ * Returns every request the Next.js server process has sent to a mocked
+ * dependency (registered via one of the `mock*` commands above), most-recent
+ * last. Useful for asserting on *what* was sent - e.g. that Notify received
+ * the resident's real email/personalisation rather than anything supplied by
+ * the caller - in cases where the response status alone doesn't tell you
+ * (some gateways intentionally swallow the downstream response/error and
+ * always report success upstream).
+ */
+Cypress.Commands.add(
+  'getE2eCapturedRequests',
+  (hostname: string, method: string, path: string) => {
+    return cy
+      .request({
+        method: 'POST',
+        url: '/api/e2e/captured-requests',
+        body: { hostname, method, path },
+        failOnStatusCode: true,
+      })
+      .then((res) => (res.body as { requests: object[] }).requests);
+  },
+);
+
 Cypress.Commands.add('mockAddressAPISearchByPostcode', (postcode: string) => {
   e2eRegisterNock({
     hostname: exposed('LOOKUP_API_URL'),

--- a/lib/server/e2eHttpMocks.ts
+++ b/lib/server/e2eHttpMocks.ts
@@ -41,8 +41,24 @@ function normalizeHostname(hostname: string): string {
  * network, not to fail loudly - so mocks should match on path only (not on
  * request body) and rely on this capture log for body assertions, rather
  * than on registering a deliberately-non-matching interceptor.
+ *
+ * Stored on `globalThis` rather than as a module-level variable: each
+ * `pages/api/**` route is bundled by Next.js as its own server chunk, so a
+ * plain module-level array here would give `/api/e2e/nock` (where requests
+ * are captured) and `/api/e2e/captured-requests` (where they're read back)
+ * *different* instances of this module, despite running in the same Node.js
+ * process. `globalThis` is the one thing genuinely shared across bundles.
  */
-const capturedRequests: CapturedE2eRequest[] = [];
+declare global {
+  var __e2eCapturedRequests: CapturedE2eRequest[] | undefined;
+}
+
+function getCaptureStore(): CapturedE2eRequest[] {
+  if (!globalThis.__e2eCapturedRequests) {
+    globalThis.__e2eCapturedRequests = [];
+  }
+  return globalThis.__e2eCapturedRequests;
+}
 
 export function getCapturedE2eRequests(
   hostname: string,
@@ -51,7 +67,7 @@ export function getCapturedE2eRequests(
 ): CapturedE2eRequest[] {
   const normalizedHostname = normalizeHostname(hostname);
   const normalizedMethod = method.toLowerCase();
-  return capturedRequests.filter(
+  return getCaptureStore().filter(
     (request) =>
       request.hostname === normalizedHostname &&
       request.method === normalizedMethod &&
@@ -99,7 +115,7 @@ export function registerE2eNockMock(input: E2eNockRegisterPayload): void {
   interceptor
     .delay(delay)
     .reply(status, (_uri: string, requestBody: unknown) => {
-      capturedRequests.push({
+      getCaptureStore().push({
         hostname,
         method,
         path,
@@ -114,5 +130,5 @@ export function registerE2eNockMock(input: E2eNockRegisterPayload): void {
 export function clearE2eNockMocks(): void {
   nock.restore();
   nock.cleanAll();
-  capturedRequests.length = 0;
+  globalThis.__e2eCapturedRequests = [];
 }

--- a/lib/server/e2eHttpMocks.ts
+++ b/lib/server/e2eHttpMocks.ts
@@ -12,12 +12,51 @@ export type E2eNockRegisterPayload = {
   delay?: number;
 };
 
+export type CapturedE2eRequest = {
+  hostname: string;
+  method: string;
+  path: string;
+  body: unknown;
+  at: number;
+};
+
 function normalizeHostname(hostname: string): string {
   const trimmed = hostname.trim().replaceAll(/^['"]|['"]$/g, '');
   if (!trimmed) {
     throw new TypeError('E2E nock: hostname is required');
   }
   return trimmed;
+}
+
+/**
+ * Requests matched by any registered mock, most-recent last. Lets tests
+ * assert on *what* the server actually sent to a mocked dependency (e.g.
+ * GOV.UK Notify) rather than only on the response status. This matters
+ * because some callers (see `lib/gateways/notify-api.ts`) deliberately
+ * swallow the downstream response/error and always report success upstream,
+ * so the caller's HTTP status can't be used to infer what was sent.
+ *
+ * Note: nock's default behaviour for a request that doesn't match *any*
+ * registered interceptor for a mocked host is to fall through to the real
+ * network, not to fail loudly - so mocks should match on path only (not on
+ * request body) and rely on this capture log for body assertions, rather
+ * than on registering a deliberately-non-matching interceptor.
+ */
+const capturedRequests: CapturedE2eRequest[] = [];
+
+export function getCapturedE2eRequests(
+  hostname: string,
+  method: string,
+  path: string,
+): CapturedE2eRequest[] {
+  const normalizedHostname = normalizeHostname(hostname);
+  const normalizedMethod = method.toLowerCase();
+  return capturedRequests.filter(
+    (request) =>
+      request.hostname === normalizedHostname &&
+      request.method === normalizedMethod &&
+      request.path === path,
+  );
 }
 
 /**
@@ -59,11 +98,21 @@ export function registerE2eNockMock(input: E2eNockRegisterPayload): void {
 
   interceptor
     .delay(delay)
-    .reply(status, input.body as nock.Body)
+    .reply(status, (_uri: string, requestBody: unknown) => {
+      capturedRequests.push({
+        hostname,
+        method,
+        path,
+        body: requestBody,
+        at: Date.now(),
+      });
+      return input.body as nock.Body;
+    })
     .persist(!!input.persist);
 }
 
 export function clearE2eNockMocks(): void {
   nock.restore();
   nock.cleanAll();
+  capturedRequests.length = 0;
 }

--- a/lib/store/application.ts
+++ b/lib/store/application.ts
@@ -10,7 +10,7 @@ import {
 import { exit } from './auth';
 import mainApplicant from './mainApplicant';
 import otherMembers from './otherMembers';
-import { NotifyRequest, NotifyResponse } from '../../domain/govukNotify';
+import { NotifyResponse } from '../../domain/govukNotify';
 import { getRequiredDocumentsForApplication } from '../utils/evidence';
 import { ApplicationStatus } from '../types/application-status';
 
@@ -104,22 +104,15 @@ export const createEvidenceRequest = createAsyncThunk(
   },
 );
 
+// The server derives the NotifyRequest (email address, reference,
+// personalisation) entirely from the caller's own stored application record
+// - see pages/api/notify/[template].tsx - so these thunks don't send a body.
+
 export const sendConfirmation = createAsyncThunk(
   'application/confirmation',
-  async (application: Application) => {
-    const notifyRequest: NotifyRequest = {
-      emailAddress:
-        application.mainApplicant?.contactInformation?.emailAddress ?? '',
-      personalisation: {
-        ref_number: application.reference ?? '',
-        resident_name: application.mainApplicant?.person?.firstName ?? '',
-      },
-      reference: `${application.reference}`,
-    };
-
+  async () => {
     const res = await fetch(`/api/notify/new-application`, {
       method: 'POST',
-      body: JSON.stringify(notifyRequest),
     });
 
     return (await res.json()) as NotifyResponse;
@@ -128,26 +121,9 @@ export const sendConfirmation = createAsyncThunk(
 
 export const sendMedicalNeed = createAsyncThunk(
   'application/medical',
-  async ({
-    application,
-    medicalNeeds,
-  }: {
-    application: Application;
-    medicalNeeds: number;
-  }) => {
-    const notifyRequest: NotifyRequest = {
-      emailAddress:
-        application.mainApplicant?.contactInformation?.emailAddress ?? '',
-      personalisation: {
-        household_members_with_medical_need: medicalNeeds.toString(),
-        resident_name: application.mainApplicant?.person?.firstName ?? '',
-      },
-      reference: `${application.reference}`,
-    };
-
+  async () => {
     const res = await fetch(`/api/notify/medical`, {
       method: 'POST',
-      body: JSON.stringify(notifyRequest),
     });
 
     return (await res.json()) as NotifyResponse;
@@ -156,27 +132,9 @@ export const sendMedicalNeed = createAsyncThunk(
 
 export const sendDisqualifyEmail = createAsyncThunk(
   'application/disqualify',
-  async ({
-    application,
-    reason,
-  }: {
-    application: Application;
-    reason: string;
-  }) => {
-    const notifyRequest: NotifyRequest = {
-      emailAddress:
-        application.mainApplicant?.contactInformation?.emailAddress ?? '',
-      personalisation: {
-        ref_number: application.reference ?? '',
-        resident_name: application.mainApplicant?.person?.firstName ?? '',
-        reason: reason,
-      },
-      reference: `${application.reference}`,
-    };
-
+  async () => {
     const res = await fetch(`/api/notify/disqualify`, {
       method: 'POST',
-      body: JSON.stringify(notifyRequest),
     });
 
     return (await res.json()) as NotifyResponse;

--- a/lib/utils/notifyRequestBuilders.test.ts
+++ b/lib/utils/notifyRequestBuilders.test.ts
@@ -64,7 +64,7 @@ describe('notifyRequestBuilders', () => {
 
       expect(buildNewApplicationNotifyRequest(application)).toStrictEqual({
         emailAddress: '',
-        reference: 'undefined',
+        reference: '',
         personalisation: {
           ref_number: '',
           resident_name: '',

--- a/lib/utils/notifyRequestBuilders.test.ts
+++ b/lib/utils/notifyRequestBuilders.test.ts
@@ -1,0 +1,144 @@
+import { Application } from '../../domain/HousingApi';
+import {
+  buildDisqualifyNotifyRequest,
+  buildMedicalNeedNotifyRequest,
+  buildNewApplicationNotifyRequest,
+} from './notifyRequestBuilders';
+import { checkEligible } from './form';
+import { applicantsWithMedicalNeed } from './medicalNeed';
+import {
+  DisqualificationReason,
+  getDisqualificationReasonOption,
+} from './disqualificationReasonOptions';
+
+jest.mock('./form', () => ({
+  checkEligible: jest.fn(),
+}));
+
+jest.mock('./medicalNeed', () => ({
+  applicantsWithMedicalNeed: jest.fn(),
+}));
+
+jest.mock('./disqualificationReasonOptions', () => ({
+  getDisqualificationReasonOption: jest.fn(),
+}));
+
+const checkEligibleMock = checkEligible as jest.Mock;
+const applicantsWithMedicalNeedMock = applicantsWithMedicalNeed as jest.Mock;
+const getDisqualificationReasonOptionMock =
+  getDisqualificationReasonOption as jest.Mock;
+
+const baseApplication: Application = {
+  id: 'application-id',
+  reference: 'REF123',
+  mainApplicant: {
+    person: { firstName: 'Jane' },
+    contactInformation: { emailAddress: 'jane@example.com' },
+  },
+};
+
+describe('notifyRequestBuilders', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    checkEligibleMock.mockReturnValue([true, []]);
+    applicantsWithMedicalNeedMock.mockReturnValue(0);
+    getDisqualificationReasonOptionMock.mockImplementation(
+      (reason: DisqualificationReason) => `readable(${reason})`,
+    );
+  });
+
+  describe('buildNewApplicationNotifyRequest', () => {
+    it('derives emailAddress, reference and personalisation from the application', () => {
+      expect(buildNewApplicationNotifyRequest(baseApplication)).toStrictEqual({
+        emailAddress: 'jane@example.com',
+        reference: 'REF123',
+        personalisation: {
+          ref_number: 'REF123',
+          resident_name: 'Jane',
+        },
+      });
+    });
+
+    it('falls back to empty strings when the applicant email or name are missing', () => {
+      const application: Application = { id: 'application-id' };
+
+      expect(buildNewApplicationNotifyRequest(application)).toStrictEqual({
+        emailAddress: '',
+        reference: 'undefined',
+        personalisation: {
+          ref_number: '',
+          resident_name: '',
+        },
+      });
+    });
+  });
+
+  describe('buildMedicalNeedNotifyRequest', () => {
+    it('includes the count of household members with a medical need', () => {
+      applicantsWithMedicalNeedMock.mockReturnValue(2);
+
+      expect(buildMedicalNeedNotifyRequest(baseApplication)).toStrictEqual({
+        emailAddress: 'jane@example.com',
+        reference: 'REF123',
+        personalisation: {
+          household_members_with_medical_need: '2',
+          resident_name: 'Jane',
+        },
+      });
+      expect(applicantsWithMedicalNeedMock).toHaveBeenCalledWith(
+        baseApplication,
+      );
+    });
+
+    it('falls back to an empty resident_name when the applicant name is missing', () => {
+      const application: Application = { id: 'application-id' };
+
+      expect(
+        buildMedicalNeedNotifyRequest(application).personalisation,
+      ).toStrictEqual(expect.objectContaining({ resident_name: '' }));
+    });
+  });
+
+  describe('buildDisqualifyNotifyRequest', () => {
+    it('joins the human-readable disqualification reasons from checkEligible', () => {
+      checkEligibleMock.mockReturnValue([
+        false,
+        ['under18YearsOld', 'incomeOver80000'] as DisqualificationReason[],
+      ]);
+
+      const result = buildDisqualifyNotifyRequest(baseApplication);
+
+      expect(checkEligibleMock).toHaveBeenCalledWith(baseApplication);
+      expect(
+        getDisqualificationReasonOptionMock.mock.calls.map((c) => c[0]),
+      ).toStrictEqual(['under18YearsOld', 'incomeOver80000']);
+      expect(result).toStrictEqual({
+        emailAddress: 'jane@example.com',
+        reference: 'REF123',
+        personalisation: {
+          ref_number: 'REF123',
+          resident_name: 'Jane',
+          reason: 'readable(under18YearsOld),readable(incomeOver80000)',
+        },
+      });
+    });
+
+    it('sends an empty reason when there are no disqualification reasons', () => {
+      checkEligibleMock.mockReturnValue([true, []]);
+
+      const result = buildDisqualifyNotifyRequest(baseApplication);
+
+      expect((result.personalisation as { reason: string }).reason).toBe('');
+    });
+
+    it('falls back to empty ref_number and resident_name when the application data is missing', () => {
+      const application: Application = { id: 'application-id' };
+
+      expect(
+        buildDisqualifyNotifyRequest(application).personalisation,
+      ).toStrictEqual(
+        expect.objectContaining({ ref_number: '', resident_name: '' }),
+      );
+    });
+  });
+});

--- a/lib/utils/notifyRequestBuilders.ts
+++ b/lib/utils/notifyRequestBuilders.ts
@@ -14,7 +14,7 @@ function baseNotifyRequest(
   return {
     emailAddress:
       application.mainApplicant?.contactInformation?.emailAddress ?? '',
-    reference: `${application.reference}`,
+    reference: application.reference ?? '',
   };
 }
 

--- a/lib/utils/notifyRequestBuilders.ts
+++ b/lib/utils/notifyRequestBuilders.ts
@@ -1,0 +1,60 @@
+import { Application } from '../../domain/HousingApi';
+import { NotifyRequest } from '../../domain/govukNotify';
+import { checkEligible } from './form';
+import { applicantsWithMedicalNeed } from './medicalNeed';
+import { getDisqualificationReasonOption } from './disqualificationReasonOptions';
+
+// These builders derive the entire NotifyRequest from the application record
+// fetched server-side, rather than trusting client-supplied email/reference/
+// personalisation values - the caller only chooses which template to send,
+// authorised against their own application.
+function baseNotifyRequest(
+  application: Application,
+): Pick<NotifyRequest, 'emailAddress' | 'reference'> {
+  return {
+    emailAddress:
+      application.mainApplicant?.contactInformation?.emailAddress ?? '',
+    reference: `${application.reference}`,
+  };
+}
+
+export function buildNewApplicationNotifyRequest(
+  application: Application,
+): NotifyRequest {
+  return {
+    ...baseNotifyRequest(application),
+    personalisation: {
+      ref_number: application.reference ?? '',
+      resident_name: application.mainApplicant?.person?.firstName ?? '',
+    },
+  };
+}
+
+export function buildMedicalNeedNotifyRequest(
+  application: Application,
+): NotifyRequest {
+  return {
+    ...baseNotifyRequest(application),
+    personalisation: {
+      household_members_with_medical_need:
+        applicantsWithMedicalNeed(application).toString(),
+      resident_name: application.mainApplicant?.person?.firstName ?? '',
+    },
+  };
+}
+
+export function buildDisqualifyNotifyRequest(
+  application: Application,
+): NotifyRequest {
+  const [, reasons] = checkEligible(application);
+  const reason = reasons.map(getDisqualificationReasonOption).join(',');
+
+  return {
+    ...baseNotifyRequest(application),
+    personalisation: {
+      ref_number: application.reference ?? '',
+      resident_name: application.mainApplicant?.person?.firstName ?? '',
+      reason,
+    },
+  };
+}

--- a/pages/api/e2e/captured-requests.ts
+++ b/pages/api/e2e/captured-requests.ts
@@ -1,0 +1,41 @@
+import { StatusCodes } from 'http-status-codes';
+import type { NextApiHandler } from 'next';
+
+import { getCapturedE2eRequests } from '../../../lib/server/e2eHttpMocks';
+
+interface CapturedRequestsQuery {
+  hostname: string;
+  method: string;
+  path: string;
+}
+
+const endpoint: NextApiHandler = (req, res) => {
+  if (process.env.E2E_HTTP_MOCKS !== 'true') {
+    res.status(StatusCodes.NOT_FOUND).end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
+
+  try {
+    const { hostname, method, path } =
+      typeof req.body === 'string'
+        ? (JSON.parse(req.body) as CapturedRequestsQuery)
+        : (req.body as CapturedRequestsQuery);
+
+    const requests = getCapturedE2eRequests(hostname, method, path);
+    res.status(StatusCodes.OK).json({ requests });
+  } catch (err) {
+    console.error('e2e/captured-requests', err);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: err instanceof Error ? err.message : 'failed' });
+  }
+};
+
+export default endpoint;

--- a/pages/api/notify/[template].tsx
+++ b/pages/api/notify/[template].tsx
@@ -24,7 +24,9 @@ const endpoint: NextApiHandler = async (
   res: NextApiResponse,
 ) => {
   switch (req.method) {
-    case 'POST':
+    case 'POST': {
+      let application: Awaited<ReturnType<typeof getApplication>>;
+
       try {
         const applicationId = getUser(req)?.application_id;
         if (!applicationId) {
@@ -34,14 +36,32 @@ const endpoint: NextApiHandler = async (
           break;
         }
 
-        const application = await getApplication(applicationId);
-        if (!application) {
-          res
-            .status(StatusCodes.NOT_FOUND)
-            .json({ message: 'Application not found' });
-          break;
-        }
+        application = await getApplication(applicationId);
+      } catch (error) {
+        console.error('Unable to load application for Notify', error);
+        res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ message: 'Unable to load application' });
+        break;
+      }
 
+      if (!application) {
+        res
+          .status(StatusCodes.NOT_FOUND)
+          .json({ message: 'Application not found' });
+        break;
+      }
+
+      const emailAddress =
+        application.mainApplicant?.contactInformation?.emailAddress;
+      if (!emailAddress?.trim()) {
+        res
+          .status(StatusCodes.UNPROCESSABLE_ENTITY)
+          .json({ message: 'Application has no email address' });
+        break;
+      }
+
+      try {
         const template = req.query.template as string;
 
         switch (template) {
@@ -73,17 +93,19 @@ const endpoint: NextApiHandler = async (
             break;
         }
       } catch (error) {
-        console.error(error);
+        console.error('Unable to send Notify email', error);
         res
           .status(StatusCodes.INTERNAL_SERVER_ERROR)
           .json({ message: 'Unable to send email' });
       }
       break;
+    }
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'POST')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/notify/[template].tsx
+++ b/pages/api/notify/[template].tsx
@@ -6,7 +6,19 @@ import {
   sendDisqualifyEmail,
   sendMedicalNeedEmail,
 } from '../../../lib/gateways/notify-api';
+import { getApplication } from '../../../lib/gateways/applications-api';
+import {
+  buildDisqualifyNotifyRequest,
+  buildMedicalNeedNotifyRequest,
+  buildNewApplicationNotifyRequest,
+} from '../../../lib/utils/notifyRequestBuilders';
+import { getUser } from '../../../lib/utils/users';
 
+// This endpoint sends real emails via GOV.UK Notify, so it must not trust
+// client-supplied email/personalisation/reference values - a caller could
+// otherwise trigger arbitrary Hackney-branded emails to any address. Instead,
+// it authorises the caller against their own application (via their session)
+// and builds the entire NotifyRequest server-side from that stored record.
 const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
@@ -14,25 +26,43 @@ const endpoint: NextApiHandler = async (
   switch (req.method) {
     case 'POST':
       try {
-        const notification = JSON.parse(req.body);
+        const applicationId = getUser(req)?.application_id;
+        if (!applicationId) {
+          res
+            .status(StatusCodes.UNAUTHORIZED)
+            .json({ message: 'Unauthorized' });
+          break;
+        }
+
+        const application = await getApplication(applicationId);
+        if (!application) {
+          res
+            .status(StatusCodes.NOT_FOUND)
+            .json({ message: 'Application not found' });
+          break;
+        }
+
         const template = req.query.template as string;
 
         switch (template) {
           case 'new-application': {
-            const sendNewApplicationData =
-              await sendNewApplicationEmail(notification);
+            const sendNewApplicationData = await sendNewApplicationEmail(
+              buildNewApplicationNotifyRequest(application),
+            );
             res.status(StatusCodes.OK).json(sendNewApplicationData);
             break;
           }
           case 'medical': {
-            const sendMedicalEmailData =
-              await sendMedicalNeedEmail(notification);
+            const sendMedicalEmailData = await sendMedicalNeedEmail(
+              buildMedicalNeedNotifyRequest(application),
+            );
             res.status(StatusCodes.OK).json(sendMedicalEmailData);
             break;
           }
           case 'disqualify': {
-            const sendDisqualifyEmailData =
-              await sendDisqualifyEmail(notification);
+            const sendDisqualifyEmailData = await sendDisqualifyEmail(
+              buildDisqualifyNotifyRequest(application),
+            );
             res.status(StatusCodes.OK).json(sendDisqualifyEmailData);
             break;
           }

--- a/pages/apply/[resident]/summary.tsx
+++ b/pages/apply/[resident]/summary.tsx
@@ -24,7 +24,6 @@ import { isOver18 } from '../../../lib/utils/dateOfBirth';
 import { FormID } from '../../../lib/utils/form-data';
 import withApplication from '../../../lib/hoc/withApplication';
 import { removeApplicant } from '../../../lib/store/otherMembers';
-import { getDisqualificationReasonOption } from '../../../lib/utils/disqualificationReasonOptions';
 import {
   disqualifyApplication,
   sendDisqualifyEmail,
@@ -80,16 +79,11 @@ const UserSummary = (): JSX.Element => {
   }
 
   const onConfirmData = async () => {
-    const [isEligible, reasons] = checkEligible(application);
+    const [isEligible] = checkEligible(application);
     if (!isEligible) {
-      const reasonStrings = reasons.map((reason) =>
-        getDisqualificationReasonOption(reason),
-      );
-      const reason = reasonStrings.join(',');
-
       try {
         setIsSaving(true);
-        await dispatch(sendDisqualifyEmail({ application, reason }));
+        await dispatch(sendDisqualifyEmail());
         await dispatch(disqualifyApplication(application.id!)).unwrap();
         router.push('/apply/not-eligible');
       } catch {

--- a/pages/apply/submit/declaration.tsx
+++ b/pages/apply/submit/declaration.tsx
@@ -16,7 +16,6 @@ import Form from '../../../components/form/form';
 import Layout from '../../../components/layout/resident-layout';
 import { HeadingOne } from '../../../components/content/headings';
 import Paragraph from '../../../components/content/paragraph';
-import { getDisqualificationReasonOption } from '../../../lib/utils/disqualificationReasonOptions';
 import Custom404 from '../../404';
 import Link from 'next/link';
 import { useState } from 'react';
@@ -35,15 +34,11 @@ const Declaration = (): JSX.Element => {
   const [userError, setUserError] = useState<string | null>(null);
 
   const submitApplication = async () => {
-    const [isEligible, reasons] = checkEligible(application);
+    const [isEligible] = checkEligible(application);
     setUserError(null);
 
     if (!isEligible) {
-      const reasonStrings = reasons.map((reason) =>
-        getDisqualificationReasonOption(reason),
-      );
-      const reason = reasonStrings.join(',');
-      await dispatch(sendDisqualifyEmail({ application, reason }));
+      await dispatch(sendDisqualifyEmail());
 
       try {
         setLoading(true);
@@ -57,11 +52,11 @@ const Declaration = (): JSX.Element => {
         setLoading(false);
       }
     } else {
-      await dispatch(sendConfirmation(application));
+      await dispatch(sendConfirmation());
 
       const medicalNeeds = applicantsWithMedicalNeed(application);
       if (medicalNeeds > 0) {
-        await dispatch(sendMedicalNeed({ application, medicalNeeds }));
+        await dispatch(sendMedicalNeed());
       }
       try {
         setLoading(true);

--- a/types/cypress.d.ts
+++ b/types/cypress.d.ts
@@ -72,6 +72,11 @@ declare global {
         statusCode?: number,
       ): Chainable<void>;
       mockNotifyEmailResponse(statusCode?: number): Chainable<void>;
+      getE2eCapturedRequests(
+        hostname: string,
+        method: string,
+        path: string,
+      ): Chainable<object[]>;
     }
   }
 }


### PR DESCRIPTION
## What

- The endpoint now requires a valid resident session (getUser(req)?.application_id) and returns 401 without contacting Notify if there isn't one.
- It looks up the caller's own application server-side (404 if not found) and builds the entire NotifyRequest from that trusted record via new lib/utils/notifyRequestBuilders.ts helpers.
- The request body is no longer parsed or used at all — a caller can no longer influence the email address, reference, or personalisation sent to Notify.
- Simplified the frontend (sendConfirmation/sendMedicalNeed/sendDisqualifyEmail thunks and their call sites in declaration.tsx/summary.tsx) to POST with no body, since the server derives everything itself now.

## Testing

- Unit tests (__tests__/pages/api/notify/[template].spec.ts, lib/utils/notifyRequestBuilders.test.ts): auth rejection, 404 handling, per-template request building, and that the request body is never parsed/used.
- E2E: fixed two existing Cypress specs whose backend mocks were sized for the old call count and would have silently stopped exercising the Notify flow once this endpoint started looking up the application itself. Added a new spec proving, against a real running server, that (a) an unauthenticated request never reaches Notify, and (b) a spoofed request body is ignored in favour of the resident's real application data.