### PR TITLE
Fix/api method not allowed

### DIFF
--- a/__tests__/lib/gateways/notify-api.spec.ts
+++ b/__tests__/lib/gateways/notify-api.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment node
+ */
+
+import * as Sentry from '@sentry/nextjs';
+import { NotifyClient } from 'notifications-node-client';
+
+import { NotifyRequest } from '../../../domain/govukNotify';
+import {
+  sendDisqualifyEmail,
+  sendMedicalNeedEmail,
+  sendNewApplicationEmail,
+} from '../../../lib/gateways/notify-api';
+
+jest.mock('notifications-node-client', () => ({
+  NotifyClient: jest.fn(),
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+}));
+
+const NotifyClientMock = NotifyClient as unknown as jest.Mock;
+const captureExceptionMock = Sentry.captureException as jest.Mock;
+
+const mockRequest: NotifyRequest = {
+  emailAddress: 'jane@example.com',
+  reference: 'REF123',
+  personalisation: { resident_name: 'Jane' },
+};
+
+const mockNotifyResponseData = {
+  id: 'notify-id',
+  reference: 'REF123',
+  content: {
+    subject: 'subject',
+    body: 'body',
+    from_email: 'from@example.com',
+  },
+};
+
+describe('notify-api gateway', () => {
+  const sendEmailMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NOTIFY_TEMPLATE_NEW_APPLICATION = 'template-new-application';
+    process.env.NOTIFY_TEMPLATE_MEDICAL_NEED = 'template-medical-need';
+    process.env.NOTIFY_TEMPLATE_DISQUALIFY = 'template-disqualify';
+    NotifyClientMock.mockImplementation(() => ({ sendEmail: sendEmailMock }));
+  });
+
+  it.each([
+    [
+      'sendNewApplicationEmail',
+      sendNewApplicationEmail,
+      'template-new-application',
+    ],
+    ['sendMedicalNeedEmail', sendMedicalNeedEmail, 'template-medical-need'],
+    ['sendDisqualifyEmail', sendDisqualifyEmail, 'template-disqualify'],
+  ] as const)(
+    '%s resolves with the unwrapped Notify response data',
+    async (_name, sendFn, expectedTemplateId) => {
+      sendEmailMock.mockResolvedValue({
+        status: 201,
+        data: mockNotifyResponseData,
+      });
+
+      const result = await sendFn(mockRequest);
+
+      expect(result).toStrictEqual(mockNotifyResponseData);
+      expect(sendEmailMock).toHaveBeenCalledWith(
+        expectedTemplateId,
+        mockRequest.emailAddress,
+        {
+          personalisation: mockRequest.personalisation,
+          reference: mockRequest.reference,
+        },
+      );
+      expect(captureExceptionMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('captures the failure to Sentry with the request attached and rethrows, rather than resolving as if it succeeded', async () => {
+    const notifyError = new Error('Notify API rejected the request');
+    sendEmailMock.mockRejectedValue(notifyError);
+
+    await expect(sendDisqualifyEmail(mockRequest)).rejects.toThrow(notifyError);
+
+    expect(captureExceptionMock).toHaveBeenCalledWith(notifyError, {
+      extra: { notifyRequest: mockRequest },
+    });
+  });
+});

--- a/__tests__/pages/api/admin/logout.spec.ts
+++ b/__tests__/pages/api/admin/logout.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment node
+ */
+
+import { StatusCodes } from 'http-status-codes';
+import { createMocks } from 'node-mocks-http';
+
+import endpoint from '../../../../pages/api/admin/logout';
+import { ApiRequest, ApiResponse } from '../../../../testUtils/types';
+
+describe('/api/admin/logout', () => {
+  it('signs the user out on GET', async () => {
+    const { req, res }: { req: ApiRequest; res: ApiResponse } = createMocks({
+      method: 'GET',
+    });
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.OK);
+    expect(res._getJSONData()).toStrictEqual({ message: 'Admin sign out' });
+  });
+
+  it('returns 405 for methods other than GET', async () => {
+    const { req, res }: { req: ApiRequest; res: ApiResponse } = createMocks({
+      method: 'POST',
+    });
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.METHOD_NOT_ALLOWED);
+    expect(res.getHeader('Allow')).toBe('GET');
+    expect(res._getJSONData()).toStrictEqual({ message: 'Method not allowed' });
+  });
+});

--- a/__tests__/pages/api/applications/[id]/complete.spec.ts
+++ b/__tests__/pages/api/applications/[id]/complete.spec.ts
@@ -3,6 +3,7 @@
  */
 
 import { faker } from '@faker-js/faker';
+import axios, { AxiosError } from 'axios';
 import { StatusCodes } from 'http-status-codes';
 
 import { Application } from 'domain/HousingApi';
@@ -15,6 +16,12 @@ import {
   UserRole,
   generateSignedTokenByRole,
 } from '../../../../../testUtils/userHelper';
+
+jest.mock('axios', () => {
+  const actualAxios = jest.requireActual('axios');
+  return { ...actualAxios, isAxiosError: jest.fn() };
+});
+const mockAxiosInstance = axios as jest.Mocked<typeof axios>;
 
 const applicationId = faker.string.uuid();
 const mockApplicationData: Application = {
@@ -61,5 +68,80 @@ describe('authorization', () => {
     await endpoint(req, res);
 
     expect(res.statusCode).toBe(StatusCodes.OK);
+  });
+
+  it('forwards the backend status and body when completeApplication fails with an axios error', async () => {
+    jest.spyOn(requestAuth, 'canUpdateApplication').mockReturnValue(true);
+
+    const axiosErrorStatusCode = StatusCodes.BAD_GATEWAY;
+    const axiosErrorData = { message: 'upstream failure' };
+    const mockAxiosError = {
+      response: { status: axiosErrorStatusCode, data: axiosErrorData },
+    } as AxiosError;
+
+    jest
+      .spyOn(applicationApi, 'completeApplication')
+      .mockImplementationOnce(() => {
+        throw mockAxiosError;
+      });
+    mockAxiosInstance.isAxiosError.mockReturnValueOnce(true);
+
+    const { req, res } = generateMockRequestResponseWithHackneyToken({
+      hackneyToken: signedToken,
+      requestBody: undefined,
+      method: 'PATCH',
+    });
+
+    req.query.id = applicationId;
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(axiosErrorStatusCode);
+    expect(res._getJSONData()).toStrictEqual(axiosErrorData);
+  });
+
+  it('returns a 500 when completeApplication fails with a non-axios error', async () => {
+    jest.spyOn(requestAuth, 'canUpdateApplication').mockReturnValue(true);
+
+    jest
+      .spyOn(applicationApi, 'completeApplication')
+      .mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+
+    const { req, res } = generateMockRequestResponseWithHackneyToken({
+      hackneyToken: signedToken,
+      requestBody: undefined,
+      method: 'PATCH',
+    });
+
+    req.query.id = applicationId;
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+    expect(res._getJSONData()).toStrictEqual({
+      message: 'Unable to update application',
+    });
+  });
+
+  it('returns status code 405 when the request method is not PATCH', async () => {
+    jest.spyOn(requestAuth, 'canUpdateApplication').mockReturnValue(true);
+
+    const { req, res } = generateMockRequestResponseWithHackneyToken({
+      hackneyToken: signedToken,
+      requestBody: undefined,
+      method: 'POST',
+    });
+
+    req.query.id = applicationId;
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.METHOD_NOT_ALLOWED);
+    expect(res.getHeader('Allow')).toBe('PATCH');
+    expect(res._getJSONData()).toStrictEqual({
+      message: 'Method not allowed',
+    });
   });
 });

--- a/__tests__/pages/api/applications/[id]/complete.spec.ts
+++ b/__tests__/pages/api/applications/[id]/complete.spec.ts
@@ -46,7 +46,7 @@ describe('authorization', () => {
 
     req.query.id = applicationId;
 
-    const expectedErrorMessage = { message: 'Unable to update application' };
+    const expectedErrorMessage = { message: 'Access denied' };
 
     await endpoint(req, res);
 

--- a/__tests__/pages/api/applications/[id]/evidence.spec.ts
+++ b/__tests__/pages/api/applications/[id]/evidence.spec.ts
@@ -39,7 +39,7 @@ describe('authorization', () => {
 
     req.query.id = applicationId;
 
-    const expectedErrorMessage = { message: 'Unable to update application' };
+    const expectedErrorMessage = { message: 'Access denied' };
 
     await endpoint(req, res);
 

--- a/__tests__/pages/api/applications/[id]/index.spec.ts
+++ b/__tests__/pages/api/applications/[id]/index.spec.ts
@@ -126,7 +126,7 @@ describe('PATCH', () => {
       });
       canUpdateApplicationSpy.mockReturnValue(false);
       isStaffActionMock.mockReturnValue(false);
-      const expectedError = { message: 'Unable to update application' };
+      const expectedError = { message: 'Access denied' };
 
       //res.status().json() is using the same mock parser as JSON.parse, so need to override the default mock here
       jest.spyOn(JSON, 'parse').mockReturnValue(expectedError);

--- a/__tests__/pages/api/applications/[id]/index.spec.ts
+++ b/__tests__/pages/api/applications/[id]/index.spec.ts
@@ -163,14 +163,40 @@ describe('PATCH', () => {
       create: jest.fn(),
     }));
 
-    it('sets response status code to 500 and returns correct error message when non AxiosError is thrown', async () => {
+    it('sets response status code to 400 when the request body cannot be parsed', async () => {
       const { req, res } = generateMockRequestResponseWithHackneyToken({
         hackneyToken: signedToken,
         method: 'PATCH',
       });
+      const expectedErrorMessage = { message: 'Unable to parse request' };
+
+      // The first call (ours, on req.body) throws; res.json() internally
+      // re-parses the body through this same mocked JSON.parse to power
+      // _getJSONData(), so the fallback also needs to resolve to what we
+      // expect the response body to be (see similar note further down).
       jest.spyOn(JSON, 'parse').mockImplementationOnce(() => {
         throw new Error();
       });
+      jest.spyOn(JSON, 'parse').mockReturnValue(expectedErrorMessage);
+
+      await endpoint(req, res);
+
+      expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+      expect(res._getJSONData()).toStrictEqual(expectedErrorMessage);
+    });
+
+    it('sets response status code to 500 and returns correct error message when non AxiosError is thrown while updating', async () => {
+      const { req, res } = generateMockRequestResponseWithHackneyToken({
+        hackneyToken: signedToken,
+        method: 'PATCH',
+      });
+      jest.spyOn(JSON, 'parse').mockReturnValueOnce(mockApplicationData);
+      jest.spyOn(requestAuth, 'canUpdateApplication').mockReturnValue(true);
+      jest
+        .spyOn(applicationApi, 'updateApplication')
+        .mockImplementationOnce(() => {
+          throw new Error('boom');
+        });
 
       const expectedErrorMessage = { message: 'Unable to update application' };
       await endpoint(req, res);
@@ -226,7 +252,7 @@ describe('PATCH', () => {
       );
     });
 
-    it('logs the error when axios request error is thrown', async () => {
+    it('logs and returns a 500 when an axios error has no response (request made, none received)', async () => {
       const axiosErrorMessage = 'request error from axios';
 
       const mockAxiosError = {
@@ -249,17 +275,23 @@ describe('PATCH', () => {
           throw mockAxiosError;
         });
 
-      const consoleLogSpy = jest.spyOn(console, 'log');
+      const consoleErrorSpy = jest.spyOn(console, 'error');
 
       mockAxiosInstance.isAxiosError.mockReturnValueOnce(true);
 
       await endpoint(req, res);
 
-      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-      expect(consoleLogSpy).toHaveBeenCalledWith(mockAxiosError.request);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Unable to update application',
+        mockAxiosError,
+      );
+      expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(res._getJSONData()).toStrictEqual({
+        message: 'Unable to update application',
+      });
     });
 
-    it('logs the error when axios error other than request or resposne is thrown', async () => {
+    it('logs and returns a 500 when an axios error is thrown with neither request nor response', async () => {
       const mockAxiosError = {
         message: 'error code from axios',
       } as AxiosError;
@@ -278,20 +310,23 @@ describe('PATCH', () => {
           throw mockAxiosError;
         });
 
-      const consoleLogSpy = jest.spyOn(console, 'log');
+      const consoleErrorSpy = jest.spyOn(console, 'error');
 
       mockAxiosInstance.isAxiosError.mockReturnValueOnce(true);
 
       await endpoint(req, res);
 
-      //doing assertions this way to avoid issues with escape characters in expected values
-      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-      const consoleLogSpyCall = consoleLogSpy.mock.calls.pop();
-      expect(consoleLogSpyCall?.[0]).toBe('Error');
-      expect(consoleLogSpyCall?.[1]).toBe(mockAxiosError.message);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Unable to update application',
+        mockAxiosError,
+      );
+      expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
+      expect(res._getJSONData()).toStrictEqual({
+        message: 'Unable to update application',
+      });
     });
 
-    it('sets response status to 400 and returns correct error message when wrong request method is used', async () => {
+    it('sets response status to 405 and returns correct error message when wrong request method is used', async () => {
       const { req, res } = generateMockRequestResponseWithHackneyToken({
         hackneyToken: signedToken,
         method: 'GET',
@@ -299,9 +334,10 @@ describe('PATCH', () => {
 
       await endpoint(req, res);
 
-      const expectedError = { message: 'Invalid request method' };
+      const expectedError = { message: 'Method not allowed' };
 
-      expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+      expect(res.statusCode).toBe(StatusCodes.METHOD_NOT_ALLOWED);
+      expect(res.getHeader('Allow')).toBe('PATCH');
       expect(res._getJSONData()).toStrictEqual(expectedError);
     });
   });

--- a/__tests__/pages/api/applications/[id]/note.spec.ts
+++ b/__tests__/pages/api/applications/[id]/note.spec.ts
@@ -42,7 +42,7 @@ describe('authorization', () => {
     await endpoint(req, res);
 
     expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
-    expect(res._getJSONData()).toStrictEqual({ message: 'Unable to add note' });
+    expect(res._getJSONData()).toStrictEqual({ message: 'Access denied' });
   });
 
   it('returns status code 200 when canUpdateApplication returns true', async () => {

--- a/__tests__/pages/api/applications/[id]/note.spec.ts
+++ b/__tests__/pages/api/applications/[id]/note.spec.ts
@@ -8,7 +8,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import * as applicationApi from '../../../../../lib/gateways/applications-api';
 import * as requestAuth from '../../../../../lib/utils/requestAuth';
-import endpoint from '../../../../../pages/api/applications/[id]/evidence';
+import endpoint from '../../../../../pages/api/applications/[id]/note';
 import { generateMockRequestResponseWithHackneyToken } from '../../../../../testUtils/apiHelper';
 import {
   UserRole,
@@ -26,7 +26,7 @@ const applicationId = faker.string.uuid();
 describe('authorization', () => {
   //claims in the token don't matter in these tests, it just need to exist
   const { signedToken } = generateSignedTokenByRole(UserRole.Officer);
-  jest.spyOn(applicationApi, 'createEvidenceRequest').mockResolvedValue(null);
+  jest.spyOn(applicationApi, 'addNoteToHistory').mockResolvedValue(null);
 
   it('returns status code 403 and error message when canUpdateApplication returns false', async () => {
     jest.spyOn(requestAuth, 'canUpdateApplication').mockReturnValue(false);
@@ -39,12 +39,10 @@ describe('authorization', () => {
 
     req.query.id = applicationId;
 
-    const expectedErrorMessage = { message: 'Unable to update application' };
-
     await endpoint(req, res);
 
     expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
-    expect(res._getJSONData()).toStrictEqual(expectedErrorMessage);
+    expect(res._getJSONData()).toStrictEqual({ message: 'Unable to add note' });
   });
 
   it('returns status code 200 when canUpdateApplication returns true', async () => {
@@ -86,7 +84,7 @@ describe('authorization', () => {
     });
   });
 
-  it('forwards the backend status and body when createEvidenceRequest fails with an axios error', async () => {
+  it('forwards the backend status and body when addNoteToHistory fails with an axios error', async () => {
     jest.spyOn(requestAuth, 'canUpdateApplication').mockReturnValue(true);
 
     const axiosErrorStatusCode = StatusCodes.BAD_GATEWAY;
@@ -96,7 +94,7 @@ describe('authorization', () => {
     } as AxiosError;
 
     jest
-      .spyOn(applicationApi, 'createEvidenceRequest')
+      .spyOn(applicationApi, 'addNoteToHistory')
       .mockImplementationOnce(() => {
         throw mockAxiosError;
       });
@@ -114,5 +112,18 @@ describe('authorization', () => {
 
     expect(res.statusCode).toBe(axiosErrorStatusCode);
     expect(res._getJSONData()).toStrictEqual(axiosErrorData);
+  });
+
+  it('returns 405 for methods other than POST', async () => {
+    const { req, res } = generateMockRequestResponseWithHackneyToken({
+      hackneyToken: signedToken,
+      method: 'GET',
+    });
+
+    await endpoint(req, res);
+
+    expect(res.statusCode).toBe(StatusCodes.METHOD_NOT_ALLOWED);
+    expect(res.getHeader('Allow')).toBe('POST');
+    expect(res._getJSONData()).toStrictEqual({ message: 'Method not allowed' });
   });
 });

--- a/__tests__/pages/api/applications/index.spec.ts
+++ b/__tests__/pages/api/applications/index.spec.ts
@@ -10,7 +10,6 @@ import { Application } from '../../../../domain/HousingApi';
 import * as applicationApi from '../../../../lib/gateways/applications-api';
 import { hasReadOnlyStaffPermissions } from '../../../../lib/utils/hasReadOnlyStaffPermissions';
 import { hasStaffPermissions } from '../../../../lib/utils/hasStaffPermissions';
-import { isStaffAction } from '../../../../lib/utils/isStaffAction';
 import endpoint from '../../../../pages/api/applications/index';
 import {
   MockRequestResponseParams,
@@ -26,16 +25,16 @@ const applicationId = faker.string.uuid();
 const mockApplicationData: Application = {
   id: applicationId,
 };
+const mockApplicationWithAssessment: Application = {
+  id: applicationId,
+  assessment: { reason: 'test' },
+};
 
 const mockRequestResponseParameters: MockRequestResponseParams = {
   hackneyToken: signedToken,
   method: 'POST',
   requestBody: JSON.stringify(mockApplicationData),
 };
-
-jest.mock('../../../../lib/utils/isStaffAction', () => ({
-  isStaffAction: jest.fn(),
-}));
 
 jest.mock('../../../../lib/utils/hasStaffPermissions', () => ({
   hasStaffPermissions: jest.fn(),
@@ -51,17 +50,14 @@ const addApplicationSpy = jest
 
 describe('POST', () => {
   const parseSpy = jest.spyOn(JSON, 'parse');
-  const isStaffActionMock = isStaffAction as jest.Mock;
   const hasStaffPermissionsMock = hasStaffPermissions as jest.Mock;
   const hasReadOnlyStaffPermissionsMock =
     hasReadOnlyStaffPermissions as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    isStaffActionMock.mockReset();
     hasStaffPermissionsMock.mockReset();
     hasReadOnlyStaffPermissionsMock.mockReset();
-    isStaffActionMock.mockReturnValue(true);
     hasStaffPermissionsMock.mockReturnValue(true);
     hasReadOnlyStaffPermissionsMock.mockReturnValue(false);
     addApplicationSpy.mockResolvedValue({ ...mockApplicationData });
@@ -79,10 +75,28 @@ describe('POST', () => {
       await endpoint(req, res);
 
       expect(addApplicationSpy).not.toHaveBeenCalled();
-      expect(parseSpy).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
       expect(res._getJSONData()).toStrictEqual({
         message: 'Unable to add application',
+      });
+    });
+
+    it('returns 403 with the assessment message when the body is a staff action and the caller is not staff', async () => {
+      hasStaffPermissionsMock.mockReturnValue(false);
+
+      const { req, res } = createMocks({
+        method: 'POST',
+        body: JSON.stringify(
+          mockApplicationWithAssessment,
+        ) as unknown as RequestOptions['body'],
+      });
+
+      await endpoint(req, res);
+
+      expect(addApplicationSpy).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
+      expect(res._getJSONData()).toStrictEqual({
+        message: 'Unable to add application with assessment',
       });
     });
 
@@ -97,10 +111,27 @@ describe('POST', () => {
       await endpoint(req, res);
 
       expect(addApplicationSpy).not.toHaveBeenCalled();
-      expect(parseSpy).not.toHaveBeenCalled();
       expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
       expect(res._getJSONData()).toStrictEqual({
         message: 'Unable to add application',
+      });
+    });
+
+    it('returns 403 with the assessment message when the body is a staff action and the caller is read-only staff', async () => {
+      hasStaffPermissionsMock.mockReturnValue(true);
+      hasReadOnlyStaffPermissionsMock.mockReturnValue(true);
+
+      const { req, res } = generateMockRequestResponseWithHackneyToken({
+        ...mockRequestResponseParameters,
+        requestBody: JSON.stringify(mockApplicationWithAssessment),
+      });
+
+      await endpoint(req, res);
+
+      expect(addApplicationSpy).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
+      expect(res._getJSONData()).toStrictEqual({
+        message: 'Unable to add application with assessment',
       });
     });
 
@@ -115,71 +146,24 @@ describe('POST', () => {
       expect(parseSpy).toHaveBeenCalledWith(req.body);
     });
 
-    it('calls isStaffAction with application from request body, hasStaffPermissions and hasReadOnlyStaffPermissions with request when isStaffAction returns true', async () => {
+    it('checks staff permissions once after parsing the body', async () => {
       const { req, res } = generateMockRequestResponseWithHackneyToken(
         mockRequestResponseParameters,
       );
-      const expectedApplication = JSON.parse(req.body);
 
       await endpoint(req, res);
 
-      expect(isStaffActionMock).toHaveBeenCalledWith(expectedApplication);
-      expect(hasStaffPermissionsMock).toHaveBeenCalledTimes(2);
+      expect(hasStaffPermissionsMock).toHaveBeenCalledTimes(1);
       expect(hasStaffPermissionsMock).toHaveBeenCalledWith(req);
-      expect(hasReadOnlyStaffPermissionsMock).toHaveBeenCalledTimes(2);
+      expect(hasReadOnlyStaffPermissionsMock).toHaveBeenCalledTimes(1);
       expect(hasReadOnlyStaffPermissionsMock).toHaveBeenCalledWith(req);
     });
 
-    it('sets response status code to 403 when isStaffAction returns true and hasStaffPermissions returns false after parsing', async () => {
-      const { req, res } = generateMockRequestResponseWithHackneyToken(
-        mockRequestResponseParameters,
-      );
-      const expectedErrorMessage = {
-        message: 'Unable to add application with assessment',
-      };
-
-      isStaffActionMock.mockReturnValue(true);
-      hasStaffPermissionsMock
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false);
-
-      await endpoint(req, res);
-
-      expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
-      expect(res._getJSONData()).toStrictEqual(expectedErrorMessage);
-    });
-
-    it('sets response status code to 403 and adds an error message to the response when isStaffAction returns true, hasStaffPermissions returns false and hasReadOnlyStaffPermissions returns true', async () => {
-      const { req, res } = generateMockRequestResponseWithHackneyToken(
-        mockRequestResponseParameters,
-      );
-      const expectedErrorMessage = {
-        message: 'Unable to add application with assessment',
-      };
-
-      isStaffActionMock.mockReturnValue(true);
-      hasStaffPermissionsMock
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false);
-      hasReadOnlyStaffPermissionsMock
-        .mockReturnValueOnce(false)
-        .mockReturnValueOnce(true);
-
-      await endpoint(req, res);
-
-      expect(res.statusCode).toBe(StatusCodes.FORBIDDEN);
-      expect(res._getJSONData()).toStrictEqual(expectedErrorMessage);
-    });
-
-    it('calls addApplication with application from the request body when isStaffAction and hasStaffPermissions return true and hasReadOnlyStaffPermissions returns false', async () => {
+    it('calls addApplication with application from the request body when the caller has write access', async () => {
       const { req, res } = generateMockRequestResponseWithHackneyToken(
         mockRequestResponseParameters,
       );
       const expectedApplication = JSON.parse(req.body);
-
-      isStaffActionMock.mockReturnValue(true);
-      hasStaffPermissionsMock.mockReturnValue(true);
-      hasReadOnlyStaffPermissionsMock.mockReturnValue(false);
 
       await endpoint(req, res);
 
@@ -192,9 +176,6 @@ describe('POST', () => {
         mockRequestResponseParameters,
       );
       const expectedApplication = JSON.parse(req.body);
-
-      isStaffActionMock.mockReturnValue(true);
-      hasStaffPermissionsMock.mockReturnValue(true);
 
       await endpoint(req, res);
 

--- a/__tests__/pages/api/applications/index.spec.ts
+++ b/__tests__/pages/api/applications/index.spec.ts
@@ -202,11 +202,11 @@ describe('POST', () => {
       expect(res._getJSONData()).toStrictEqual(expectedApplication);
     });
 
-    it('sets correct response status code (500) and error message when exception is thrown', async () => {
+    it('sets response status code to 400 when the request body cannot be parsed', async () => {
       const { req, res } = generateMockRequestResponseWithHackneyToken(
         mockRequestResponseParameters,
       );
-      const expectedErrorMessage = { message: 'Unable to add application' };
+      const expectedErrorMessage = { message: 'Unable to parse request' };
       const mockErrorMessage = 'parse error';
 
       parseSpy.mockImplementationOnce(() => {
@@ -215,8 +215,43 @@ describe('POST', () => {
 
       await endpoint(req, res);
 
+      expect(addApplicationSpy).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+      expect(res._getJSONData()).toStrictEqual(expectedErrorMessage);
+    });
+
+    it('sets correct response status code (500) and error message when addApplication throws a non-axios error', async () => {
+      const { req, res } = generateMockRequestResponseWithHackneyToken(
+        mockRequestResponseParameters,
+      );
+      const expectedErrorMessage = { message: 'Unable to add application' };
+
+      addApplicationSpy.mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+
+      await endpoint(req, res);
+
       expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR);
       expect(res._getJSONData()).toStrictEqual(expectedErrorMessage);
+    });
+  });
+});
+
+describe('unsupported request methods', () => {
+  it('returns 405 and advertises both supported methods', async () => {
+    const { req, res } = generateMockRequestResponseWithHackneyToken({
+      ...mockRequestResponseParameters,
+      method: 'DELETE',
+    });
+
+    await endpoint(req, res);
+
+    expect(addApplicationSpy).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(StatusCodes.METHOD_NOT_ALLOWED);
+    expect(res.getHeader('Allow')).toBe('GET, POST');
+    expect(res._getJSONData()).toStrictEqual({
+      message: 'Method not allowed',
     });
   });
 });

--- a/__tests__/pages/api/auth/generate.spec.ts
+++ b/__tests__/pages/api/auth/generate.spec.ts
@@ -266,7 +266,7 @@ describe('POST', () => {
   });
 
   it.each(invalidRequestMethods)(
-    'returns status code 400 when request method is %p',
+    'returns status code 405 when request method is %p',
     async (requestMethod) => {
       const reqOptions: RequestOptions = {
         method: requestMethod as RequestMethod,
@@ -277,8 +277,9 @@ describe('POST', () => {
         createMocks(reqOptions);
 
       await endpoint(req, res);
-      expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
-      expect(res._getJSONData()).toEqual({ message: 'Invalid request method' });
+      expect(res.statusCode).toBe(StatusCodes.METHOD_NOT_ALLOWED);
+      expect(res.getHeader('Allow')).toBe('POST');
+      expect(res._getJSONData()).toEqual({ message: 'Method not allowed' });
     },
   );
 });

--- a/__tests__/pages/api/auth/verify.spec.ts
+++ b/__tests__/pages/api/auth/verify.spec.ts
@@ -206,7 +206,7 @@ describe('POST /api/auth/verify', () => {
   });
 
   it.each(invalidRequestMethods)(
-    'returns 400 when the request method is %p',
+    'returns 405 when the request method is %p',
     async (requestMethod) => {
       const { req, res }: { req: ApiRequest; res: ApiResponse } = createMocks({
         method: requestMethod as RequestMethod,
@@ -215,9 +215,10 @@ describe('POST /api/auth/verify', () => {
 
       await endpoint(req, res);
 
-      expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+      expect(res.statusCode).toBe(StatusCodes.METHOD_NOT_ALLOWED);
+      expect(res.getHeader('Allow')).toBe('POST');
       expect(res._getJSONData()).toStrictEqual({
-        message: 'Invalid request method',
+        message: 'Method not allowed',
       });
     },
   );

--- a/components/admin/other-members.tsx
+++ b/components/admin/other-members.tsx
@@ -77,22 +77,6 @@ export default function OtherMembers({
                     Remove household member
                   </button>
                 )}
-
-                <Dialog
-                  isOpen={showDeleteWarningDialog && !userError}
-                  title="Confirm delete"
-                  onDismiss={() => setShowDeleteWarningDialog(false)}
-                  onConfirm={() => handleDelete(applicantToDelete)}
-                  onCancel={() => setShowDeleteWarningDialog(false)}
-                  confirmButtonTestId={`test-remove-household-member-confirmation-button-${applicant.person?.id}`}
-                >
-                  <Paragraph>
-                    Are you sure you want to remove{' '}
-                    {applicantToDelete.person?.title}{' '}
-                    {applicantToDelete.person?.firstName}{' '}
-                    {applicantToDelete.person?.surname}?
-                  </Paragraph>
-                </Dialog>
               </td>
               <td className="govuk-table__cell govuk-table__cell--numeric">
                 {canEdit && (
@@ -115,6 +99,20 @@ export default function OtherMembers({
           ))}
         </tbody>
       </table>
+      <Dialog
+        isOpen={showDeleteWarningDialog && !userError}
+        title="Confirm delete"
+        onDismiss={() => setShowDeleteWarningDialog(false)}
+        onConfirm={() => handleDelete(applicantToDelete)}
+        onCancel={() => setShowDeleteWarningDialog(false)}
+        confirmButtonTestId={`test-remove-household-member-confirmation-button-${applicantToDelete.person?.id}`}
+      >
+        <Paragraph>
+          Are you sure you want to remove {applicantToDelete.person?.title}{' '}
+          {applicantToDelete.person?.firstName}{' '}
+          {applicantToDelete.person?.surname}?
+        </Paragraph>
+      </Dialog>
     </>
   );
 }

--- a/cypress/e2e/local/managerActions.cy.ts
+++ b/cypress/e2e/local/managerActions.cy.ts
@@ -360,8 +360,13 @@ describe('Manager actions', () => {
       cy.contains(`${childFirstName} ${childLastName}`);
 
       //remove partner and check
-      cy.contains('Remove household member').first().click();
-      cy.contains('Yes').click({ force: true });
+      cy.contains('tr', `${partnerFirstName} ${partnerLastName}`)
+        .find('[data-testid^="test-remove-household-member-button-"]')
+        .click();
+      cy.contains('Confirm delete');
+      cy.get(
+        '[data-testid^="test-remove-household-member-confirmation-button-"]',
+      ).click();
 
       cy.contains(
         `${mainApplicantTitle} ${mainApplicantFirstName} ${mainApplicantLastName} (+1)`,

--- a/cypress/e2e/pages/api/notify/[template].cy.ts
+++ b/cypress/e2e/pages/api/notify/[template].cy.ts
@@ -13,13 +13,13 @@ import { generatePerson } from '../../../../../testUtils/personHelper';
 //   2. a request with a valid session sends the *server's* application
 //      record to Notify, ignoring any client-supplied email/personalisation.
 //
-// Note: `lib/gateways/notify-api.ts` deliberately swallows Notify's
-// response/error and always reports success upstream (so a failed send
-// doesn't block a resident's application), so the endpoint's HTTP status
-// can't be used to infer what was sent to Notify. These tests instead use
-// `cy.getE2eCapturedRequests` to inspect the actual request body the server
-// sent, and always register `cy.mockNotifyEmailResponse()` so a bug can
-// never cause a real call to the live GOV.UK Notify API.
+// Note: a 200 here only proves the request was authorised, the application
+// was found, and Notify accepted the call - it doesn't on its own prove
+// *what* was sent (an attacker-controlled body sent to Notify unchanged
+// would also come back 200). These tests use `cy.getE2eCapturedRequests` to
+// inspect the actual request body the server sent to Notify, and always
+// register `cy.mockNotifyEmailResponse()` so a bug can never cause a real
+// call to the live GOV.UK Notify API.
 
 const notifyHostname = 'https://api.notifications.service.gov.uk';
 const notifyPath = '/v2/notifications/email';

--- a/cypress/e2e/pages/apply/submit/declaration.cy.ts
+++ b/cypress/e2e/pages/apply/submit/declaration.cy.ts
@@ -170,7 +170,7 @@ describe('Declaration', () => {
     cy.wait('@sendDisqualify').its('response.statusCode').should('eq', 200);
 
     RejectionPage.getRejectionPage().should('be.visible');
-    Components.getLoadingSpinner().should('be.visible');
+    Components.getLoadingSpinner().should('not.exist');
   });
 
   it('shows an error message when cannot complete successful application', () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -427,9 +427,8 @@ Cypress.Commands.add(
  * dependency (registered via one of the `mock*` commands above), most-recent
  * last. Useful for asserting on *what* was sent - e.g. that Notify received
  * the resident's real email/personalisation rather than anything supplied by
- * the caller - in cases where the response status alone doesn't tell you
- * (some gateways intentionally swallow the downstream response/error and
- * always report success upstream).
+ * the caller - since the response status alone can't distinguish "sent the
+ * real data" from "sent the attacker-supplied data" when both succeed.
  */
 Cypress.Commands.add(
   'getE2eCapturedRequests',

--- a/lib/gateways/applications-api.ts
+++ b/lib/gateways/applications-api.ts
@@ -192,7 +192,7 @@ export const listNovaletExports = async (
 
 export const downloadNovaletExport = async (
   filename: string,
-): Promise<AxiosResponse | null> => {
+): Promise<AxiosResponse> => {
   const url = `reporting/novaletexport/${filename}`;
   return await housingAxios().get(url, {
     responseType: 'blob',
@@ -207,15 +207,14 @@ export const generateNovaletExport = async (): Promise<AxiosResponse> => {
 export const downloadInternalReport = async (
   reportDetails: InternalReportRequest,
   req: NextApiRequest,
-): Promise<AxiosResponse | null> => {
+): Promise<AxiosResponse> => {
   const url = `reporting/export`;
-  const data = await authenticatedHousingAxios(req).post(url, reportDetails, {
+  return await authenticatedHousingAxios(req).post(url, reportDetails, {
     headers: {
       'Content-Type': 'application/json',
     },
     responseType: 'blob',
   });
-  return data;
 };
 
 export const approveNovaletExport = async (

--- a/lib/gateways/notify-api.ts
+++ b/lib/gateways/notify-api.ts
@@ -6,55 +6,51 @@ import { NotifyClient } from 'notifications-node-client';
 // itself (rather than relying on `console.error` + breadcrumbs), so the
 // payload that caused a Notify failure is always visible on the event,
 // regardless of breadcrumb/scope isolation health.
-function captureNotifyError(err: unknown, request: NotifyRequest) {
+function captureNotifyError(err: unknown, request: NotifyRequest): void {
   Sentry.captureException(err, { extra: { notifyRequest: request } });
 }
 
-export const sendNewApplicationEmail = async (
+async function sendEmail(
+  templateId: string | undefined,
   request: NotifyRequest,
-): Promise<NotifyResponse> => {
+): Promise<NotifyResponse> {
   const notifyClient = new NotifyClient(process.env.NOTIFY_API_KEY);
-  const response = await notifyClient
-    .sendEmail(
-      process.env.NOTIFY_TEMPLATE_NEW_APPLICATION,
+
+  try {
+    const response = await notifyClient.sendEmail(
+      templateId,
       request.emailAddress,
       {
         personalisation: request.personalisation,
         reference: request.reference,
       },
-    )
-    .then((response: NotifyResponse) => console.log(response))
-    .catch((err: NotifyResponse) => captureNotifyError(err, request));
+    );
 
-  return response as NotifyResponse;
-};
+    // sendEmail resolves with the raw Axios response - the NotifyResponse
+    // shape (id/reference/content) lives on `.data`.
+    return response.data as NotifyResponse;
+  } catch (err) {
+    // Previously this was swallowed here (logged/captured then treated as a
+    // successful, empty response), so the caller always got a 200 with no
+    // body regardless of whether the email actually sent. Capture to Sentry
+    // with the payload attached, then rethrow so /api/notify/[template] can
+    // return a proper error status to the client.
+    captureNotifyError(err, request);
+    throw err;
+  }
+}
 
-export const sendMedicalNeedEmail = async (
+export const sendNewApplicationEmail = (
   request: NotifyRequest,
-): Promise<NotifyResponse> => {
-  const notifyClient = new NotifyClient(process.env.NOTIFY_API_KEY);
-  const response = await notifyClient
-    .sendEmail(process.env.NOTIFY_TEMPLATE_MEDICAL_NEED, request.emailAddress, {
-      personalisation: request.personalisation,
-      reference: request.reference,
-    })
-    .then((response: NotifyResponse) => console.log(response))
-    .catch((err: NotifyResponse) => captureNotifyError(err, request));
+): Promise<NotifyResponse> =>
+  sendEmail(process.env.NOTIFY_TEMPLATE_NEW_APPLICATION, request);
 
-  return response as NotifyResponse;
-};
-
-export const sendDisqualifyEmail = async (
+export const sendMedicalNeedEmail = (
   request: NotifyRequest,
-): Promise<NotifyResponse> => {
-  const notifyClient = new NotifyClient(process.env.NOTIFY_API_KEY);
-  const response = await notifyClient
-    .sendEmail(process.env.NOTIFY_TEMPLATE_DISQUALIFY, request.emailAddress, {
-      personalisation: request.personalisation,
-      reference: request.reference,
-    })
-    .then((response: NotifyResponse) => console.log(response))
-    .catch((err: NotifyResponse) => captureNotifyError(err, request));
+): Promise<NotifyResponse> =>
+  sendEmail(process.env.NOTIFY_TEMPLATE_MEDICAL_NEED, request);
 
-  return response as NotifyResponse;
-};
+export const sendDisqualifyEmail = (
+  request: NotifyRequest,
+): Promise<NotifyResponse> =>
+  sendEmail(process.env.NOTIFY_TEMPLATE_DISQUALIFY, request);

--- a/lib/server/e2eHttpMocks.ts
+++ b/lib/server/e2eHttpMocks.ts
@@ -31,10 +31,9 @@ function normalizeHostname(hostname: string): string {
 /**
  * Requests matched by any registered mock, most-recent last. Lets tests
  * assert on *what* the server actually sent to a mocked dependency (e.g.
- * GOV.UK Notify) rather than only on the response status. This matters
- * because some callers (see `lib/gateways/notify-api.ts`) deliberately
- * swallow the downstream response/error and always report success upstream,
- * so the caller's HTTP status can't be used to infer what was sent.
+ * GOV.UK Notify), which is the only way to tell the real application data
+ * apart from an attacker-supplied body when both would otherwise produce
+ * the same HTTP status.
  *
  * Note: nock's default behaviour for a request that doesn't match *any*
  * registered interceptor for a mocked host is to fall through to the real

--- a/lib/store/application.ts
+++ b/lib/store/application.ts
@@ -10,7 +10,6 @@ import {
 import { exit } from './auth';
 import mainApplicant from './mainApplicant';
 import otherMembers from './otherMembers';
-import { NotifyResponse } from '../../domain/govukNotify';
 import { getRequiredDocumentsForApplication } from '../utils/evidence';
 import { ApplicationStatus } from '../types/application-status';
 
@@ -107,37 +106,50 @@ export const createEvidenceRequest = createAsyncThunk(
 // The server derives the NotifyRequest (email address, reference,
 // personalisation) entirely from the caller's own stored application record
 // - see pages/api/notify/[template].tsx - so these thunks don't send a body.
-
 export const sendConfirmation = createAsyncThunk(
   'application/confirmation',
-  async () => {
+  async (_: void, { rejectWithValue }) => {
     const res = await fetch(`/api/notify/new-application`, {
       method: 'POST',
     });
 
-    return (await res.json()) as NotifyResponse;
+    if (!res.ok) {
+      const message = `Unable to send confirmation email (${res.status})`;
+      console.error(message);
+      return rejectWithValue(message);
+    }
   },
 );
 
 export const sendMedicalNeed = createAsyncThunk(
   'application/medical',
-  async () => {
+  async (_: void, { rejectWithValue }) => {
     const res = await fetch(`/api/notify/medical`, {
       method: 'POST',
     });
 
-    return (await res.json()) as NotifyResponse;
+    if (!res.ok) {
+      const message = `Unable to send medical need email (${res.status})`;
+      console.error(message);
+      return rejectWithValue(message);
+    }
   },
 );
 
+// Must not share `disqualifyApplication`'s type prefix: these are different
+// actions, and that case replaces the whole application state with its payload.
 export const sendDisqualifyEmail = createAsyncThunk(
-  'application/disqualify',
-  async () => {
+  'application/disqualifyEmail',
+  async (_: void, { rejectWithValue }) => {
     const res = await fetch(`/api/notify/disqualify`, {
       method: 'POST',
     });
 
-    return (await res.json()) as NotifyResponse;
+    if (!res.ok) {
+      const message = `Unable to send disqualify email (${res.status})`;
+      console.error(message);
+      return rejectWithValue(message);
+    }
   },
 );
 

--- a/pages/api/address/[postcode]/index.ts
+++ b/pages/api/address/[postcode]/index.ts
@@ -7,29 +7,27 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'GET':
-      try {
-        const { postcode } = req.query;
-        if (!postcode) {
-          res.status(StatusCodes.BAD_REQUEST).send('Missing postcode');
-          return;
-        }
-        const data = await lookUpAddress(postcode);
-        res.status(StatusCodes.OK).json(data);
-      } catch (error) {
-        console.error(error);
-        res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ message: 'Unable to look up address' });
-      }
-      break;
+  if (req.method !== 'GET') {
+    res
+      .setHeader('Allow', 'GET')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-    default:
-      res
-        .setHeader('Allow', 'GET')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+  try {
+    const { postcode } = req.query;
+    if (!postcode) {
+      res.status(StatusCodes.BAD_REQUEST).send('Missing postcode');
+      return;
+    }
+    const data = await lookUpAddress(postcode);
+    res.status(StatusCodes.OK).json(data);
+  } catch (error) {
+    console.error(error);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: 'Unable to look up address' });
   }
 };
 

--- a/pages/api/address/[postcode]/index.ts
+++ b/pages/api/address/[postcode]/index.ts
@@ -27,8 +27,9 @@ const endpoint: NextApiHandler = async (
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'GET')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/admin/logout.tsx
+++ b/pages/api/admin/logout.tsx
@@ -7,29 +7,27 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
+  if (req.method !== 'GET') {
+    res
+      .setHeader('Allow', 'GET')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
+
   const isAdminUser = !!getSession(req);
 
-  switch (req.method) {
-    case 'GET':
-      try {
-        if (isAdminUser) {
-          removeHackneyToken(res);
-        }
+  try {
+    if (isAdminUser) {
+      removeHackneyToken(res);
+    }
 
-        res.status(StatusCodes.OK).json({ message: 'Admin sign out' });
-      } catch (error) {
-        console.error(error);
-        res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ message: 'Unable to sign out' });
-      }
-      break;
-
-    default:
-      res
-        .setHeader('Allow', 'GET')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+    res.status(StatusCodes.OK).json({ message: 'Admin sign out' });
+  } catch (error) {
+    console.error(error);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: 'Unable to sign out' });
   }
 };
 

--- a/pages/api/admin/logout.tsx
+++ b/pages/api/admin/logout.tsx
@@ -24,6 +24,12 @@ const endpoint: NextApiHandler = async (
           .json({ message: 'Unable to sign out' });
       }
       break;
+
+    default:
+      res
+        .setHeader('Allow', 'GET')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/applications/[id]/complete.tsx
+++ b/pages/api/applications/[id]/complete.tsx
@@ -9,36 +9,32 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'PATCH':
-      try {
-        const id = req.query.id as string;
+  if (req.method !== 'PATCH') {
+    res
+      .setHeader('Allow', 'PATCH')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-        if (canUpdateApplication(req, id)) {
-          const data = await completeApplication(id, req);
-          res.status(StatusCodes.OK).json(data);
-        } else {
-          res
-            .status(StatusCodes.FORBIDDEN)
-            .json({ message: 'Unable to update application' });
-        }
-      } catch (error) {
-        if (axios.isAxiosError(error) && error.response) {
-          res.status(error.response.status).json(error.response.data);
-        } else {
-          console.error(error);
-          res
-            .status(StatusCodes.INTERNAL_SERVER_ERROR)
-            .json({ message: 'Unable to update application' });
-        }
-      }
-      break;
+  try {
+    const id = req.query.id as string;
 
-    default:
+    if (canUpdateApplication(req, id)) {
+      const data = await completeApplication(id, req);
+      res.status(StatusCodes.OK).json(data);
+    } else {
+      res.status(StatusCodes.FORBIDDEN).json({ message: 'Access denied' });
+    }
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      res.status(error.response.status).json(error.response.data);
+    } else {
+      console.error(error);
       res
-        .setHeader('Allow', 'PATCH')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json({ message: 'Unable to update application' });
+    }
   }
 };
 

--- a/pages/api/applications/[id]/complete.tsx
+++ b/pages/api/applications/[id]/complete.tsx
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { StatusCodes } from 'http-status-codes';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { completeApplication } from '../../../../lib/gateways/applications-api';
@@ -22,17 +23,22 @@ const endpoint: NextApiHandler = async (
             .json({ message: 'Unable to update application' });
         }
       } catch (error) {
-        console.error(error);
-        res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ message: 'Unable to update application' });
+        if (axios.isAxiosError(error) && error.response) {
+          res.status(error.response.status).json(error.response.data);
+        } else {
+          console.error(error);
+          res
+            .status(StatusCodes.INTERNAL_SERVER_ERROR)
+            .json({ message: 'Unable to update application' });
+        }
       }
       break;
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'PATCH')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/applications/[id]/evidence.tsx
+++ b/pages/api/applications/[id]/evidence.tsx
@@ -10,49 +10,44 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'POST': {
-      let request: CreateEvidenceRequest;
-      try {
-        request = JSON.parse(req.body);
-      } catch (error) {
-        console.error('Unable to parse evidence request body', error);
-        res
-          .status(StatusCodes.BAD_REQUEST)
-          .json({ message: 'Unable to parse request' });
-        break;
-      }
+  if (req.method !== 'POST') {
+    res
+      .setHeader('Allow', 'POST')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-      const id = req.query.id as string;
+  let request: CreateEvidenceRequest;
+  try {
+    request = JSON.parse(req.body);
+  } catch (error) {
+    console.error('Unable to parse evidence request body', error);
+    res
+      .status(StatusCodes.BAD_REQUEST)
+      .json({ message: 'Unable to parse request' });
+    return;
+  }
 
-      if (!canUpdateApplication(req, id)) {
-        res
-          .status(StatusCodes.FORBIDDEN)
-          .json({ message: 'Unable to update application' });
-        break;
-      }
+  const id = req.query.id as string;
 
-      try {
-        const data = await createEvidenceRequest(id, request);
-        res.status(StatusCodes.OK).json(data);
-      } catch (error) {
-        if (axios.isAxiosError(error) && error.response) {
-          res.status(error.response.status).json(error.response.data);
-        } else {
-          console.error(error);
-          res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-            message: 'Unable to create evidence request for application',
-          });
-        }
-      }
-      break;
+  if (!canUpdateApplication(req, id)) {
+    res.status(StatusCodes.FORBIDDEN).json({ message: 'Access denied' });
+    return;
+  }
+
+  try {
+    const data = await createEvidenceRequest(id, request);
+    res.status(StatusCodes.OK).json(data);
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      res.status(error.response.status).json(error.response.data);
+    } else {
+      console.error(error);
+      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        message: 'Unable to create evidence request for application',
+      });
     }
-
-    default:
-      res
-        .setHeader('Allow', 'POST')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/applications/[id]/evidence.tsx
+++ b/pages/api/applications/[id]/evidence.tsx
@@ -1,5 +1,7 @@
+import axios from 'axios';
 import { StatusCodes } from 'http-status-codes';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+import { CreateEvidenceRequest } from '../../../../domain/HousingApi';
 import { createEvidenceRequest } from '../../../../lib/gateways/applications-api';
 import { canUpdateApplication } from '../../../../lib/utils/requestAuth';
 import { wrapApiHandlerWithSentry } from '@sentry/nextjs';
@@ -9,31 +11,48 @@ const endpoint: NextApiHandler = async (
   res: NextApiResponse,
 ) => {
   switch (req.method) {
-    case 'POST':
+    case 'POST': {
+      let request: CreateEvidenceRequest;
       try {
-        const request = JSON.parse(req.body);
-        const id = req.query.id as string;
-
-        if (canUpdateApplication(req, id)) {
-          const data = await createEvidenceRequest(id, request);
-          res.status(StatusCodes.OK).json(data);
-        } else {
-          res
-            .status(StatusCodes.FORBIDDEN)
-            .json({ message: 'Unable to update application' });
-        }
+        request = JSON.parse(req.body);
       } catch (error) {
-        console.error(error);
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-          message: 'Unable to create evidence request for application',
-        });
+        console.error('Unable to parse evidence request body', error);
+        res
+          .status(StatusCodes.BAD_REQUEST)
+          .json({ message: 'Unable to parse request' });
+        break;
+      }
+
+      const id = req.query.id as string;
+
+      if (!canUpdateApplication(req, id)) {
+        res
+          .status(StatusCodes.FORBIDDEN)
+          .json({ message: 'Unable to update application' });
+        break;
+      }
+
+      try {
+        const data = await createEvidenceRequest(id, request);
+        res.status(StatusCodes.OK).json(data);
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response) {
+          res.status(error.response.status).json(error.response.data);
+        } else {
+          console.error(error);
+          res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+            message: 'Unable to create evidence request for application',
+          });
+        }
       }
       break;
+    }
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'POST')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/applications/[id]/index.tsx
+++ b/pages/api/applications/[id]/index.tsx
@@ -15,56 +15,51 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'PATCH': {
-      let application: Application;
-      try {
-        application = JSON.parse(req.body);
-      } catch (error) {
-        console.error('Unable to parse application request body', error);
-        res
-          .status(StatusCodes.BAD_REQUEST)
-          .json({ message: 'Unable to parse request' });
-        break;
-      }
+  if (req.method !== 'PATCH') {
+    res
+      .setHeader('Allow', 'PATCH')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-      const id = req.query.id as string;
+  let application: Application;
+  try {
+    application = JSON.parse(req.body);
+  } catch (error) {
+    console.error('Unable to parse application request body', error);
+    res
+      .status(StatusCodes.BAD_REQUEST)
+      .json({ message: 'Unable to parse request' });
+    return;
+  }
 
-      try {
-        if (
-          canUpdateApplication(req, id) ||
-          (isStaffAction(application) &&
-            hasStaffPermissions(req) &&
-            !hasReadOnlyStaffPermissions(req))
-        ) {
-          const data = await updateApplication(application, id, req);
-          res.status(StatusCodes.OK).json(data);
-        } else {
-          res
-            .status(StatusCodes.FORBIDDEN)
-            .json({ message: 'Unable to update application' });
-        }
-      } catch (error) {
-        // Every branch below must write a response - previously the
-        // "no response received" / "request setup failed" cases only
-        // logged, leaving the request to hang with no status ever sent.
-        if (axios.isAxiosError(error) && error.response) {
-          res.status(error.response.status).json(error.response.data);
-        } else {
-          console.error('Unable to update application', error);
-          res
-            .status(StatusCodes.INTERNAL_SERVER_ERROR)
-            .json({ message: 'Unable to update application' });
-        }
-      }
-      break;
+  const id = req.query.id as string;
+
+  try {
+    if (
+      canUpdateApplication(req, id) ||
+      (isStaffAction(application) &&
+        hasStaffPermissions(req) &&
+        !hasReadOnlyStaffPermissions(req))
+    ) {
+      const data = await updateApplication(application, id, req);
+      res.status(StatusCodes.OK).json(data);
+    } else {
+      res.status(StatusCodes.FORBIDDEN).json({ message: 'Access denied' });
     }
-
-    default:
+  } catch (error) {
+    // Every branch below must write a response - previously the
+    // "no response received" / "request setup failed" cases only
+    // logged, leaving the request to hang with no status ever sent.
+    if (axios.isAxiosError(error) && error.response) {
+      res.status(error.response.status).json(error.response.data);
+    } else {
+      console.error('Unable to update application', error);
       res
-        .setHeader('Allow', 'PATCH')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json({ message: 'Unable to update application' });
+    }
   }
 };
 

--- a/pages/api/applications/[id]/index.tsx
+++ b/pages/api/applications/[id]/index.tsx
@@ -1,10 +1,8 @@
-/*  eslint-disable @typescript-eslint/no-unused-vars */
-/*  eslint-disable @typescript-eslint/no-explicit-any */
-// disable unused AxiosError and usage of any until reconfiguration/refactor
 import { wrapApiHandlerWithSentry } from '@sentry/nextjs';
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 import { StatusCodes } from 'http-status-codes';
 
+import { Application } from '../../../../domain/HousingApi';
 import { updateApplication } from '../../../../lib/gateways/applications-api';
 import { hasReadOnlyStaffPermissions } from '../../../../lib/utils/hasReadOnlyStaffPermissions';
 import { hasStaffPermissions } from '../../../../lib/utils/hasStaffPermissions';
@@ -18,10 +16,21 @@ const endpoint: NextApiHandler = async (
   res: NextApiResponse,
 ) => {
   switch (req.method) {
-    case 'PATCH':
+    case 'PATCH': {
+      let application: Application;
       try {
-        const application = JSON.parse(req.body);
-        const id = req.query.id as string;
+        application = JSON.parse(req.body);
+      } catch (error) {
+        console.error('Unable to parse application request body', error);
+        res
+          .status(StatusCodes.BAD_REQUEST)
+          .json({ message: 'Unable to parse request' });
+        break;
+      }
+
+      const id = req.query.id as string;
+
+      try {
         if (
           canUpdateApplication(req, id) ||
           (isStaffAction(application) &&
@@ -35,30 +44,27 @@ const endpoint: NextApiHandler = async (
             .status(StatusCodes.FORBIDDEN)
             .json({ message: 'Unable to update application' });
         }
-      } catch (error: any | AxiosError) {
-        if (axios.isAxiosError(error)) {
-          if (error.response) {
-            // Request made and server responded
-            res.status(error.response.status).json(error.response.data);
-          } else if (error.request) {
-            // The request was made but no response was received
-            console.log(error.request);
-          } else {
-            // Something happened in setting up the request that triggered an Error
-            console.log('Error', error.message);
-          }
+      } catch (error) {
+        // Every branch below must write a response - previously the
+        // "no response received" / "request setup failed" cases only
+        // logged, leaving the request to hang with no status ever sent.
+        if (axios.isAxiosError(error) && error.response) {
+          res.status(error.response.status).json(error.response.data);
         } else {
+          console.error('Unable to update application', error);
           res
             .status(StatusCodes.INTERNAL_SERVER_ERROR)
             .json({ message: 'Unable to update application' });
         }
       }
       break;
+    }
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'PATCH')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/applications/[id]/note.tsx
+++ b/pages/api/applications/[id]/note.tsx
@@ -10,49 +10,44 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'POST': {
-      let request: AddNoteToHistoryRequest;
-      try {
-        request = JSON.parse(req.body);
-      } catch (error) {
-        console.error('Unable to parse note request body', error);
-        res
-          .status(StatusCodes.BAD_REQUEST)
-          .json({ message: 'Unable to parse request' });
-        break;
-      }
+  if (req.method !== 'POST') {
+    res
+      .setHeader('Allow', 'POST')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-      const id = req.query.id as string;
+  let request: AddNoteToHistoryRequest;
+  try {
+    request = JSON.parse(req.body);
+  } catch (error) {
+    console.error('Unable to parse note request body', error);
+    res
+      .status(StatusCodes.BAD_REQUEST)
+      .json({ message: 'Unable to parse request' });
+    return;
+  }
 
-      if (!canUpdateApplication(req, id)) {
-        res
-          .status(StatusCodes.FORBIDDEN)
-          .json({ message: 'Unable to add note' });
-        break;
-      }
+  const id = req.query.id as string;
 
-      try {
-        const data = await addNoteToHistory(id, request, req);
-        res.status(StatusCodes.OK).json(data);
-      } catch (error) {
-        if (axios.isAxiosError(error) && error.response) {
-          res.status(error.response.status).json(error.response.data);
-        } else {
-          console.error(error);
-          res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-            message: 'Unable to add note to activity history',
-          });
-        }
-      }
-      break;
+  if (!canUpdateApplication(req, id)) {
+    res.status(StatusCodes.FORBIDDEN).json({ message: 'Access denied' });
+    return;
+  }
+
+  try {
+    const data = await addNoteToHistory(id, request, req);
+    res.status(StatusCodes.OK).json(data);
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      res.status(error.response.status).json(error.response.data);
+    } else {
+      console.error(error);
+      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        message: 'Unable to add note to activity history',
+      });
     }
-
-    default:
-      res
-        .setHeader('Allow', 'POST')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/applications/[id]/note.tsx
+++ b/pages/api/applications/[id]/note.tsx
@@ -1,6 +1,8 @@
+import axios from 'axios';
 import { StatusCodes } from 'http-status-codes';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { wrapApiHandlerWithSentry } from '@sentry/nextjs';
+import { AddNoteToHistoryRequest } from '../../../../domain/HousingApi';
 import { addNoteToHistory } from '../../../../lib/gateways/applications-api';
 import { canUpdateApplication } from '../../../../lib/utils/requestAuth';
 
@@ -9,31 +11,48 @@ const endpoint: NextApiHandler = async (
   res: NextApiResponse,
 ) => {
   switch (req.method) {
-    case 'POST':
+    case 'POST': {
+      let request: AddNoteToHistoryRequest;
       try {
-        const request = JSON.parse(req.body);
-        const id = req.query.id as string;
-
-        if (canUpdateApplication(req, id)) {
-          const data = await addNoteToHistory(id, request, req);
-          res.status(StatusCodes.OK).json(data);
-        } else {
-          res
-            .status(StatusCodes.FORBIDDEN)
-            .json({ message: 'Unable to add note' });
-        }
+        request = JSON.parse(req.body);
       } catch (error) {
-        console.error(error);
-        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-          message: 'Unable to add note to activity history',
-        });
+        console.error('Unable to parse note request body', error);
+        res
+          .status(StatusCodes.BAD_REQUEST)
+          .json({ message: 'Unable to parse request' });
+        break;
+      }
+
+      const id = req.query.id as string;
+
+      if (!canUpdateApplication(req, id)) {
+        res
+          .status(StatusCodes.FORBIDDEN)
+          .json({ message: 'Unable to add note' });
+        break;
+      }
+
+      try {
+        const data = await addNoteToHistory(id, request, req);
+        res.status(StatusCodes.OK).json(data);
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response) {
+          res.status(error.response.status).json(error.response.data);
+        } else {
+          console.error(error);
+          res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+            message: 'Unable to add note to activity history',
+          });
+        }
       }
       break;
+    }
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'POST')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/applications/index.ts
+++ b/pages/api/applications/index.ts
@@ -46,23 +46,33 @@ const endpoint: NextApiHandler = async (
 
       break;
     }
-    case 'POST':
+    case 'POST': {
+      if (!hasStaffPermissions(req)) {
+        res
+          .status(StatusCodes.FORBIDDEN)
+          .json({ message: 'Unable to add application' });
+        break;
+      }
+
+      if (hasReadOnlyStaffPermissions(req)) {
+        res
+          .status(StatusCodes.FORBIDDEN)
+          .json({ message: 'Unable to add application' });
+        break;
+      }
+
+      let application: Application;
       try {
-        if (!hasStaffPermissions(req)) {
-          res
-            .status(StatusCodes.FORBIDDEN)
-            .json({ message: 'Unable to add application' });
-          break;
-        }
+        application = JSON.parse(req.body);
+      } catch (error) {
+        console.error('Unable to parse application request body', error);
+        res
+          .status(StatusCodes.BAD_REQUEST)
+          .json({ message: 'Unable to parse request' });
+        break;
+      }
 
-        if (hasReadOnlyStaffPermissions(req)) {
-          res
-            .status(StatusCodes.FORBIDDEN)
-            .json({ message: 'Unable to add application' });
-          break;
-        }
-
-        const application: Application = JSON.parse(req.body);
+      try {
         if (
           isStaffAction(application) &&
           (!hasStaffPermissions(req) || hasReadOnlyStaffPermissions(req))
@@ -74,17 +84,24 @@ const endpoint: NextApiHandler = async (
           const data = await addApplication(application, req);
           res.status(StatusCodes.OK).json(data);
         }
-      } catch {
-        res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ message: 'Unable to add application' });
+      } catch (error) {
+        if (axios.isAxiosError(error) && error.response) {
+          res.status(error.response.status).json(error.response.data);
+        } else {
+          console.error(error);
+          res
+            .status(StatusCodes.INTERNAL_SERVER_ERROR)
+            .json({ message: 'Unable to add application' });
+        }
       }
       break;
+    }
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'GET, POST')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/applications/index.ts
+++ b/pages/api/applications/index.ts
@@ -47,20 +47,9 @@ const endpoint: NextApiHandler = async (
       break;
     }
     case 'POST': {
-      if (!hasStaffPermissions(req)) {
-        res
-          .status(StatusCodes.FORBIDDEN)
-          .json({ message: 'Unable to add application' });
-        break;
-      }
-
-      if (hasReadOnlyStaffPermissions(req)) {
-        res
-          .status(StatusCodes.FORBIDDEN)
-          .json({ message: 'Unable to add application' });
-        break;
-      }
-
+      // Staff-write-only (add-case). Parse first so isStaffAction can pick a
+      // more specific 403 message when the body includes privileged fields;
+      // it is not a second auth gate.
       let application: Application;
       try {
         application = JSON.parse(req.body);
@@ -72,18 +61,18 @@ const endpoint: NextApiHandler = async (
         break;
       }
 
+      if (!hasStaffPermissions(req) || hasReadOnlyStaffPermissions(req)) {
+        res.status(StatusCodes.FORBIDDEN).json({
+          message: isStaffAction(application)
+            ? 'Unable to add application with assessment'
+            : 'Unable to add application',
+        });
+        break;
+      }
+
       try {
-        if (
-          isStaffAction(application) &&
-          (!hasStaffPermissions(req) || hasReadOnlyStaffPermissions(req))
-        ) {
-          res
-            .status(StatusCodes.FORBIDDEN)
-            .json({ message: 'Unable to add application with assessment' });
-        } else {
-          const data = await addApplication(application, req);
-          res.status(StatusCodes.OK).json(data);
-        }
+        const data = await addApplication(application, req);
+        res.status(StatusCodes.OK).json(data);
       } catch (error) {
         if (axios.isAxiosError(error) && error.response) {
           res.status(error.response.status).json(error.response.data);

--- a/pages/api/auth/exit.tsx
+++ b/pages/api/auth/exit.tsx
@@ -25,8 +25,9 @@ const endpoint: NextApiHandler = async (
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'POST')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/auth/exit.tsx
+++ b/pages/api/auth/exit.tsx
@@ -7,27 +7,23 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'POST':
-      try {
-        removeAuthCookie(res);
+  if (req.method !== 'POST') {
+    res
+      .setHeader('Allow', 'POST')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-        res
-          .status(StatusCodes.OK)
-          .json({ message: 'Application form sign out' });
-      } catch (error) {
-        console.error(error);
-        res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ message: 'Unable to sign out' });
-      }
-      break;
+  try {
+    removeAuthCookie(res);
 
-    default:
-      res
-        .setHeader('Allow', 'POST')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+    res.status(StatusCodes.OK).json({ message: 'Application form sign out' });
+  } catch (error) {
+    console.error(error);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: 'Unable to sign out' });
   }
 };
 

--- a/pages/api/auth/generate.tsx
+++ b/pages/api/auth/generate.tsx
@@ -26,8 +26,9 @@ const endpoint: NextApiHandler = async (
 ) => {
   if (req.method !== 'POST') {
     res
-      .status(StatusCodes.BAD_REQUEST)
-      .json({ message: 'Invalid request method' });
+      .setHeader('Allow', 'POST')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
     return;
   }
 

--- a/pages/api/auth/verify.tsx
+++ b/pages/api/auth/verify.tsx
@@ -92,8 +92,9 @@ const endpoint: NextApiHandler = async (
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'POST')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/auth/verify.tsx
+++ b/pages/api/auth/verify.tsx
@@ -31,70 +31,68 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'POST':
-      try {
-        const request = parseVerifyBody(req);
-        if (!request) {
-          res
-            .status(StatusCodes.BAD_REQUEST)
-            .json({ message: 'Unable to parse request' });
-          return;
-        }
+  if (req.method !== 'POST') {
+    res
+      .setHeader('Allow', 'POST')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-        // Fail here on missing fields so we don't trigger a backend 500
-        if (
-          typeof request.email !== 'string' ||
-          request.email.trim() === '' ||
-          typeof request.code !== 'string' ||
-          request.code.trim() === ''
-        ) {
-          res
-            .status(StatusCodes.BAD_REQUEST)
-            .json({ message: 'Email and code are required' });
-          return;
-        }
-
-        if (!isValidAuthEmail(request.email)) {
-          res
-            .status(StatusCodes.BAD_REQUEST)
-            .json({ message: INVALID_AUTH_EMAIL_MESSAGE });
-          return;
-        }
-
-        const verifyRequest: VerifyAuthRequest = {
-          email: request.email.trim(),
-          code: request.code.trim(),
-        };
-
-        const data = await confirmVerifyCode(verifyRequest);
-
-        // set cookie with access token (JWT)
-        if (data) {
-          setAuthCookie(res, data);
-        }
-
-        res.status(StatusCodes.OK).json(data);
-      } catch (error) {
-        if (axios.isAxiosError(error) && error.response?.status) {
-          res
-            .status(error.response.status)
-            .json({ message: 'Unable to confirm verify code' });
-          return;
-        }
-
-        console.error(error);
-        res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ message: 'Unable to confirm verify code' });
-      }
-      break;
-
-    default:
+  try {
+    const request = parseVerifyBody(req);
+    if (!request) {
       res
-        .setHeader('Allow', 'POST')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: 'Unable to parse request' });
+      return;
+    }
+
+    // Fail here on missing fields so we don't trigger a backend 500
+    if (
+      typeof request.email !== 'string' ||
+      request.email.trim() === '' ||
+      typeof request.code !== 'string' ||
+      request.code.trim() === ''
+    ) {
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: 'Email and code are required' });
+      return;
+    }
+
+    if (!isValidAuthEmail(request.email)) {
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: INVALID_AUTH_EMAIL_MESSAGE });
+      return;
+    }
+
+    const verifyRequest: VerifyAuthRequest = {
+      email: request.email.trim(),
+      code: request.code.trim(),
+    };
+
+    const data = await confirmVerifyCode(verifyRequest);
+
+    // set cookie with access token (JWT)
+    if (data) {
+      setAuthCookie(res, data);
+    }
+
+    res.status(StatusCodes.OK).json(data);
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status) {
+      res
+        .status(error.response.status)
+        .json({ message: 'Unable to confirm verify code' });
+      return;
+    }
+
+    console.error(error);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: 'Unable to confirm verify code' });
   }
 };
 

--- a/pages/api/notify/[template].tsx
+++ b/pages/api/notify/[template].tsx
@@ -23,89 +23,84 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'POST': {
-      let application: Awaited<ReturnType<typeof getApplication>>;
+  if (req.method !== 'POST') {
+    res
+      .setHeader('Allow', 'POST')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-      try {
-        const applicationId = getUser(req)?.application_id;
-        if (!applicationId) {
-          res
-            .status(StatusCodes.UNAUTHORIZED)
-            .json({ message: 'Unauthorized' });
-          break;
-        }
+  let application: Awaited<ReturnType<typeof getApplication>>;
 
-        application = await getApplication(applicationId);
-      } catch (error) {
-        console.error('Unable to load application for Notify', error);
-        res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ message: 'Unable to load application' });
-        break;
-      }
-
-      if (!application) {
-        res
-          .status(StatusCodes.NOT_FOUND)
-          .json({ message: 'Application not found' });
-        break;
-      }
-
-      const emailAddress =
-        application.mainApplicant?.contactInformation?.emailAddress;
-      if (!emailAddress?.trim()) {
-        res
-          .status(StatusCodes.UNPROCESSABLE_ENTITY)
-          .json({ message: 'Application has no email address' });
-        break;
-      }
-
-      try {
-        const template = req.query.template as string;
-
-        switch (template) {
-          case 'new-application': {
-            const sendNewApplicationData = await sendNewApplicationEmail(
-              buildNewApplicationNotifyRequest(application),
-            );
-            res.status(StatusCodes.OK).json(sendNewApplicationData);
-            break;
-          }
-          case 'medical': {
-            const sendMedicalEmailData = await sendMedicalNeedEmail(
-              buildMedicalNeedNotifyRequest(application),
-            );
-            res.status(StatusCodes.OK).json(sendMedicalEmailData);
-            break;
-          }
-          case 'disqualify': {
-            const sendDisqualifyEmailData = await sendDisqualifyEmail(
-              buildDisqualifyNotifyRequest(application),
-            );
-            res.status(StatusCodes.OK).json(sendDisqualifyEmailData);
-            break;
-          }
-          default:
-            res
-              .status(StatusCodes.BAD_REQUEST)
-              .json({ message: 'Invalid template request' });
-            break;
-        }
-      } catch (error) {
-        console.error('Unable to send Notify email', error);
-        res
-          .status(StatusCodes.INTERNAL_SERVER_ERROR)
-          .json({ message: 'Unable to send email' });
-      }
-      break;
+  try {
+    const applicationId = getUser(req)?.application_id;
+    if (!applicationId) {
+      res.status(StatusCodes.UNAUTHORIZED).json({ message: 'Unauthorized' });
+      return;
     }
 
-    default:
-      res
-        .setHeader('Allow', 'POST')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+    application = await getApplication(applicationId);
+  } catch (error) {
+    console.error('Unable to load application for Notify', error);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: 'Unable to load application' });
+    return;
+  }
+
+  if (!application) {
+    res
+      .status(StatusCodes.NOT_FOUND)
+      .json({ message: 'Application not found' });
+    return;
+  }
+
+  const emailAddress =
+    application.mainApplicant?.contactInformation?.emailAddress;
+  if (!emailAddress?.trim()) {
+    res
+      .status(StatusCodes.UNPROCESSABLE_ENTITY)
+      .json({ message: 'Application has no email address' });
+    return;
+  }
+
+  try {
+    const template = req.query.template as string;
+
+    switch (template) {
+      case 'new-application': {
+        const sendNewApplicationData = await sendNewApplicationEmail(
+          buildNewApplicationNotifyRequest(application),
+        );
+        res.status(StatusCodes.OK).json(sendNewApplicationData);
+        break;
+      }
+      case 'medical': {
+        const sendMedicalEmailData = await sendMedicalNeedEmail(
+          buildMedicalNeedNotifyRequest(application),
+        );
+        res.status(StatusCodes.OK).json(sendMedicalEmailData);
+        break;
+      }
+      case 'disqualify': {
+        const sendDisqualifyEmailData = await sendDisqualifyEmail(
+          buildDisqualifyNotifyRequest(application),
+        );
+        res.status(StatusCodes.OK).json(sendDisqualifyEmailData);
+        break;
+      }
+      default:
+        res
+          .status(StatusCodes.BAD_REQUEST)
+          .json({ message: 'Invalid template request' });
+        break;
+    }
+  } catch (error) {
+    console.error('Unable to send Notify email', error);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: 'Unable to send email' });
   }
 };
 

--- a/pages/api/reports/internal/download.tsx
+++ b/pages/api/reports/internal/download.tsx
@@ -4,93 +4,77 @@ import { downloadInternalReport } from '../../../../lib/gateways/applications-ap
 import { getAuth, getSession } from '../../../../lib/utils/googleAuth';
 import { wrapApiHandlerWithSentry } from '@sentry/nextjs';
 import { InternalReportRequest } from '../../../../domain/HousingApi';
-import { AxiosResponse } from 'axios';
 
 const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'POST':
-      {
-        const user = getSession(req);
+  if (req.method !== 'POST') {
+    res
+      .setHeader('Allow', 'POST')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-        const auth = getAuth(
-          process.env.AUTHORISED_MANAGER_GROUP as string,
-          user,
-        );
+  const user = getSession(req);
 
-        if (!('user' in auth)) {
-          res.status(StatusCodes.FORBIDDEN).json({ message: 'access denied' });
-          return;
+  const auth = getAuth(process.env.AUTHORISED_MANAGER_GROUP as string, user);
+
+  if (!('user' in auth)) {
+    res.status(StatusCodes.FORBIDDEN).json({ message: 'access denied' });
+    return;
+  }
+
+  try {
+    const reportData: InternalReportRequest = {
+      ReportType: parseInt(req.body.ReportType),
+      StartDate: req.body.StartDate,
+      EndDate: req.body.EndDate,
+    };
+
+    if (Buffer.isBuffer(req.body)) {
+      //For some reason, the body has been interpreted by NextJS as a buffer once its behind API Gateway
+      const requestBodyAsString = req.body.toString();
+      const formKeys = requestBodyAsString.split('&');
+      formKeys.forEach((formKeyValuePair) => {
+        const keyvaluepair = formKeyValuePair.split('=');
+        if (keyvaluepair[0].toLowerCase() == 'reporttype') {
+          reportData.ReportType = parseInt(keyvaluepair[1]);
+        } else {
+          reportData[keyvaluepair[0]] = keyvaluepair[1];
         }
-        let fileResponse = {} as AxiosResponse;
-        try {
-          const reportData: InternalReportRequest = {
-            ReportType: parseInt(req.body.ReportType),
-            StartDate: req.body.StartDate,
-            EndDate: req.body.EndDate,
-          };
+      });
+    }
 
-          if (Buffer.isBuffer(req.body)) {
-            //For some reason, the body has been interpreted by NextJS as a buffer once its behind API Gateway
-            const requestBodyAsString = req.body.toString();
-            const formKeys = requestBodyAsString.split('&');
-            formKeys.forEach((formKeyValuePair) => {
-              const keyvaluepair = formKeyValuePair.split('=');
-              if (keyvaluepair[0].toLowerCase() == 'reporttype') {
-                reportData.ReportType = parseInt(keyvaluepair[1]);
-              } else {
-                reportData[keyvaluepair[0]] = keyvaluepair[1];
-              }
-            });
-          }
+    // Axios rejects non-2xx into the catch below - a resolved response is
+    // always a real AxiosResponse (the gateway's `| null` return type is
+    // inaccurate), so the old `if (fileResponse)` / 404 else was unreachable.
+    const fileResponse = await downloadInternalReport(reportData, req);
 
-          fileResponse = (await downloadInternalReport(
-            reportData,
-            req,
-          )) as AxiosResponse;
-
-          if (fileResponse) {
-            res.status(fileResponse.status);
-            const contentType = fileResponse.headers['content-type'];
-            res.setHeader(
-              'Content-Type',
-              typeof contentType === 'string'
-                ? contentType
-                : 'application/octet-stream',
-            );
-            const contentDisposition =
-              fileResponse.headers['content-disposition'];
-            res.setHeader(
-              'Content-Disposition',
-              typeof contentDisposition === 'string'
-                ? contentDisposition
-                : 'attachment',
-            );
-            res.send(fileResponse.data);
-          } else {
-            res.status(404);
-            res.send({
-              message: 'Unable to download report',
-            });
-          }
-        } catch (error) {
-          // Previously the raw Axios response and error were included in the
-          // response body, leaking internal details to the client.
-          console.error('Unable to download report', error);
-          res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-            message: 'Unable to download report',
-          });
-        }
-      }
-      break;
-
-    default:
-      res
-        .setHeader('Allow', 'POST')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+    res.status(fileResponse.status);
+    const contentType = fileResponse.headers['content-type'];
+    res.setHeader(
+      'Content-Type',
+      typeof contentType === 'string'
+        ? contentType
+        : 'application/octet-stream',
+    );
+    const contentDisposition = fileResponse.headers['content-disposition'];
+    res.setHeader(
+      'Content-Disposition',
+      typeof contentDisposition === 'string'
+        ? contentDisposition
+        : 'attachment',
+    );
+    res.send(fileResponse.data);
+  } catch (error) {
+    // Previously the raw Axios response and error were included in the
+    // response body, leaking internal details to the client.
+    console.error('Unable to download report', error);
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message: 'Unable to download report',
+    });
   }
 };
 

--- a/pages/api/reports/internal/download.tsx
+++ b/pages/api/reports/internal/download.tsx
@@ -76,10 +76,11 @@ const endpoint: NextApiHandler = async (
             });
           }
         } catch (error) {
+          // Previously the raw Axios response and error were included in the
+          // response body, leaking internal details to the client.
+          console.error('Unable to download report', error);
           res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-            message: 'Request error: Unable to download report: ',
-            response: fileResponse,
-            error: error,
+            message: 'Unable to download report',
           });
         }
       }
@@ -87,8 +88,9 @@ const endpoint: NextApiHandler = async (
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'POST')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/reports/novalet/approve/[fileName].tsx
+++ b/pages/api/reports/novalet/approve/[fileName].tsx
@@ -8,59 +8,58 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'POST':
-      {
-        const user = getSession(req);
+  if (req.method !== 'POST') {
+    res
+      .setHeader('Allow', 'POST')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-        const auth = getAuth(
-          process.env.AUTHORISED_MANAGER_GROUP as string,
-          user,
-        );
+  const user = getSession(req);
 
-        if (!('user' in auth)) {
-          res.status(StatusCodes.FORBIDDEN).json({ message: 'access denied' });
-          return;
-        }
+  const auth = getAuth(process.env.AUTHORISED_MANAGER_GROUP as string, user);
 
-        try {
-          const fileName = req.query.fileName as string;
-          const response = await approveNovaletExport(fileName);
+  if (!('user' in auth)) {
+    res.status(StatusCodes.FORBIDDEN).json({ message: 'access denied' });
+    return;
+  }
 
-          if (response) {
-            res.status(response.status);
+  try {
+    const fileName = req.query.fileName as string;
+    const response = await approveNovaletExport(fileName);
 
-            if (response.status == StatusCodes.OK) {
-              res.send({
-                message: 'Export file approved successfully',
-              });
-            } else {
-              res.send({
-                message: 'Unable to approve export file',
-              });
-            }
-          } else {
-            // Previously fell through here with no response ever written,
-            // leaving the caller's request to hang.
-            res
-              .status(StatusCodes.INTERNAL_SERVER_ERROR)
-              .json({ message: 'Unable to approve export file' });
-          }
-        } catch (error) {
-          console.error('Unable to approve export file', error);
-          res
-            .status(StatusCodes.INTERNAL_SERVER_ERROR)
-            .json({ message: 'Unable to approve export file' });
-        }
+    if (response) {
+      res.status(response.status);
+
+      if (response.status == StatusCodes.OK) {
+        res.send({
+          message: 'Export file approved successfully',
+        });
+      } else {
+        // Status tells you where to look: 4xx = request/auth, 5xx = upstream.
+        console.error('Unable to approve export file', {
+          fileName,
+          status: response.status,
+          data: response.data,
+        });
+        res.send({
+          message: 'Unable to approve export file',
+        });
       }
-
-      break;
-
-    default:
+    } else {
+      // Previously fell through here with no response ever written,
+      // leaving the caller's request to hang.
+      console.error('Unable to approve export file: empty response');
       res
-        .setHeader('Allow', 'POST')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json({ message: 'Unable to approve export file' });
+    }
+  } catch (error) {
+    console.error('Unable to approve export file', error);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: 'Unable to approve export file' });
   }
 };
 

--- a/pages/api/reports/novalet/approve/[fileName].tsx
+++ b/pages/api/reports/novalet/approve/[fileName].tsx
@@ -23,21 +23,34 @@ const endpoint: NextApiHandler = async (
           return;
         }
 
-        const fileName = req.query.fileName as string;
-        const response = await approveNovaletExport(fileName);
+        try {
+          const fileName = req.query.fileName as string;
+          const response = await approveNovaletExport(fileName);
 
-        if (response) {
-          res.status(response.status);
+          if (response) {
+            res.status(response.status);
 
-          if (response.status == StatusCodes.OK) {
-            res.send({
-              message: 'Export file approved successfully',
-            });
+            if (response.status == StatusCodes.OK) {
+              res.send({
+                message: 'Export file approved successfully',
+              });
+            } else {
+              res.send({
+                message: 'Unable to approve export file',
+              });
+            }
           } else {
-            res.send({
-              message: 'Unable to approve export file',
-            });
+            // Previously fell through here with no response ever written,
+            // leaving the caller's request to hang.
+            res
+              .status(StatusCodes.INTERNAL_SERVER_ERROR)
+              .json({ message: 'Unable to approve export file' });
           }
+        } catch (error) {
+          console.error('Unable to approve export file', error);
+          res
+            .status(StatusCodes.INTERNAL_SERVER_ERROR)
+            .json({ message: 'Unable to approve export file' });
         }
       }
 
@@ -45,8 +58,9 @@ const endpoint: NextApiHandler = async (
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'POST')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/reports/novalet/download/[fileName].tsx
+++ b/pages/api/reports/novalet/download/[fileName].tsx
@@ -8,61 +8,54 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'GET':
-      {
-        const user = getSession(req);
+  if (req.method !== 'GET') {
+    res
+      .setHeader('Allow', 'GET')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-        const auth = getAuth(
-          process.env.AUTHORISED_MANAGER_GROUP as string,
-          user,
-        );
+  const user = getSession(req);
 
-        if (!('user' in auth)) {
-          res.status(StatusCodes.FORBIDDEN).json({ message: 'access denied' });
-          return;
-        }
+  const auth = getAuth(process.env.AUTHORISED_MANAGER_GROUP as string, user);
 
-        try {
-          const fileName = req.query.fileName as string;
-          const file = await downloadNovaletExport(fileName);
+  if (!('user' in auth)) {
+    res.status(StatusCodes.FORBIDDEN).json({ message: 'access denied' });
+    return;
+  }
 
-          if (file) {
-            res.status(file.status);
-            const contentType = file.headers['content-type'];
-            res.setHeader(
-              'Content-Type',
-              typeof contentType === 'string'
-                ? contentType
-                : 'application/octet-stream',
-            );
-            const contentDisposition = file.headers['content-disposition'];
-            res.setHeader(
-              'Content-Disposition',
-              typeof contentDisposition === 'string'
-                ? contentDisposition
-                : 'attachment',
-            );
-            res.send(file.data);
-          } else {
-            res.status(404);
-            res.send({
-              message: 'Unable to download report',
-            });
-          }
-        } catch {
-          res
-            .status(StatusCodes.INTERNAL_SERVER_ERROR)
-            .json({ message: 'Unable to download report' });
-        }
-      }
-      break;
+  try {
+    const fileName = req.query.fileName as string;
+    // Axios rejects non-2xx into the catch below - a resolved response is
+    // always a real AxiosResponse (the gateway's `| null` return type was
+    // inaccurate), so the old `if (file)` / 404 else was unreachable.
+    const file = await downloadNovaletExport(fileName);
 
-    default:
-      res
-        .setHeader('Allow', 'GET')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+    res.status(file.status);
+    const contentType = file.headers['content-type'];
+    res.setHeader(
+      'Content-Type',
+      typeof contentType === 'string'
+        ? contentType
+        : 'application/octet-stream',
+    );
+    const contentDisposition = file.headers['content-disposition'];
+    res.setHeader(
+      'Content-Disposition',
+      typeof contentDisposition === 'string'
+        ? contentDisposition
+        : 'attachment',
+    );
+    res.send(file.data);
+  } catch (error) {
+    console.error('Unable to download report', {
+      fileName: req.query.fileName,
+      error,
+    });
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: 'Unable to download report' });
   }
 };
 

--- a/pages/api/reports/novalet/download/[fileName].tsx
+++ b/pages/api/reports/novalet/download/[fileName].tsx
@@ -60,8 +60,9 @@ const endpoint: NextApiHandler = async (
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'GET')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/pages/api/reports/novalet/generate.tsx
+++ b/pages/api/reports/novalet/generate.tsx
@@ -8,50 +8,47 @@ const endpoint: NextApiHandler = async (
   req: NextApiRequest,
   res: NextApiResponse,
 ) => {
-  switch (req.method) {
-    case 'POST':
-      {
-        const user = getSession(req);
+  if (req.method !== 'POST') {
+    res
+      .setHeader('Allow', 'POST')
+      .status(StatusCodes.METHOD_NOT_ALLOWED)
+      .json({ message: 'Method not allowed' });
+    return;
+  }
 
-        const auth = getAuth(
-          process.env.AUTHORISED_MANAGER_GROUP as string,
-          user,
-        );
+  const user = getSession(req);
 
-        if (!('user' in auth)) {
-          res.status(StatusCodes.FORBIDDEN).json({ message: 'access denied' });
-          return;
-        }
+  const auth = getAuth(process.env.AUTHORISED_MANAGER_GROUP as string, user);
 
-        try {
-          const response = await generateNovaletExport();
+  if (!('user' in auth)) {
+    res.status(StatusCodes.FORBIDDEN).json({ message: 'access denied' });
+    return;
+  }
 
-          res.status(response.status);
+  try {
+    const response = await generateNovaletExport();
 
-          if (response.status == StatusCodes.OK) {
-            res.send({
-              message: 'Export file generated successfully',
-            });
-          } else {
-            res.send({
-              message: 'Unable to generate export file',
-            });
-          }
-        } catch (error) {
-          console.error('Unable to generate export file', error);
-          res
-            .status(StatusCodes.INTERNAL_SERVER_ERROR)
-            .json({ message: 'Unable to generate export file' });
-        }
-      }
+    res.status(response.status);
 
-      break;
-
-    default:
-      res
-        .setHeader('Allow', 'POST')
-        .status(StatusCodes.METHOD_NOT_ALLOWED)
-        .json({ message: 'Method not allowed' });
+    if (response.status == StatusCodes.OK) {
+      res.send({
+        message: 'Export file generated successfully',
+      });
+    } else {
+      // Status tells you where to look: 4xx = request/auth, 5xx = upstream.
+      console.error('Unable to generate export file', {
+        status: response.status,
+        data: response.data,
+      });
+      res.send({
+        message: 'Unable to generate export file',
+      });
+    }
+  } catch (error) {
+    console.error('Unable to generate export file', error);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: 'Unable to generate export file' });
   }
 };
 

--- a/pages/api/reports/novalet/generate.tsx
+++ b/pages/api/reports/novalet/generate.tsx
@@ -23,18 +23,25 @@ const endpoint: NextApiHandler = async (
           return;
         }
 
-        const response = await generateNovaletExport();
+        try {
+          const response = await generateNovaletExport();
 
-        res.status(response.status);
+          res.status(response.status);
 
-        if (response.status == StatusCodes.OK) {
-          res.send({
-            message: 'Export file generated successfully',
-          });
-        } else {
-          res.send({
-            message: 'Unable to generate export file',
-          });
+          if (response.status == StatusCodes.OK) {
+            res.send({
+              message: 'Export file generated successfully',
+            });
+          } else {
+            res.send({
+              message: 'Unable to generate export file',
+            });
+          }
+        } catch (error) {
+          console.error('Unable to generate export file', error);
+          res
+            .status(StatusCodes.INTERNAL_SERVER_ERROR)
+            .json({ message: 'Unable to generate export file' });
         }
       }
 
@@ -42,8 +49,9 @@ const endpoint: NextApiHandler = async (
 
     default:
       res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid request method' });
+        .setHeader('Allow', 'POST')
+        .status(StatusCodes.METHOD_NOT_ALLOWED)
+        .json({ message: 'Method not allowed' });
   }
 };
 

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -23,13 +23,10 @@ Sentry.init({
     ENVIRONMENT === 'staging' ||
     ENVIRONMENT === 'development',
 
-  // Next's own API body parser throws these *before* any of our route code
-  // runs, when a request has a `application/json` Content-Type but a body
+  // When a request has a `application/json` Content-Type but a body
   // that isn't valid JSON (or exceeds the size limit) - Next already catches
-  // this itself and correctly responds 400/413, so it's not something our
-  // code can fix. In practice this is almost always automated scanners
-  // (e.g. Probely) fuzzing endpoints with malformed bodies, so it's noise
-  // rather than a signal worth alerting on.
+  // this itself and correctly responds 400/413.
+  // Ignore these errors from automated scanners (e.g. Probely) fuzzing endpoints with malformed bodies.
   ignoreErrors: [
     /^Invalid JSON$/,
     /^Invalid body$/,

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -23,6 +23,19 @@ Sentry.init({
     ENVIRONMENT === 'staging' ||
     ENVIRONMENT === 'development',
 
+  // Next's own API body parser throws these *before* any of our route code
+  // runs, when a request has a `application/json` Content-Type but a body
+  // that isn't valid JSON (or exceeds the size limit) - Next already catches
+  // this itself and correctly responds 400/413, so it's not something our
+  // code can fix. In practice this is almost always automated scanners
+  // (e.g. Probely) fuzzing endpoints with malformed bodies, so it's noise
+  // rather than a signal worth alerting on.
+  ignoreErrors: [
+    /^Invalid JSON$/,
+    /^Invalid body$/,
+    /^Body exceeded .* limit$/,
+  ],
+
   // remove cookies from the event before sending
   beforeSend(event) {
     if (event.request?.cookies['hackneyToken']) {


### PR DESCRIPTION
## Summary
After adding 405 to the Notifiy endpoint as part of #564 - this was a clean-up task for all API endpoints returning 400 Bad Request for unsupported HTTP methods (should be 405 Method Not Allowed). On auditing every endpoint's error handling several related bugs where errors weren't being handled consistently or correctly.

## Method handling
All API routes now return 405 Method Not Allowed with an Allow header for unsupported methods, instead of 400 Bad Request:

- applications (GET, POST), applications/[id] (PATCH), applications/[id]/evidence, applications/[id]/note, applications/[id]/complete, address/[postcode], auth/generate, auth/verify, auth/exit, reports/internal/download, reports/novalet/generate, reports/novalet/approve/[fileName], reports/novalet/download/[fileName]
- admin/logout had no default case at all, so non-GET requests silently returned an empty 200 OK. It now returns 405 like the rest.
## Error handling bugs

- Requests that could hang with no response. applications/[id] swallowed the "no response received" / "request setup failed" with only a console.log, never writing a status. reports/novalet/generate and reports/novalet/approve/[fileName] didn't wrap their gateway calls in try/catch at all, so a thrown error left the request hanging. All now guarantee a response on every path.
- Malformed JSON bodies returned 500 instead of 400. applications, applications/[id], applications/[id]/evidence, and applications/[id]/note all did JSON.parse(req.body) with no error handling, so a bad request body was reported to Sentry as a server error. Parsing is now wrapped separately and returns 400 Bad Request / "Unable to parse request".
- Upstream error responses were being collapsed to a generic 500. Several endpoints didn't forward the backend API's actual status code/body on failure. Now consistently checking axios.isAxiosError(error) && error.response and forwarding it, falling back to 500 only for genuine non-HTTP failures.
- Internal details leaking in error responses. reports/internal/download was returning the raw Axios response object and error in the JSON body on failure. Now just logs server-side and returns a generic message.
- Notify gateway silently swallowing failures. lib/gateways/notify-api.ts's sendEmail caught Notify API errors, reported them to Sentry, but then resolved successfully with undefined - so /api/notify/[template] always returned 200 OK regardless of whether the email actually sent. It also console.logged the successful response instead of returning response.data, so a real success also came back as undefined. Both now behave correctly: success returns the actual NotifyResponse, failure rethrows so the endpoint can respond with the right status.
- Sentry noise from scanner traffic. Next's own body parser throws Invalid JSON/Invalid body/Body exceeded ... limit before our route code runs (already handled correctly by Next with 400/413). These were filling Sentry with noise from Probely scans; now filtered via ignoreErrors.
## Other fixes found along the way

- Cleaned up confirm dialogs on the staff "remove household member" action. Surfaced from a cypress test flake in the local suite. components/admin/other-members.tsx rendered a delete-confirmation dialog per row, all driven by one shared piece of state - deleting a member with siblings in the household opened multiple modal dialogs on top of each other, and only the topmost was interactive. Moved to a single dialog per table.
- sendDisqualifyEmail/sendConfirmation/sendMedicalNeed thunk failures were completely invisible. These fetch /api/notify/[template] and deliberately don't block the resident's flow on failure, but nothing logged a rejection either - a 401/404/422/500 from Notify vanished with no trace. Added console.error before rejectWithValue.

## Test plan

- [x] tsc --noEmit, ESLint, and full Jest suite (28 suites / 260 tests) all pass
- [x] Added/updated unit tests for every endpoint's new status codes and error paths (__tests__/pages/api/**, __tests__/lib/gateways/notify-api.spec.ts)
- [x] Reviewed and updated the E2E suite for the new response codes (cypress/e2e/pages/api/notify/[template].cy.ts, declaration.cy.ts, managerActions.cy.ts)
- [x] Run full Cypress E2E suite before merge