### PR TITLE
test: cypress vars in the pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,7 @@ jobs:
       AUTHORISED_MANAGER_GROUP: 'cypress-authorised-manager-group'
       AUTHORISED_OFFICER_GROUP: 'cypress-authorised-officer-group'
       AUTHORISED_READONLY_GROUP: 'cypress-authorised-readonly-group'
+      NOTIFY_API_KEY: 'testing'
       # 127.0.0.1 avoids IPv6 localhost (::1) vs nock/axios scope mismatches in Docker.
       HOUSING_REGISTER_API: 'http://127.0.0.1:3910/api/v1/'
       HOUSING_REGISTER_KEY: 'testing'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,7 +326,7 @@ workflows:
             tags:
               only: /^hackney-housing-register-v[0-9]+(\.[0-9]+)*$/
             branches:
-              only: [development, main, tests/add-cypress-envs]
+              only: [development, main]
           matrix:
             parameters:
               browser: [chrome, firefox]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,6 +217,16 @@ jobs:
     environment:
       E2E_HTTP_MOCKS: 'true'
       PORT: '3000'
+      # Cypress signs test JWTs with a dummy secret (see cypress/support/commands.ts),
+      # so verification must be skipped for the app to accept them. Must be 'true'
+      # here even though serverless.yml hardcodes it to false for real deploys.
+      SKIP_VERIFY_TOKEN: 'true'
+      # Group names are arbitrary for testing - value is not important, must just
+      # match cypress.config.ts's exposed defaults for the same vars.
+      AUTHORISED_ADMIN_GROUP: 'cypress-authorised-admin-group'
+      AUTHORISED_MANAGER_GROUP: 'cypress-authorised-manager-group'
+      AUTHORISED_OFFICER_GROUP: 'cypress-authorised-officer-group'
+      AUTHORISED_READONLY_GROUP: 'cypress-authorised-readonly-group'
       # 127.0.0.1 avoids IPv6 localhost (::1) vs nock/axios scope mismatches in Docker.
       HOUSING_REGISTER_API: 'http://127.0.0.1:3910/api/v1/'
       HOUSING_REGISTER_KEY: 'testing'
@@ -315,7 +325,7 @@ workflows:
             tags:
               only: /^hackney-housing-register-v[0-9]+(\.[0-9]+)*$/
             branches:
-              only: [development, main]
+              only: [development, main, tests/add-cypress-envs]
           matrix:
             parameters:
               browser: [chrome, firefox]


### PR DESCRIPTION
## What
On a cleanup I removed old project envs from circle without realising that cypress uses them. This adds them into the pipeline directly as they have no value. 