### PR TITLE
fix: guard checkbox-list data against unanswered questions

### DIFF
--- a/cypress/e2e/pages/reviewApplicant.cy.ts
+++ b/cypress/e2e/pages/reviewApplicant.cy.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 
 import { generateApplication } from '../../../testUtils/applicationHelper';
+import { QuestionKey } from '../../../lib/utils/question-data';
 import ReviewApplicantPage from '../../pages/reviewApplicant';
 
 const personId = faker.string.uuid();
@@ -29,5 +30,120 @@ describe('Review applicant details', () => {
   it("doesn't show the view documents button for read only users", () => {
     ReviewApplicantPage.visit(applicationId, personId);
     ReviewApplicantPage.getViewDocumentsButton().should('not.exist');
+  });
+});
+
+// Regression coverage for a production incident: form answers are persisted
+// as JSON.stringify(value), so an unanswered question is stored as the
+// *string* "null" - truthy, but re-parses to the JS value `null`. Several
+// checkboxListData helpers then called a property/method directly on that
+// parsed value (.toString(), .map(...), array[0].label) with no null guard,
+// throwing an unhandled 500 and taking down the whole page for every field
+// on it. See lib/utils/applicationQuestions.ts and lib/utils/checkboxListData.ts.
+describe('Review applicant details - questions answered with the JSON literal "null"', () => {
+  beforeEach(() => {
+    cy.clearAllCookies();
+    cy.loginAsUser('officer');
+    cy.clearE2eNock();
+  });
+
+  it('shows N/A rather than throwing a 500 for a plain text question', () => {
+    const brokenApplicationId = faker.string.uuid();
+    const brokenPersonId = faker.string.uuid();
+    const brokenApplication = generateApplication(
+      brokenApplicationId,
+      brokenPersonId,
+    );
+    brokenApplication.mainApplicant!.questions = [
+      {
+        id: QuestionKey.RESIDENTIAL_STATUS_RESIDENTIAL_STATUS,
+        answer: 'null',
+      },
+    ];
+
+    cy.mockHousingRegisterApiGetApplications(
+      brokenApplicationId,
+      brokenApplication,
+    );
+    ReviewApplicantPage.visit(brokenApplicationId, brokenPersonId);
+
+    cy.contains('Review main applicant').should('be.visible');
+    ReviewApplicantPage.getLivingSituationSectionNavLink().click();
+    cy.contains('th', '3 year residential status')
+      .siblings('td')
+      .should('have.text', 'N/A');
+  });
+
+  it('renders no address history rows rather than throwing a 500', () => {
+    const brokenApplicationId = faker.string.uuid();
+    const brokenPersonId = faker.string.uuid();
+    const brokenApplication = generateApplication(
+      brokenApplicationId,
+      brokenPersonId,
+    );
+    brokenApplication.mainApplicant!.questions = [
+      { id: QuestionKey.ADDRESS_HISTORY, answer: 'null' },
+    ];
+
+    cy.mockHousingRegisterApiGetApplications(
+      brokenApplicationId,
+      brokenApplication,
+    );
+    ReviewApplicantPage.visit(brokenApplicationId, brokenPersonId);
+
+    cy.contains('Review main applicant').should('be.visible');
+    ReviewApplicantPage.getLivingSituationSectionNavLink().click();
+    cy.contains('caption', 'Address History')
+      .parent()
+      .find('tbody tr')
+      .should('have.length', 0);
+  });
+
+  it('renders no institutions text rather than throwing a 500', () => {
+    const brokenApplicationId = faker.string.uuid();
+    const brokenPersonId = faker.string.uuid();
+    const brokenApplication = generateApplication(
+      brokenApplicationId,
+      brokenPersonId,
+    );
+    brokenApplication.mainApplicant!.questions = [
+      { id: QuestionKey.RESIDENTIAL_STATUS_INSTITUTIONS, answer: 'null' },
+    ];
+
+    cy.mockHousingRegisterApiGetApplications(
+      brokenApplicationId,
+      brokenApplication,
+    );
+    ReviewApplicantPage.visit(brokenApplicationId, brokenPersonId);
+
+    cy.contains('Review main applicant').should('be.visible');
+    ReviewApplicantPage.getLivingSituationSectionNavLink().click();
+    cy.contains(
+      'th',
+      'Applicant has been staying at the following institutions for the last 3 years',
+    )
+      .siblings('td')
+      .should('have.text', 'N/A');
+  });
+
+  it('shows N/A for ethnicity rather than throwing a 500 when the extended category is unanswered', () => {
+    const brokenApplicationId = faker.string.uuid();
+    const brokenPersonId = faker.string.uuid();
+    const brokenApplication = generateApplication(
+      brokenApplicationId,
+      brokenPersonId,
+    );
+    brokenApplication.mainApplicant!.questions = [
+      { id: QuestionKey.ETHNICITY_MAIN_CATEGORY, answer: '"asian"' },
+      { id: 'ethnicity-extended-category-asian', answer: 'null' },
+    ];
+
+    cy.mockHousingRegisterApiGetApplications(
+      brokenApplicationId,
+      brokenApplication,
+    );
+    ReviewApplicantPage.visit(brokenApplicationId, brokenPersonId);
+
+    cy.contains('th', 'Ethnicity').siblings('td').should('have.text', 'N/A');
   });
 });

--- a/cypress/pages/reviewApplicant.ts
+++ b/cypress/pages/reviewApplicant.ts
@@ -13,6 +13,12 @@ class ReviewApplicantPage {
     return cy.get(`[data-testid="${testId}"]`);
   }
 
+  static getLivingSituationSectionNavLink() {
+    // No dataTestId prop is passed for this nav item, but HorizontalNavItem
+    // always sets a `test-nav-item-${itemName}` testid on its button.
+    return cy.get('[data-testid="test-nav-item-livingsituation"]');
+  }
+
   static getViewDocumentsButton() {
     const testId = 'test-view-documents-button';
     return cy.get(`[data-testid="${testId}"]`);

--- a/lib/utils/applicationQuestions.test.ts
+++ b/lib/utils/applicationQuestions.test.ts
@@ -21,6 +21,12 @@ describe('jsonParse', () => {
   test('falls back to an empty string on invalid JSON', () => {
     expect(jsonParse('not valid json')).toBe('');
   });
+
+  test('falls back to an empty string when the input is nullish or empty', () => {
+    expect(jsonParse(undefined)).toBe('');
+    expect(jsonParse(null)).toBe('');
+    expect(jsonParse('')).toBe('');
+  });
 });
 
 describe('getQuestionValue', () => {

--- a/lib/utils/applicationQuestions.test.ts
+++ b/lib/utils/applicationQuestions.test.ts
@@ -1,0 +1,69 @@
+import { Applicant } from '../../domain/HousingApi';
+import {
+  getQuestionValue,
+  jsonParse,
+  questionLookup,
+} from './applicationQuestions';
+
+function applicantWithAnswer(answer: string): Applicant {
+  return {
+    questions: [{ id: 'money/income', answer }],
+  } as Applicant;
+}
+
+describe('jsonParse', () => {
+  test('parses valid JSON', () => {
+    expect(jsonParse('"yes"')).toBe('yes');
+    expect(jsonParse('123')).toBe(123);
+    expect(jsonParse('null')).toBeNull();
+  });
+
+  test('falls back to an empty string on invalid JSON', () => {
+    expect(jsonParse('not valid json')).toBe('');
+  });
+});
+
+describe('getQuestionValue', () => {
+  test('returns N/A when the question has not been answered at all', () => {
+    expect(getQuestionValue('money/income', {})).toBe('N/A');
+  });
+
+  test('returns N/A rather than throwing when the answer is the JSON literal "null"', () => {
+    // JSON.stringify(null) produces the string "null" - a truthy string that
+    // must not be treated as a real answer once parsed back.
+    const applicant = applicantWithAnswer('null');
+    expect(() => getQuestionValue('money/income', applicant)).not.toThrow();
+    expect(getQuestionValue('money/income', applicant)).toBe('N/A');
+  });
+
+  test('returns N/A when the stored answer parses to an empty string', () => {
+    const applicant = applicantWithAnswer('""');
+    expect(getQuestionValue('money/income', applicant)).toBe('N/A');
+  });
+
+  test('capitalises a plain string answer', () => {
+    const applicant = applicantWithAnswer('"yes"');
+    expect(getQuestionValue('money/income', applicant)).toBe('Yes');
+  });
+
+  test('stringifies a numeric answer', () => {
+    const applicant = applicantWithAnswer('1500');
+    expect(getQuestionValue('money/income', applicant)).toBe('1500');
+  });
+
+  test('stringifies a boolean answer', () => {
+    const applicant = applicantWithAnswer('true');
+    expect(getQuestionValue('money/income', applicant)).toBe('True');
+  });
+});
+
+describe('questionLookup', () => {
+  test('returns undefined when the applicant is undefined', () => {
+    expect(questionLookup('money/income', undefined)).toBeUndefined();
+  });
+
+  test('returns the raw stored answer for a matching question id', () => {
+    const applicant = applicantWithAnswer('"yes"');
+    expect(questionLookup('money/income', applicant)).toBe('"yes"');
+  });
+});

--- a/lib/utils/applicationQuestions.ts
+++ b/lib/utils/applicationQuestions.ts
@@ -16,7 +16,7 @@ export const questionLookup = (
   return applicant?.questions?.find((q) => q.id === questionId)?.answer;
 };
 
-export const jsonParse = (parseItem: string): string => {
+export const jsonParse = (parseItem: string): unknown => {
   try {
     return JSON.parse(parseItem);
   } catch {
@@ -29,7 +29,15 @@ export const getQuestionValue = (
   applicant?: Applicant,
 ): string => {
   const questionValue = questionLookup(questionId, applicant);
-  return questionValue
-    ? capitalize(jsonParse(questionValue).toString())
-    : 'N/A';
+  if (questionValue === undefined) {
+    return 'N/A';
+  }
+
+  // Answers are stored via JSON.stringify, so an unanswered question can be
+  // persisted as the *string* "null" (JSON.stringify(null)) - that string is
+  // truthy, but parses back to the JS value `null`, which has no .toString().
+  const parsedValue = jsonParse(questionValue);
+  return parsedValue === null || parsedValue === undefined || parsedValue === ''
+    ? 'N/A'
+    : capitalize(String(parsedValue));
 };

--- a/lib/utils/applicationQuestions.ts
+++ b/lib/utils/applicationQuestions.ts
@@ -16,7 +16,14 @@ export const questionLookup = (
   return applicant?.questions?.find((q) => q.id === questionId)?.answer;
 };
 
-export const jsonParse = (parseItem: string): unknown => {
+export const jsonParse = (parseItem: string | undefined | null): unknown => {
+  // Question.answer is optional on the domain type, and callers previously
+  // papered over that with `answer!` before handing it to JSON.parse - which
+  // would coerce undefined to the string "undefined" and throw a SyntaxError.
+  if (parseItem == null || parseItem === '') {
+    return '';
+  }
+
   try {
     return JSON.parse(parseItem);
   } catch {

--- a/lib/utils/checkboxListData.test.ts
+++ b/lib/utils/checkboxListData.test.ts
@@ -1,0 +1,138 @@
+import { Applicant } from '../../domain/HousingApi';
+import {
+  addressHistoryCheckboxList,
+  personalDetailsCheckboxList,
+  residentialStatusCheckboxList,
+} from './checkboxListData';
+import { QuestionKey } from './question-data';
+
+function applicantWithQuestions(
+  questions: { id: string; answer: string }[],
+): Applicant {
+  return { questions } as Applicant;
+}
+
+function rowValue(
+  list: { data: { title: string; value: string }[] },
+  title: string,
+) {
+  return list.data.find((row) => row.title === title)?.value;
+}
+
+describe('residentialStatusCheckboxList - institutions', () => {
+  test('renders N/A when the question has not been answered', () => {
+    const applicant = applicantWithQuestions([]);
+    const list = residentialStatusCheckboxList(applicant);
+    expect(
+      rowValue(
+        list,
+        'Applicant has been staying at the following institutions for the last 3 years',
+      ),
+    ).toBe('N/A');
+  });
+
+  test('does not throw, and renders N/A, when the stored answer is the JSON literal "null"', () => {
+    const applicant = applicantWithQuestions([
+      { id: QuestionKey.RESIDENTIAL_STATUS_INSTITUTIONS, answer: 'null' },
+    ]);
+    expect(() => residentialStatusCheckboxList(applicant)).not.toThrow();
+    const list = residentialStatusCheckboxList(applicant);
+    expect(
+      rowValue(
+        list,
+        'Applicant has been staying at the following institutions for the last 3 years',
+      ),
+    ).toBe('N/A');
+  });
+
+  test('concatenates institution names when answered', () => {
+    const applicant = applicantWithQuestions([
+      {
+        id: QuestionKey.RESIDENTIAL_STATUS_INSTITUTIONS,
+        answer: JSON.stringify(['Hospital', 'Care Home']),
+      },
+    ]);
+    const list = residentialStatusCheckboxList(applicant);
+    expect(
+      rowValue(
+        list,
+        'Applicant has been staying at the following institutions for the last 3 years',
+      ),
+    ).toBe('HospitalCare Home');
+  });
+});
+
+describe('addressHistoryCheckboxList', () => {
+  test('renders no rows when the question has not been answered', () => {
+    const applicant = applicantWithQuestions([]);
+    expect(addressHistoryCheckboxList(applicant).data).toEqual([]);
+  });
+
+  test('does not throw, and renders no rows, when the stored answer is the JSON literal "null"', () => {
+    const applicant = applicantWithQuestions([
+      { id: QuestionKey.ADDRESS_HISTORY, answer: 'null' },
+    ]);
+    expect(() => addressHistoryCheckboxList(applicant)).not.toThrow();
+    expect(addressHistoryCheckboxList(applicant).data).toEqual([]);
+  });
+
+  test('renders address rows when answered', () => {
+    const applicant = applicantWithQuestions([
+      {
+        id: QuestionKey.ADDRESS_HISTORY,
+        answer: JSON.stringify([
+          {
+            postcode: 'E8 1AB',
+            date: '2021-01-01',
+            dateTo: '',
+            address: { line1: 'Address Line One', town: 'London' },
+          },
+        ]),
+      },
+    ]);
+    const list = addressHistoryCheckboxList(applicant);
+    expect(list.data).toHaveLength(1);
+    expect(list.data[0].title).toBe('Current address');
+    expect(list.data[0].value).toContain('Address Line One');
+  });
+});
+
+describe('personalDetailsCheckboxList - ethnicity', () => {
+  test('renders N/A when the main category has not been answered', () => {
+    const applicant = applicantWithQuestions([]);
+    const list = personalDetailsCheckboxList(applicant);
+    expect(rowValue(list, 'Ethnicity')).toBe('N/A');
+  });
+
+  test('renders N/A rather than the literal text "undefined" when the extended category answer is the JSON literal "null"', () => {
+    const applicant = applicantWithQuestions([
+      { id: QuestionKey.ETHNICITY_MAIN_CATEGORY, answer: '"asian"' },
+      { id: 'ethnicity-extended-category-asian', answer: 'null' },
+    ]);
+    const list = personalDetailsCheckboxList(applicant);
+    expect(rowValue(list, 'Ethnicity')).toBe('N/A');
+  });
+
+  test('renders N/A rather than throwing when the extended category answer does not match any known option', () => {
+    const applicant = applicantWithQuestions([
+      { id: QuestionKey.ETHNICITY_MAIN_CATEGORY, answer: '"asian"' },
+      {
+        id: 'ethnicity-extended-category-asian',
+        answer: '"some-retired-legacy-value"',
+      },
+    ]);
+    expect(() => personalDetailsCheckboxList(applicant)).not.toThrow();
+    expect(rowValue(personalDetailsCheckboxList(applicant), 'Ethnicity')).toBe(
+      'N/A',
+    );
+  });
+
+  test('renders the matching label when answered', () => {
+    const applicant = applicantWithQuestions([
+      { id: QuestionKey.ETHNICITY_MAIN_CATEGORY, answer: '"asian"' },
+      { id: 'ethnicity-extended-category-asian', answer: '"indian"' },
+    ]);
+    const list = personalDetailsCheckboxList(applicant);
+    expect(rowValue(list, 'Ethnicity')).toBe('Indian');
+  });
+});

--- a/lib/utils/checkboxListData.test.ts
+++ b/lib/utils/checkboxListData.test.ts
@@ -113,6 +113,32 @@ describe('personalDetailsCheckboxList - ethnicity', () => {
     expect(rowValue(list, 'Ethnicity')).toBe('N/A');
   });
 
+  test('renders N/A rather than throwing when the extended category answer is missing', () => {
+    const applicant = {
+      questions: [
+        { id: QuestionKey.ETHNICITY_MAIN_CATEGORY, answer: '"asian"' },
+        // Domain type allows answer to be optional - previously forced through
+        // with `answer!` which would make JSON.parse(undefined) throw.
+        { id: 'ethnicity-extended-category-asian' },
+      ],
+    } as Applicant;
+    expect(() => personalDetailsCheckboxList(applicant)).not.toThrow();
+    expect(rowValue(personalDetailsCheckboxList(applicant), 'Ethnicity')).toBe(
+      'N/A',
+    );
+  });
+
+  test('renders N/A rather than throwing when the extended category answer is invalid JSON', () => {
+    const applicant = applicantWithQuestions([
+      { id: QuestionKey.ETHNICITY_MAIN_CATEGORY, answer: '"asian"' },
+      { id: 'ethnicity-extended-category-asian', answer: 'not-valid-json' },
+    ]);
+    expect(() => personalDetailsCheckboxList(applicant)).not.toThrow();
+    expect(rowValue(personalDetailsCheckboxList(applicant), 'Ethnicity')).toBe(
+      'N/A',
+    );
+  });
+
   test('renders N/A rather than throwing when the extended category answer does not match any known option', () => {
     const applicant = applicantWithQuestions([
       { id: QuestionKey.ETHNICITY_MAIN_CATEGORY, answer: '"asian"' },

--- a/lib/utils/checkboxListData.ts
+++ b/lib/utils/checkboxListData.ts
@@ -3,6 +3,7 @@ import { CheckBoxListPageProps } from '../../components/admin/checkbox-list';
 import {
   questionLookup,
   getQuestionValue,
+  jsonParse,
 } from '../../lib/utils/applicationQuestions';
 import { QuestionKey } from './question-data';
 import {
@@ -121,7 +122,7 @@ const ethnicityExtendedCategoryString = (applicant?: Applicant) => {
   const JsonStringEthnicityCategory =
     questionLookup(QuestionKey.ETHNICITY_MAIN_CATEGORY, applicant) || '""';
 
-  const ethnicityCategory = JSON.parse(JsonStringEthnicityCategory);
+  const ethnicityCategory = jsonParse(JsonStringEthnicityCategory);
 
   if (!ethnicityCategory) {
     return 'N/A';
@@ -131,20 +132,21 @@ const ethnicityExtendedCategoryString = (applicant?: Applicant) => {
     return 'Prefer not to say';
   }
 
-  const ethnicityExtendedCategoryQuestion = applicant?.questions?.filter(
+  const ethnicityExtendedCategoryQuestion = applicant?.questions?.find(
     (question) =>
       question.id?.includes(`ethnicity-extended-category-${ethnicityCategory}`),
-  )[0];
+  );
 
   if (!ethnicityExtendedCategoryQuestion) {
     return 'N/A';
   }
 
   // Answers are stored via JSON.stringify, so an unanswered question is
-  // persisted as the string "null" - truthy as a string, but JSON.parse
-  // returns the JS value `null`.
-  const ethnicityExtendedCategory = JSON.parse(
-    ethnicityExtendedCategoryQuestion.answer!,
+  // persisted as the string "null" - truthy as a string, but parses back
+  // to the JS value `null`. jsonParse also tolerates a missing answer
+  // (Question.answer is optional) without the previous `answer!` assertion.
+  const ethnicityExtendedCategory = jsonParse(
+    ethnicityExtendedCategoryQuestion.answer,
   );
 
   if (!ethnicityExtendedCategory) {
@@ -319,9 +321,9 @@ export const residentialStatusCheckboxList = (
 
   let institutionsText = '';
   // Answers are stored via JSON.stringify, so an unanswered question is
-  // persisted as the string "null" - truthy as a string, but JSON.parse
-  // returns the JS value `null`, not an array.
-  const institutionsArray = institutions ? JSON.parse(institutions) : null;
+  // persisted as the string "null" - truthy as a string, but parses back
+  // to the JS value `null`, not an array. jsonParse also swallows invalid JSON.
+  const institutionsArray = institutions ? jsonParse(institutions) : null;
   if (Array.isArray(institutionsArray) && institutionsArray.length > 0) {
     institutionsArray.forEach((item: string) => {
       institutionsText += item;
@@ -470,10 +472,10 @@ export const addressHistoryCheckboxList = (
   };
 
   // Answers are stored via JSON.stringify, so an unanswered question is
-  // persisted as the string "null" - truthy as a string, but JSON.parse
-  // returns the JS value `null`, not an array.
+  // persisted as the string "null" - truthy as a string, but parses back
+  // to the JS value `null`, not an array. jsonParse also swallows invalid JSON.
   const addressHistorysArray = addressHistory
-    ? JSON.parse(addressHistory)
+    ? jsonParse(addressHistory)
     : null;
 
   if (Array.isArray(addressHistorysArray) && addressHistorysArray.length > 0) {

--- a/lib/utils/checkboxListData.ts
+++ b/lib/utils/checkboxListData.ts
@@ -140,15 +140,22 @@ const ethnicityExtendedCategoryString = (applicant?: Applicant) => {
     return 'N/A';
   }
 
+  // Answers are stored via JSON.stringify, so an unanswered question is
+  // persisted as the string "null" - truthy as a string, but JSON.parse
+  // returns the JS value `null`.
   const ethnicityExtendedCategory = JSON.parse(
     ethnicityExtendedCategoryQuestion.answer!,
   );
 
-  if (ethnicityExtendedCategory) {
-    return ethnicityCategoryOptions.filter(
-      (option) => option.value === ethnicityExtendedCategory,
-    )[0].label;
+  if (!ethnicityExtendedCategory) {
+    return 'N/A';
   }
+
+  return (
+    ethnicityCategoryOptions.find(
+      (option) => option.value === ethnicityExtendedCategory,
+    )?.label ?? 'N/A'
+  );
 };
 
 export const personalDetailsCheckboxList = (
@@ -307,12 +314,16 @@ export const residentialStatusCheckboxList = (
 ): CheckBoxListPageProps => {
   const institutions = questionLookup(
     QuestionKey.RESIDENTIAL_STATUS_INSTITUTIONS,
+    applicant,
   );
 
   let institutionsText = '';
-  if (institutions) {
-    const institutionsArray = JSON.parse(institutions);
-    institutionsArray.map((item: string) => {
+  // Answers are stored via JSON.stringify, so an unanswered question is
+  // persisted as the string "null" - truthy as a string, but JSON.parse
+  // returns the JS value `null`, not an array.
+  const institutionsArray = institutions ? JSON.parse(institutions) : null;
+  if (Array.isArray(institutionsArray) && institutionsArray.length > 0) {
+    institutionsArray.forEach((item: string) => {
       institutionsText += item;
     });
   } else {
@@ -458,10 +469,15 @@ export const addressHistoryCheckboxList = (
     data: [],
   };
 
-  if (addressHistory) {
-    //Address Line one, Hackney, London, E8 1AB, From Jan 2021 (6 months)
-    const addressHistorysArray = JSON.parse(addressHistory);
+  // Answers are stored via JSON.stringify, so an unanswered question is
+  // persisted as the string "null" - truthy as a string, but JSON.parse
+  // returns the JS value `null`, not an array.
+  const addressHistorysArray = addressHistory
+    ? JSON.parse(addressHistory)
+    : null;
 
+  if (Array.isArray(addressHistorysArray) && addressHistorysArray.length > 0) {
+    //Address Line one, Hackney, London, E8 1AB, From Jan 2021 (6 months)
     const durations = calculateDurations(addressHistorysArray);
     const history = addressHistorysArray.map(
       (historyEntry: AddressHistoryEntry, index: number) => {


### PR DESCRIPTION
## What
[Sentry errors](https://london-borough-of-hackney.sentry.io/issues/7641967071/?alert_rule_id=15956553&alert_type=issue&environment=production&notification_uuid=8a33aca4-29ca-4cfe-8bcd-30d744377984&project=6292602&referrer=issue_alert-slack) unearthed that staff can't open /applications/view/[id]/[person] for certain applicants — the page throws an unhandled 500 on every load:

TypeError: Cannot read properties of null (reading 'toString')
    at .../pages/applications/view/[id]/[person].js

We're aware the form itself has historical issues outside the scope of maintenance - so it might also be released to the expectation that values are never null but the reality being different. In some places fields are sometimes not guarded correctly (both in terms of user messaging and rejection criteria). 

## Cause
Form answers are persisted as JSON.stringify(value) (lib/store/applicant.ts). An unanswered field is stored as the string "null". Several places in lib/utils/applicationQuestions.ts and lib/utils/checkboxListData.ts checked truthiness of that stored string before parsing it, then called a method on the parsed result without checking for null:

- getQuestionValue: capitalize(jsonParse(questionValue).toString()) → null.toString() throws.
- residentialStatusCheckboxList: institutionsArray.map(...) on a parsed null → same crash.
- addressHistoryCheckboxList: addressHistorysArray.map(...) on a parsed null → same crash.
- ethnicityExtendedCategoryString: silently returned undefined (rendering literal "undefined" text), and separately .filter(...)[0].label could throw on an unrecognised/legacy stored value.

Since getQuestionValue is called multiple times across this file for practically every field on the page, any applicant with even one unanswered question can crash the entire page for every member of staff who opens it.

residentialStatusCheckboxList was calling questionLookup(...) for institutions without passing applicant — a separate, pre-existing bug that meant institutions always silently rendered 'N/A' regardless of real data. 

## Fix

Check the parsed value for null/undefined/empty rather than trusting the raw string's truthiness, and use Array.isArray(...) / .find()?.label ?? 'N/A' instead of unconditional .map/.filter()[0] in the affected spots.

## Tests

- lib/utils/applicationQuestions.test.ts (new, 10 tests) and lib/utils/checkboxListData.test.ts (new, 11 tests) — cover the "null"-literal case, empty/undefined, and the happy path for each fixed function.
- cypress/e2e/pages/reviewApplicant.cy.ts — 4 new e2e tests reproducing each crash site end-to-end against a mocked application with a "null"-literal answer, asserting the page loads and shows N/A instead of a 500.